### PR TITLE
chore: gitignore Claude Code session lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ packages/renderer/dist/
 # worktrees
 .worktrees/
 
+# Per-machine Claude Code state (session lock files etc.)
+.claude/
+
 # claude-mem plugin context files (keep root CLAUDE.md)
 **/CLAUDE.md
 !/CLAUDE.md


### PR DESCRIPTION
## Summary

Ignore `.claude/` so per-machine, per-session lock files written by Claude Code's scheduled-task runtime do not get accidentally committed.

## Why

`.claude/scheduled_tasks.lock` contains session-specific metadata (`sessionId`, `pid`, `procStart`, `acquiredAt`). It kept showing up as an untracked file across recent PR work and triggered a Codex review note: \"if it is added to the repo, other checkouts will inherit a stale lock state that can interfere with whatever uses `.claude/scheduled_tasks.lock`\".

Ignoring the whole directory is safer than just the one file — any future runtime artifact Claude Code drops in `.claude/` is excluded too.

## What

\`\`\`gitignore
# Per-machine Claude Code state (session lock files etc.)
.claude/
\`\`\`

## Verification

- \`git status\` no longer reports `.claude/scheduled_tasks.lock` as untracked locally.
- No code changes; tests/typecheck/lint unaffected.

## Release impact

\`chore:\` per Conventional Commits — no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)