### PR TITLE
fix(spout): use bounded tsfn queue for drop-latest semantics

### DIFF
--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -379,8 +379,12 @@ impl TextureReceiver {
             return Err(Error::from_reason("Listener already started"));
         }
 
+        // Bounded queue with capacity 1 gives drop-latest semantics at the native
+        // boundary: when JS is behind, NonBlocking calls return Status::QueueFull
+        // and the 8MB Vec is dropped immediately instead of piling up in the tsfn
+        // queue. Matches the pull-based polling semantics on macOS (Syphon).
         let tsfn: ThreadsafeFunction<(Vec<u8>, u32, u32), ErrorStrategy::Fatal> = callback
-            .create_threadsafe_function(0, |ctx: ThreadSafeCallContext<(Vec<u8>, u32, u32)>| {
+            .create_threadsafe_function(1, |ctx: ThreadSafeCallContext<(Vec<u8>, u32, u32)>| {
                 let (data, width, height) = ctx.value;
                 let mut obj = ctx.env.create_object()?;
                 let buf = ctx.env.create_buffer_with_data(data)?;
@@ -391,6 +395,8 @@ impl TextureReceiver {
             })?;
 
         let listener = win::receiver::start_listening(&self.sender_name, move |data, w, h| {
+            // Status::QueueFull is expected under load — the frame is dropped
+            // and the Vec<u8> is freed, preventing unbounded memory growth.
             tsfn.call((data, w, h), ThreadsafeFunctionCallMode::NonBlocking);
         })
         .map_err(|e| Error::from_reason(e))?;


### PR DESCRIPTION
## Problem

On Windows, the Spout receiver spawns a native listener thread that pushes RGBA frames to JS via a napi-rs `ThreadsafeFunction`. The queue was created with `max_queue_size: 0` (unbounded), which caused unbounded memory growth whenever the JS main thread fell behind the sender's native frame rate.

### Evidence from production

Observed in a downstream app on Windows with a Spout sender running at ~100 fps (1920×1080 RGBA = ~8 MB/frame):

```
16:51:57  [output] FPS: 56.4          ← output healthy before receiver starts
16:51:58  POST /texture-receiver/start
16:51:59  [texture-receiver] FPS: 103.0  ← native callback rate
16:52:08  [output] FPS: 4.5           ← main process starved
16:52:19  [output] FPS: 0.2           ← frozen
16:52:20  [texture-receiver] FPS: 75.6  ← native still running at full speed
```

Native Rust listener kept firing at ~100 fps, enqueueing 8 MB `Vec<u8>` per call. JS could not drain fast enough → queue grew at ~800 MB/s → app froze.

### Root cause: architecture mismatch with macOS

| | Windows (Spout) | macOS (Syphon) |
|---|---|---|
| Driver | Native thread + tsfn.call | JS setInterval polling |
| If JS is slow | Queue grows unboundedly | Next tick delayed, no queue |
| Semantics | queue-everything | drop-latest (by design) |

macOS works fine because the pull-based polling model naturally drops frames when JS is behind. Windows adopted a push-based event-driven model but inherited no backpressure from the tsfn queue default.

## Fix

`packages/native/src/lib.rs`: change `create_threadsafe_function(0, ...)` → `create_threadsafe_function(1, ...)`.

With `NonBlocking` call mode + `max_queue_size = 1`, concurrent calls return `Status::QueueFull`; the passed `Vec<u8>` is dropped immediately, freeing the 8 MB heap allocation. No memory accumulates at the native boundary.

Behaviourally equivalent to the macOS polling path: the listener always presents the most recent frame, older unprocessed frames are dropped.

## Verification

- `cargo test --manifest-path packages/native/Cargo.toml` — 15 passed
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check` — all formatted
- `pnpm typecheck` — 3 packages pass
- `pnpm test` — 41 TS tests pass (core: 9, renderer: 32)

Downstream manual verification pending: installing the rebuilt `.node` in the affected app to confirm memory stabilises.

## Note on diff scope

This PR branches from `feat/event-driven-receiver` (local only, not yet pushed). The diff against `main` therefore includes that entire feature. The one-line semantic change this PR is about is in the final commit (`fix(spout): use bounded tsfn queue for drop-latest semantics`); everything else is the prior event-driven-receiver work that should land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)