### PR TITLE
chore(native): clear cargo build warnings

### DIFF
--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -115,15 +115,14 @@ impl TextureSender {
             inner
                 .send_surface(surface_ptr, width, height)
                 .map_err(|e| Error::from_reason(e))?;
+            Ok(())
         }
 
-        #[cfg(target_os = "windows")]
+        #[cfg(not(target_os = "macos"))]
         {
-            let _ = inner;
-            return Err(Error::from_reason("send_surface is macOS only"));
+            let _ = (inner, surface_buffer);
+            Err(Error::from_reason("send_surface is macOS only"))
         }
-
-        Ok(())
     }
 
     /// Stop the sender and release native resources immediately.
@@ -323,6 +322,7 @@ impl TextureReceiver {
     /// - `app_name`: (macOS only) Filter by application name
     /// - `server_uuid`: (macOS only) Connect by server UUID (highest priority)
     #[napi(constructor)]
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
     pub fn new(
         sender_name: String,
         app_name: Option<String>,

--- a/packages/native/src/win/ffi.rs
+++ b/packages/native/src/win/ffi.rs
@@ -6,6 +6,7 @@ extern "C" {
     pub fn spout_bridge_create(name: *const c_char, width: u32, height: u32) -> SpoutBridgeHandle;
     pub fn spout_bridge_destroy(handle: SpoutBridgeHandle);
     pub fn spout_bridge_send(handle: SpoutBridgeHandle, shared_handle: i64) -> i32;
+    #[allow(dead_code)]
     pub fn spout_bridge_resize(handle: SpoutBridgeHandle, width: u32, height: u32) -> i32;
 
     // ---- Receiver ----
@@ -31,14 +32,6 @@ extern "C" {
     pub fn spout_receiver_get_height(handle: SpoutReceiverHandle) -> u32;
 
     // ---- Discovery ----
-    pub fn spout_discovery_get_sender_count() -> i32;
-    pub fn spout_discovery_get_sender_name(
-        index: i32,
-        out_name: *mut c_char,
-        name_size: u32,
-    ) -> i32;
-
-    // ---- Consolidated Discovery ----
     pub fn spout_discovery_list_senders() -> *mut c_char;
     pub fn spout_discovery_free_string(str: *mut c_char);
 

--- a/packages/native/src/win/mod.rs
+++ b/packages/native/src/win/mod.rs
@@ -30,6 +30,7 @@ impl Sender {
         }
     }
 
+    #[allow(dead_code)]
     pub fn resize(&self, width: u32, height: u32) -> Result<(), String> {
         let ret = unsafe { ffi::spout_bridge_resize(self.handle, width, height) };
         if ret != 0 {

--- a/packages/native/src/win/receiver.rs
+++ b/packages/native/src/win/receiver.rs
@@ -4,6 +4,7 @@ use std::ffi::CString;
 pub struct Receiver {
     handle: Option<ffi::SpoutReceiverHandle>,
     buffer: Vec<u8>,
+    #[allow(dead_code)]
     sender_name: String,
 }
 
@@ -37,6 +38,7 @@ impl Receiver {
         })
     }
 
+    #[allow(dead_code)]
     pub fn sender_name(&self) -> &str {
         &self.sender_name
     }


### PR DESCRIPTION
## Summary

`pnpm build:native` was printing 10 warnings from `cargo`. This PR clears all of them without changing runtime behavior.

- **Unreachable expression in `TextureSender::send_surface`**: restructured so the macOS branch returns its own `Ok(())` and the non-macOS branch returns its own `Err(...)`, removing the trailing `Ok(())` that was unreachable on Windows builds.
- **Unused `app_name` / `server_uuid` in `TextureReceiver::new`**: these are only consumed inside a `#[cfg(target_os = "macos")]` block. Added `#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]` to the constructor.
- **Dropped legacy discovery FFI declarations**: `spout_discovery_get_sender_count` / `spout_discovery_get_sender_name` were superseded by `spout_discovery_list_senders`. The C++ implementations are left intact; only the unused Rust declarations are removed.
- **`#[allow(dead_code)]` on future-use symbols**: `Sender::resize` + `spout_bridge_resize` (resize path is wired in C++ but not yet exposed to JS) and `Receiver::sender_name` field/accessor (kept for potential reconnect/debug logic).

## Test plan

- [x] `cargo check --release` (inside `packages/native`) → `Finished \`release\` profile`, zero warnings
- [ ] `pnpm build:native` on a machine where no Electron process holds the `.node` file (the sandbox here blocked `taskkill electron.exe`, so the full napi link step was not rerun locally)
- [ ] CI build on Windows + macOS runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)