### PR TITLE
fix(native): document drop-latest backpressure in start_listening

### DIFF
--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -380,6 +380,14 @@ impl TextureReceiver {
     /// Spawns a native thread that receives frames and delivers them via callback.
     /// The callback receives a `ReceivedFrame` object for each new frame.
     /// Call `stop()` to terminate the listener thread.
+    ///
+    /// Backpressure: the JS callback is bridged via a threadsafe function with
+    /// a queue capacity of 1. When the JS main thread is slower than the
+    /// sender's native frame rate, newer frames are dropped at the native
+    /// boundary and the `Vec<u8>` buffer is freed immediately. This prevents
+    /// memory growth and matches the drop-latest semantics of the macOS
+    /// (Syphon) polling path. Consumers can assume they always observe the
+    /// most recent frame but may skip intermediate frames under load.
     #[cfg(target_os = "windows")]
     #[napi(
         ts_args_type = "callback: (frame: ReceivedFrame) => void",


### PR DESCRIPTION
## Why

Two things are being addressed in one small change:

1. **Missing API doc** — The tsfn queue capacity was set to 1 in #34 to prevent unbounded memory growth on Windows, but the public doc-comment on `start_listening` did not describe the resulting backpressure semantics. Consumers reading the API have no way to know that intermediate frames may be dropped under load.

2. **Stuck release pipeline** — v0.8.1 (the tag for the tsfn fix + Syphon event-driven receiver) was tagged on main but never reached npm: that run's publish job failed on Node 22.22.2's broken bundled npm. The npm fix landed in #36 but only touched `.github/workflows/publish.yml`, which is outside the release-please package paths, so release-please did not produce a new release PR. Adding a `fix(native):` commit inside `packages/native/` gives release-please something to release, so the prior tsfn fix finally gets published.

## What

```diff
  /// Start event-driven frame reception.
  /// Spawns a native thread that receives frames and delivers them via callback.
  /// The callback receives a `ReceivedFrame` object for each new frame.
  /// Call `stop()` to terminate the listener thread.
+ ///
+ /// Backpressure: the JS callback is bridged via a threadsafe function with
+ /// a queue capacity of 1. When the JS main thread is slower than the
+ /// sender's native frame rate, newer frames are dropped at the native
+ /// boundary and the `Vec<u8>` buffer is freed immediately. This prevents
+ /// memory growth and matches the drop-latest semantics of the macOS
+ /// (Syphon) polling path. Consumers can assume they always observe the
+ /// most recent frame but may skip intermediate frames under load.
```

## Expected release flow

1. This PR merges.
2. release-please opens a release PR bumping to v0.8.2 (linked across native / core / renderer per the workspace config).
3. That release PR merges.
4. publish workflow runs on Node 24 (from #36) → all three packages ship to npm.

## Scope / Risk

- Doc-comment only; no runtime change.
- `fix(native):` prefix chosen (rather than `docs:`) so release-please treats it as a patch-bumpable change — it is documenting a previously undocumented behavioural guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)