### PR TITLE
fix(renderer): defer imported.release() to avoid renderer tracker race

### DIFF
--- a/packages/renderer/src/__tests__/shared-texture-consumer.test.ts
+++ b/packages/renderer/src/__tests__/shared-texture-consumer.test.ts
@@ -27,6 +27,12 @@ import {
   installSharedTextureReceiver,
 } from "../client/shared-texture-consumer";
 
+// `installSharedTextureReceiver` defers `imported.release()` by one macrotask
+// to avoid racing ahead of Electron's main-side tracker update (see
+// implementation comment). Tests that assert on release side effects must
+// flush the macrotask queue after invoking the registered callback.
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
 const makeMockVideoFrame = () =>
   ({
     close: vi.fn(),
@@ -157,6 +163,23 @@ describe("consumeSharedTexture", () => {
     expect(frameArg).toMatchObject({ textureId: "tex-abc", videoFrame });
     expect(extra1).toBe("extra1");
     expect(extra2).toBe(7);
+    await flush();
+    expect(imported.release).toHaveBeenCalledTimes(1);
+
+    reg.dispose();
+  });
+
+  it("defers imported.release() to the next macrotask so the release IPC cannot race ahead of main-side tracker registration", async () => {
+    const reg = consumeSharedTexture({ onFrame: vi.fn() });
+
+    const imported = makeMockImported();
+    await registeredCallback!(makeMockData(imported));
+
+    // The callback has resolved, the consumer has run, but release is
+    // queued on the next macrotask — not fired yet.
+    expect(imported.release).not.toHaveBeenCalled();
+
+    await flush();
     expect(imported.release).toHaveBeenCalledTimes(1);
 
     reg.dispose();
@@ -184,6 +207,7 @@ describe("consumeSharedTexture", () => {
     expect(frameA.close).toHaveBeenCalledTimes(1);
     expect(frameB.close).toHaveBeenCalledTimes(1);
     // Imported texture is released exactly once after all consumers finish.
+    await flush();
     expect(imported.release).toHaveBeenCalledTimes(1);
 
     regA.dispose();
@@ -202,6 +226,7 @@ describe("consumeSharedTexture", () => {
     });
 
     await registeredCallback!(makeMockData(imported));
+    await flush();
 
     expect(videoFrame.close).toHaveBeenCalledTimes(1);
     expect(imported.release).toHaveBeenCalledTimes(1);
@@ -223,6 +248,7 @@ describe("consumeSharedTexture", () => {
     });
 
     await registeredCallback!(makeMockData(imported));
+    await flush();
 
     expect(videoFrame.close).toHaveBeenCalledTimes(1);
     expect(imported.release).toHaveBeenCalledTimes(1);
@@ -241,6 +267,7 @@ describe("consumeSharedTexture", () => {
     const reg = consumeSharedTexture({ onFrame: vi.fn() });
 
     await expect(registeredCallback!(makeMockData(imported))).resolves.toBeUndefined();
+    await flush();
     expect(imported.release).toHaveBeenCalledTimes(1);
 
     reg.dispose();
@@ -256,6 +283,7 @@ describe("consumeSharedTexture", () => {
 
     const imported = makeMockImported();
     await registeredCallback!(makeMockData(imported));
+    await flush();
 
     expect(onFrameBad).toHaveBeenCalledTimes(1);
     expect(onFrameGood).toHaveBeenCalledTimes(1);
@@ -275,6 +303,7 @@ describe("consumeSharedTexture", () => {
 
     const imported = makeMockImported();
     await registeredCallback!(makeMockData(imported));
+    await flush();
 
     expect(onFrameA).not.toHaveBeenCalled();
     expect(onFrameB).toHaveBeenCalledTimes(1);
@@ -300,6 +329,7 @@ describe("consumeSharedTexture", () => {
 
     const imported = makeMockImported();
     await registeredCallback!(makeMockData(imported));
+    await flush();
 
     expect(onFrame).not.toHaveBeenCalled();
     expect(imported.release).toHaveBeenCalledTimes(1);
@@ -353,12 +383,16 @@ describe("consumeSharedTexture", () => {
     // release() will throw, but must be swallowed.
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(registeredCallback!(makeMockData(misbehavingImported))).resolves.toBeUndefined();
+    // The outer release is deferred by one macrotask; flush to let it (and its
+    // swallowed throw) fire.
+    await flush();
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
 
     // A subsequent frame with a well-behaved imported still reaches consumers.
     const cleanImported = makeMockImported();
     await registeredCallback!(makeMockData(cleanImported));
+    await flush();
     expect(healthyOnFrame).toHaveBeenCalledTimes(2); // called on both frames
     expect(cleanImported.release).toHaveBeenCalledTimes(1);
 
@@ -384,6 +418,7 @@ describe("consumeSharedTexture", () => {
     // The onError throw must be swallowed so finally + outer release still run.
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(registeredCallback!(makeMockData(imported))).resolves.toBeUndefined();
+    await flush();
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
 

--- a/packages/renderer/src/client/shared-texture-consumer.ts
+++ b/packages/renderer/src/client/shared-texture-consumer.ts
@@ -90,15 +90,30 @@ export const installSharedTextureReceiver = (): void => {
     try {
       await dispatcher.handler(data, ...args);
     } finally {
-      // A misbehaving consumer that called `.release()` inside its own
-      // `onFrame` would otherwise throw here and kill the permanent slot
-      // (DoS). Log and swallow so the slot stays healthy for every other
-      // consumer.
-      try {
-        imported.release();
-      } catch (err) {
-        console.error("[shared-texture] imported.release() threw (possibly double-released):", err);
-      }
+      // Defer imported.release() to the next macrotask. sendSharedTexture
+      // registers the renderer-frame reference in its tracker *after* it
+      // receives our sync-token ACK from this transfer handler. If we release
+      // synchronously here, the resulting RELEASE_RENDERER_TO_MAIN IPC can be
+      // processed by main in the same tick as the ACK — the release handler
+      // then runs before the ACK continuation microtask has updated the
+      // tracker, and Electron throws
+      // "Shared texture X is not referenced by renderer frame N", silently
+      // leaking the tracker entry. One macrotask of slack puts the release
+      // IPC on main's next tick, by which point microtasks have drained.
+      setTimeout(() => {
+        // A misbehaving consumer that called `.release()` inside its own
+        // `onFrame` would otherwise throw here and kill the permanent slot
+        // (DoS). Log and swallow so the slot stays healthy for every other
+        // consumer.
+        try {
+          imported.release();
+        } catch (err) {
+          console.error(
+            "[shared-texture] imported.release() threw (possibly double-released):",
+            err,
+          );
+        }
+      }, 0);
     }
   });
 };


### PR DESCRIPTION
## Summary

During live receiver streaming, the example app's main process logged `Error occurred in handler for 'IMPORT_SHARED_TEXTURE_RELEASE_RENDERER_TO_MAIN': Error: Shared texture X is not referenced by renderer frame N` at ~12 Hz. Every such error silently leaks a tracker entry in Electron's main-side `managedSharedTextures` map.

## Root cause

Reading Electron's [`lib/browser/api/shared-texture.ts`](https://github.com/electron/electron/blob/main/lib/browser/api/shared-texture.ts) and [`lib/renderer/api/shared-texture.ts`](https://github.com/electron/electron/blob/main/lib/renderer/api/shared-texture.ts):

1. Renderer's transfer handler sends the sync-token ACK **before** awaiting the user's `setSharedTextureReceiver` callback.
2. Our outer callback in `installSharedTextureReceiver` then called `imported.release()` synchronously in its `finally`, firing `RELEASE_RENDERER_TO_MAIN` in the same event loop tick as the ACK.
3. Main's `sendSharedTexture` registers the renderer-frame reference in its tracker *after* the ACK arrives — as a microtask continuation.
4. When both IPCs reach main in the same tick, the release handler runs synchronously before the ACK continuation microtask drains, so the tracker lookup fails and Electron throws.

## Fix

Defer `imported.release()` by one macrotask (`setTimeout(..., 0)`) inside `installSharedTextureReceiver`. That puts the renderer's release IPC on main's *next* tick, after microtasks have drained and the tracker entry exists.

Trade-offs considered:
- **Handshake IPC (main → renderer `tracker-ready` per frame)** — fully deterministic but adds ~1-2% CPU at 120 Hz per stream. Overkill for a race that a one-macrotask slack already closes.
- **Upstream Electron fix** — pre-register the tracker entry before sending the transfer IPC and roll back on failure. Would eliminate the race at source. Worth filing separately; this PR is the immediate mitigation.

## Measured impact

Live 3-minute Electron run against a real Spout sender on Windows:

| metric | before fix (60 s) | after fix (~3 min) |
|---|---|---|
| FPS reports | 111 | 333 |
| `IMPORT_SHARED_TEXTURE_RELEASE_RENDERER_TO_MAIN` errors | 736 (~12/s) | **0** |
| panic / crash / other errors | 0 | 0 |
| FPS stability | 117–124 | 119.5–120.5 |

## Test plan

- [x] `vitest run packages/renderer` — 105/105 pass
- [x] `tsgo --noEmit` (core, renderer, example) — clean
- [x] `oxfmt --check` + `oxlint` (via pre-commit) — clean
- [x] 3 min live receiver streaming in `pnpm dev:example` — zero errors, FPS steady

🤖 Generated with [Claude Code](https://claude.com/claude-code)