### PR TITLE
feat(renderer): add includeAlpha option to forward alpha into shared texture

### DIFF
--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -41,7 +41,7 @@ app.whenReady().then(async () => {
     // Forward the page's alpha channel into the Syphon/Spout texture so
     // VJ software can use this output as an overlay layer. The renderer's
     // raymarching shader emits alpha=0 for background pixels.
-    transparent: true,
+    includeAlpha: true,
   });
 
   bridge.on("fps", (fps) => {

--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -38,6 +38,10 @@ app.whenReady().then(async () => {
     frameRate: 120,
     rendererUrl: getRendererUrl(),
     preview: { enabled: true, width: 960, height: 540 },
+    // Forward the page's alpha channel into the Syphon/Spout texture so
+    // VJ software can use this output as an overlay layer. The renderer's
+    // raymarching shader emits alpha=0 for background pixels.
+    transparent: true,
   });
 
   bridge.on("fps", (fps) => {

--- a/packages/example/src/renderer/index.html
+++ b/packages/example/src/renderer/index.html
@@ -8,6 +8,13 @@
         margin: 0;
         padding: 0;
       }
+      /* Transparent compositor backdrop so the createTextureBridge alpha
+         path receives per-pixel alpha from the WebGL canvas instead of the
+         opaque CSS-default. */
+      html,
+      body {
+        background: transparent;
+      }
       canvas {
         display: block;
       }

--- a/packages/example/src/renderer/render-worker.ts
+++ b/packages/example/src/renderer/render-worker.ts
@@ -76,7 +76,7 @@ function init(canvas: OffscreenCanvas) {
     antialias: true,
     // alpha:true + clearAlpha:0 lets the fragment shader's gl_FragColor.a
     // flow through to the framebuffer, which the createTextureBridge
-    // `transparent` option then forwards into the Syphon/Spout BGRA texture.
+    // `includeAlpha` option then forwards into the Syphon/Spout BGRA texture.
     alpha: true,
     premultipliedAlpha: false,
     powerPreference: "high-performance",

--- a/packages/example/src/renderer/render-worker.ts
+++ b/packages/example/src/renderer/render-worker.ts
@@ -74,7 +74,11 @@ function init(canvas: OffscreenCanvas) {
   renderer = new THREE.WebGLRenderer({
     canvas: canvas as unknown as HTMLCanvasElement,
     antialias: true,
-    alpha: false,
+    // alpha:true + clearAlpha:0 lets the fragment shader's gl_FragColor.a
+    // flow through to the framebuffer, which the createTextureBridge
+    // `transparent` option then forwards into the Syphon/Spout BGRA texture.
+    alpha: true,
+    premultipliedAlpha: false,
     powerPreference: "high-performance",
     preserveDrawingBuffer: false,
   });
@@ -83,6 +87,7 @@ function init(canvas: OffscreenCanvas) {
   renderer.setSize(canvasSize.width, canvasSize.height, false);
   renderer.setPixelRatio(1);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.setClearColor(0x000000, 0);
 
   scene = new THREE.Scene();
   camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);

--- a/packages/example/src/renderer/shaders/raymarching.frag
+++ b/packages/example/src/renderer/shaders/raymarching.frag
@@ -212,5 +212,14 @@ void main() {
   col = pow(col, vec3(0.4545));
   col = clamp(col, 0.0, 1.0);
 
-  gl_FragColor = vec4(col, 1.0);
+  // Alpha emission for the createTextureBridge `transparent` demo:
+  // - Solid raymarched surfaces are fully opaque.
+  // - Background pixels (ray missed) modulate alpha by their luminance, so
+  //   bright glow remains visible while empty void becomes fully
+  //   transparent. VJ software receives a layer with proper transparency
+  //   instead of an opaque black backdrop.
+  float alpha = (d < MAX_DIST) ? 1.0 : clamp(dot(col, vec3(0.299, 0.587, 0.114)), 0.0, 1.0);
+  alpha *= vignette;
+
+  gl_FragColor = vec4(col, alpha);
 }

--- a/packages/example/src/renderer/shaders/raymarching.frag
+++ b/packages/example/src/renderer/shaders/raymarching.frag
@@ -212,7 +212,7 @@ void main() {
   col = pow(col, vec3(0.4545));
   col = clamp(col, 0.0, 1.0);
 
-  // Alpha emission for the createTextureBridge `transparent` demo:
+  // Alpha emission for the createTextureBridge `includeAlpha` demo:
   // - Solid raymarched surfaces are fully opaque.
   // - Background pixels (ray missed) modulate alpha by their luminance, so
   //   bright glow remains visible while empty void becomes fully

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -47,18 +47,18 @@ describe("buildBrowserWindowOptions", () => {
     expect(out.backgroundColor).toBeUndefined();
   });
 
-  it("sets transparent + alpha-zero backgroundColor when transparent: true", () => {
+  it("sets transparent + alpha-zero backgroundColor when includeAlpha: true", () => {
     // The compositor only emits per-pixel alpha into the OSR shared texture
-    // when both flags are set. transparent:true alone leaves Chromium
-    // painting an opaque backdrop; backgroundColor with the alpha byte zero
-    // is what flips the initial fill to fully-transparent.
-    const out = buildBrowserWindowOptions({ ...baseOpts, transparent: true });
+    // when both flags are set on the BrowserWindow. transparent:true alone
+    // leaves Chromium painting an opaque backdrop; backgroundColor with the
+    // alpha byte zero is what flips the initial fill to fully-transparent.
+    const out = buildBrowserWindowOptions({ ...baseOpts, includeAlpha: true });
     expect(out.transparent).toBe(true);
     expect(out.backgroundColor).toBe("#00000000");
   });
 
-  it("treats transparent: false the same as omitted", () => {
-    const out = buildBrowserWindowOptions({ ...baseOpts, transparent: false });
+  it("treats includeAlpha: false the same as omitted", () => {
+    const out = buildBrowserWindowOptions({ ...baseOpts, includeAlpha: false });
     expect(out.transparent).toBeUndefined();
     expect(out.backgroundColor).toBeUndefined();
   });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock Electron and the native core so we can import bridge.ts in node tests.
+// `buildBrowserWindowOptions` is a pure function, but the module-level
+// `import { app, BrowserWindow } from "electron"` would otherwise pull the
+// real native module.
+vi.mock("electron", () => ({
+  app: { isReady: () => true },
+  BrowserWindow: class MockBrowserWindow {},
+}));
+
+vi.mock("@napolab/texture-bridge-core", () => ({
+  TextureSender: class MockTextureSender {},
+  sendTextureFromPaintEvent: vi.fn(),
+}));
+
+import { buildBrowserWindowOptions } from "../bridge";
+import type { TextureBridgeOptions } from "../types";
+
+const baseOpts: TextureBridgeOptions = {
+  name: "test",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "file:///renderer.html",
+};
+
+describe("buildBrowserWindowOptions", () => {
+  it("forwards width and height to the BrowserWindow constructor args", () => {
+    const out = buildBrowserWindowOptions({ ...baseOpts, width: 1280, height: 720 });
+    expect(out.width).toBe(1280);
+    expect(out.height).toBe(720);
+  });
+
+  it("creates a hidden offscreen window with sharedTexture by default", () => {
+    const out = buildBrowserWindowOptions(baseOpts);
+    expect(out.show).toBe(false);
+    expect(out.webPreferences?.contextIsolation).toBe(true);
+    expect(out.webPreferences?.nodeIntegration).toBe(false);
+    // `offscreen.useSharedTexture` is the contract Electron 40+ requires
+    // for the GPU zero-copy paint event path.
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
+  });
+
+  it("does not enable transparent by default", () => {
+    const out = buildBrowserWindowOptions(baseOpts);
+    expect(out.transparent).toBeUndefined();
+    expect(out.backgroundColor).toBeUndefined();
+  });
+
+  it("sets transparent + alpha-zero backgroundColor when transparent: true", () => {
+    // The compositor only emits per-pixel alpha into the OSR shared texture
+    // when both flags are set. transparent:true alone leaves Chromium
+    // painting an opaque backdrop; backgroundColor with the alpha byte zero
+    // is what flips the initial fill to fully-transparent.
+    const out = buildBrowserWindowOptions({ ...baseOpts, transparent: true });
+    expect(out.transparent).toBe(true);
+    expect(out.backgroundColor).toBe("#00000000");
+  });
+
+  it("treats transparent: false the same as omitted", () => {
+    const out = buildBrowserWindowOptions({ ...baseOpts, transparent: false });
+    expect(out.transparent).toBeUndefined();
+    expect(out.backgroundColor).toBeUndefined();
+  });
+
+  it("preserves caller-supplied webPreferences (merge over the offscreen base)", () => {
+    const out = buildBrowserWindowOptions({
+      ...baseOpts,
+      webPreferences: { backgroundThrottling: false },
+    });
+    expect(out.webPreferences?.backgroundThrottling).toBe(false);
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
+  });
+
+  it("lets caller-supplied webPreferences override the base defaults", () => {
+    // Documents the existing override behavior in createTextureBridge so we
+    // do not silently regress when refactoring the helper.
+    const out = buildBrowserWindowOptions({
+      ...baseOpts,
+      webPreferences: { contextIsolation: false },
+    });
+    expect(out.webPreferences?.contextIsolation).toBe(false);
+  });
+});

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -144,6 +144,46 @@ class TextureBridgeImpl extends EventEmitter implements TextureBridge {
 }
 
 /**
+ * Build the BrowserWindow constructor options for the offscreen renderer.
+ *
+ * Extracted as a pure function so it can be unit tested without touching
+ * Electron's native module — the actual `new BrowserWindow(...)` call lives
+ * in `createTextureBridge`.
+ *
+ * `options.transparent` flips the OSR pipeline into alpha-preserving mode:
+ * `transparent: true` plus `backgroundColor: "#00000000"` is the documented
+ * recipe for Chromium to emit per-pixel alpha into the shared texture. The
+ * page itself must use a transparent background (`html, body { background:
+ * transparent }`) for the alpha to mean anything.
+ */
+export function buildBrowserWindowOptions(
+  options: TextureBridgeOptions,
+): Electron.BrowserWindowConstructorOptions {
+  const { width, height, webPreferences, transparent } = options;
+
+  const ctorOptions: Electron.BrowserWindowConstructorOptions = {
+    width,
+    height,
+    show: false,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      offscreen: { useSharedTexture: true },
+      ...webPreferences,
+    },
+  };
+
+  if (transparent) {
+    ctorOptions.transparent = true;
+    // Hex `#RRGGBBAA` with alpha=0x00 is the explicit "fully transparent
+    // backdrop" signal Chromium honors on offscreen render surfaces.
+    ctorOptions.backgroundColor = "#00000000";
+  }
+
+  return ctorOptions;
+}
+
+/**
  * Create a fully-wired texture bridge: offscreen window, native sender,
  * optional preview, and FPS tracking.
  *
@@ -154,20 +194,10 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
     throw new Error("createTextureBridge() must be called after app.whenReady()");
   }
 
-  const { name, width, height, frameRate = 60, rendererUrl, preview, webPreferences } = options;
+  const { name, width, height, frameRate = 60, rendererUrl, preview } = options;
 
   // ---- Offscreen BrowserWindow ----
-  const renderWindow = new BrowserWindow({
-    width,
-    height,
-    show: false,
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-      offscreen: { useSharedTexture: true },
-      ...webPreferences,
-    },
-  });
+  const renderWindow = new BrowserWindow(buildBrowserWindowOptions(options));
 
   // ---- Native sender ----
   const sender = new TextureSender(name, width, height);

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -161,7 +161,7 @@ export function buildBrowserWindowOptions(
 ): Electron.BrowserWindowConstructorOptions {
   const { width, height, webPreferences, includeAlpha } = options;
 
-  const ctorOptions: Electron.BrowserWindowConstructorOptions = {
+  return {
     width,
     height,
     show: false,
@@ -171,16 +171,12 @@ export function buildBrowserWindowOptions(
       offscreen: { useSharedTexture: true },
       ...webPreferences,
     },
-  };
-
-  if (includeAlpha) {
-    ctorOptions.transparent = true;
     // Hex `#RRGGBBAA` with alpha=0x00 is the explicit "fully transparent
-    // backdrop" signal Chromium honors on offscreen render surfaces.
-    ctorOptions.backgroundColor = "#00000000";
-  }
-
-  return ctorOptions;
+    // backdrop" signal Chromium honors on offscreen render surfaces. The
+    // `transparent: true` flag alone leaves the compositor painting opaque,
+    // so both keys must be applied together.
+    ...(includeAlpha ? { transparent: true, backgroundColor: "#00000000" } : {}),
+  };
 }
 
 /**

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -150,16 +150,16 @@ class TextureBridgeImpl extends EventEmitter implements TextureBridge {
  * Electron's native module — the actual `new BrowserWindow(...)` call lives
  * in `createTextureBridge`.
  *
- * `options.transparent` flips the OSR pipeline into alpha-preserving mode:
- * `transparent: true` plus `backgroundColor: "#00000000"` is the documented
- * recipe for Chromium to emit per-pixel alpha into the shared texture. The
- * page itself must use a transparent background (`html, body { background:
- * transparent }`) for the alpha to mean anything.
+ * `options.includeAlpha` flips the OSR pipeline into alpha-preserving mode:
+ * `transparent: true` plus `backgroundColor: "#00000000"` on the BrowserWindow
+ * is the documented recipe for Chromium to emit per-pixel alpha into the
+ * shared texture. The page itself must use a transparent background
+ * (`html, body { background: transparent }`) for the alpha to mean anything.
  */
 export function buildBrowserWindowOptions(
   options: TextureBridgeOptions,
 ): Electron.BrowserWindowConstructorOptions {
-  const { width, height, webPreferences, transparent } = options;
+  const { width, height, webPreferences, includeAlpha } = options;
 
   const ctorOptions: Electron.BrowserWindowConstructorOptions = {
     width,
@@ -173,7 +173,7 @@ export function buildBrowserWindowOptions(
     },
   };
 
-  if (transparent) {
+  if (includeAlpha) {
     ctorOptions.transparent = true;
     // Hex `#RRGGBBAA` with alpha=0x00 is the explicit "fully transparent
     // backdrop" signal Chromium honors on offscreen render surfaces.

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -24,6 +24,19 @@ export interface TextureBridgeOptions {
   preview?: PreviewOptions;
   /** Additional webPreferences for the offscreen BrowserWindow */
   webPreferences?: Electron.WebPreferences;
+  /**
+   * Include the page's alpha channel in the captured texture (default: false).
+   *
+   * When true, the offscreen BrowserWindow is created with `transparent: true`
+   * and a fully-transparent backgroundColor so Chromium's compositor preserves
+   * per-pixel alpha into the BGRA shared texture. The page (or its body / root
+   * elements) must use a transparent background — opaque CSS will overwrite
+   * the alpha and produce a fully-opaque output regardless of this flag.
+   *
+   * VJ software (Resolume, VDMX, etc.) consumes the alpha channel as the
+   * layer's transparency mask, enabling overlay / lower-third compositing.
+   */
+  transparent?: boolean;
 }
 
 /** Events emitted by TextureBridge */

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -36,7 +36,7 @@ export interface TextureBridgeOptions {
    * VJ software (Resolume, VDMX, etc.) consumes the alpha channel as the
    * layer's transparency mask, enabling overlay / lower-third compositing.
    */
-  transparent?: boolean;
+  includeAlpha?: boolean;
 }
 
 /** Events emitted by TextureBridge */


### PR DESCRIPTION
## Summary

`createTextureBridge` now accepts an optional `includeAlpha: true` flag. When set, the offscreen BrowserWindow is created with `transparent: true` plus `backgroundColor: \"#00000000\"` so Chromium's compositor preserves per-pixel alpha into the BGRA shared texture. VJ software (Resolume, VDMX, etc.) can consume the output as a transparency-masked overlay layer instead of an opaque RGB rectangle.

## Why

Today the offscreen BrowserWindow has no transparency hint. Chromium fills the canvas with an opaque white backdrop, so the alpha bits in the BGRA paint texture are always `0xFF` and downstream VJ software has no way to distinguish foreground content from background. Multi-layer compositing (lower-thirds, overlays, picture-in-picture) is impossible without a per-pixel mask.

The fix is a one-flag opt-in. The Electron API for it has existed forever — we just have not been exposing it on `TextureBridgeOptions`.

## API

\`\`\`typescript
createTextureBridge({
  name: \"MyOverlay\",
  width: 1920,
  height: 1080,
  rendererUrl: \"file:///overlay.html\",
  includeAlpha: true,  // new
});
\`\`\`

The option is named for the user-facing intent — \"include the page's alpha channel in the captured texture\" — rather than the underlying \`BrowserWindow.transparent\` flag. The internal mapping is documented in JSDoc.

When \`includeAlpha: true\`:
- BrowserWindow is created with \`transparent: true\` and \`backgroundColor: \"#00000000\"\`. The hex \`#RRGGBBAA\` form with alpha=00 is the documented signal Chromium honors on offscreen render surfaces.
- The page itself must use a transparent background (\`html, body { background: transparent }\`). Opaque CSS will overwrite the alpha and produce a fully-opaque output regardless of this flag — JSDoc on the option spells this out.

When omitted or \`false\`: behavior is exactly the same as before this PR.

## Implementation

**\`packages/renderer/src/types.ts\`** — \`TextureBridgeOptions\` gains an optional \`includeAlpha\` field with JSDoc covering the page-must-be-transparent constraint and the VJ-overlay use case.

**\`packages/renderer/src/bridge.ts\`** — factor \`buildBrowserWindowOptions\` out of \`createTextureBridge\` as a pure function so the constructor-args mapping is unit testable without standing up Electron. The helper threads \`includeAlpha\` through to the constructor's \`transparent\` + \`backgroundColor\` exactly when the flag is set.

**\`packages/renderer/src/__tests__/bridge.test.ts\` (new)** — 7 tests covering default behavior, the \`includeAlpha\` toggle, \`includeAlpha: false\`, the offscreen + isolation defaults, and the existing webPreferences merge contract (so we do not silently regress when refactoring the helper).

### Example demo

The example app turns on the new flag and renders an actually-transparent layer:

- **\`packages/example/src/main/index.ts\`** — passes \`includeAlpha: true\`.
- **\`packages/example/src/renderer/index.html\`** — \`html, body { background: transparent }\` so the WebGL canvas's alpha reaches the compositor.
- **\`packages/example/src/renderer/render-worker.ts\`** — \`WebGLRenderer({ alpha: true, premultipliedAlpha: false })\` plus \`setClearColor(0x000000, 0)\`.
- **\`packages/example/src/renderer/shaders/raymarching.frag\`** — emits \`gl_FragColor.a = (rayHit ? 1.0 : luminance) * vignette\`. Solid raymarched surfaces stay fully opaque, the bright glow region is semi-transparent at its luminance, and pure void (no glow, no surface) goes fully transparent. VJ apps see a clean overlay layer with a usable alpha mask.

## Verification

- \`pnpm test\` — core **9/9** + renderer **112/112** pass (7 new \`bridge.test.ts\` tests).
- \`pnpm typecheck\` — clean across core / renderer / example.
- \`pnpm lint\` — clean (only the pre-existing \`no-empty-file\` warning on \`packages/example/src/preload/index.ts\`, untouched).

### Manual end-to-end

\`pnpm dev:example\` on macOS, third-party Syphon receiver (Resolume / VDMX / Simple Client / OBS Syphon input):

- \`ElectronVJ-ThreeJS\` shows up as a layer with a working alpha mask
- Background void is fully transparent, glow regions are semi-transparent, raymarched solids are opaque
- No console errors, no FPS regression

## Release impact

Purely additive option on \`TextureBridgeOptions\`. Default behavior is unchanged (\`includeAlpha\` omitted or \`false\`). \`feat:\` per Conventional Commits triggers a minor bump and release-please will cut the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)