### PR TITLE
fix(ci): bump publish job to Node 24 to avoid broken npm in 22.22.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,12 +140,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Node 24 ships with npm 11+, required for OIDC trusted publishing.
+          # Avoids upgrading npm at runtime — Node 22.22.2's bundled npm was
+          # found to be broken (missing 'promise-retry'), so `npm install -g
+          # npm@latest` failed before it could upgrade itself.
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
-
-      # npm >= 11.5.1 required for OIDC trusted publishing
-      - run: npm install -g npm@latest
 
       - run: pnpm install
 


### PR DESCRIPTION
## Problem

The publish workflow that ran after PR #34 merged failed with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
…
```

GitHub's hosted tool cache for Node 22.22.2 ships an npm installation whose internal dependency graph is broken (`promise-retry` missing from `@npmcli/arborist`'s tree). The step `npm install -g npm@latest` cannot run because npm itself fails to boot.

## Fix

Bump the publish job to Node 24, which ships with npm 11 already. npm 11 satisfies the `>= 11.5.1` requirement for OIDC trusted publishing, so the runtime `npm install -g npm@latest` upgrade step is no longer needed and is removed.

Diff:

```diff
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org

-      # npm >= 11.5.1 required for OIDC trusted publishing
-      - run: npm install -g npm@latest
-
       - run: pnpm install
```

Other workflows (`ci.yml`, `platform-smoke.yml`) remain on Node 22 because they do not invoke npm directly — they use pnpm throughout and are unaffected by the broken bundled npm.

## Scope

- Only touches `.github/workflows/publish.yml`.
- Does not change the publish pipeline's behaviour; just replaces a runtime npm upgrade with a baseline Node version that already carries that npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)