### PR TITLE
fix(native): add rpath for cross-compile test binaries

### DIFF
--- a/packages/native/build.rs
+++ b/packages/native/build.rs
@@ -90,6 +90,9 @@ fn build_macos(vendor_dir: &std::path::Path) {
 
     // `cargo run` のバイナリは target/debug/、`cargo test` の libtest バイナリは
     // target/debug/deps/ に置かれる。両方から workspace の vendor/ を辿れるようにする。
+    // CARGO_BUILD_TARGET 指定時は target/<triple>/debug/deps/ と1段深くなるため
+    // 4段上のパスも追加する。
     println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../../vendor");
     println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../../../vendor");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../../../../vendor");
 }


### PR DESCRIPTION
## Summary
- CI publish workflow の darwin-arm64 ビルドで `cargo test` が `dyld: Library not loaded: Syphon.framework` で失敗していた
- `CARGO_BUILD_TARGET` 指定時、テストバイナリが `target/<triple>/debug/deps/` に配置され通常より1段深くなるが、既存の rpath（2段・3段上）では `vendor/` に到達できなかった
- `@loader_path/../../../../vendor` の rpath を追加して修正

## Test plan
- [x] `CARGO_BUILD_TARGET=aarch64-apple-darwin cargo test` でローカル検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)