### PR TITLE
feat(syphon): event-driven receiver with vertical flip fix

### DIFF
--- a/packages/native/cpp/mac/syphon_bridge.mm
+++ b/packages/native/cpp/mac/syphon_bridge.mm
@@ -93,7 +93,7 @@ int syphon_bridge_send(SyphonBridgeHandle handle,
         [bridge->server publishFrameTexture:texture
                             onCommandBuffer:cmdBuf
                                 imageRegion:NSMakeRect(0, 0, width, height)
-                                    flipped:NO];
+                                    flipped:YES];
         [cmdBuf commit];
 
         return 0;
@@ -137,7 +137,7 @@ int syphon_bridge_send_surface(SyphonBridgeHandle handle,
         [bridge->server publishFrameTexture:texture
                             onCommandBuffer:cmdBuf
                                 imageRegion:NSMakeRect(0, 0, width, height)
-                                    flipped:NO];
+                                    flipped:YES];
         [cmdBuf commit];
 
         return 0;
@@ -210,7 +210,7 @@ int syphon_bridge_send_rgba(SyphonBridgeHandle handle,
         [bridge->server publishFrameTexture:texture
                             onCommandBuffer:cmdBuf
                                 imageRegion:NSMakeRect(0, 0, width, height)
-                                    flipped:NO];
+                                    flipped:YES];
         [cmdBuf commit];
 
         return 0;


### PR DESCRIPTION
## Summary
- Native listener thread for event-driven Syphon frame reception (no polling)
- Auto-detect IOSurface pixel format and BGRA→RGBA conversion in receiver
- Fix vertical flip: set `flipped:YES` on all `publishFrameTexture` calls so Syphon output displays correctly in receiving apps
- Add receiver test window with Syphon server selector in example app

## Test plan
- [ ] Run example app and confirm Syphon output is not vertically flipped
- [ ] Verify receiver can connect to Syphon servers and receive frames
- [ ] Check pixel format and color correctness in both sender and receiver

🤖 Generated with [Claude Code](https://claude.com/claude-code)