### PR TITLE
feat(receiver): make macOS Y-flip opt-out via flipY option

### DIFF
--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -110,14 +110,15 @@ app.whenReady().then(async () => {
     }
   });
 
-  ipcMain.handle("connect-receiver", (_event, senderName: string) => {
+  ipcMain.handle("connect-receiver", (_event, senderName: string, flipY: boolean) => {
     stopActiveReceiver();
-    console.log(`[receiver-test] connecting to "${senderName}" (zero-copy)`);
+    console.log(`[receiver-test] connecting to "${senderName}" (zero-copy, flipY=${flipY})`);
 
     activeReceiver = createSharedTextureReceiver({
       senderName,
       target: receiverWindow.webContents,
       pollIntervalMs: 8,
+      flipY,
     });
     activeReceiver.on("fps", (fps) => {
       if (!receiverWindow.isDestroyed()) {
@@ -128,6 +129,12 @@ app.whenReady().then(async () => {
       console.error("[receiver-test] bridge error:", err.message);
     });
     activeReceiver.start();
+  });
+
+  ipcMain.handle("set-flip-y", (_event, flipY: boolean) => {
+    if (!activeReceiver) return;
+    activeReceiver.setFlipY(flipY);
+    console.log(`[receiver-test] live toggle flipY=${flipY}`);
   });
 
   ipcMain.handle("disconnect-receiver", () => {
@@ -141,6 +148,7 @@ app.whenReady().then(async () => {
     stopActiveReceiver();
     ipcMain.removeHandler("list-senders");
     ipcMain.removeHandler("connect-receiver");
+    ipcMain.removeHandler("set-flip-y");
     ipcMain.removeHandler("disconnect-receiver");
   });
 });

--- a/packages/example/src/preload/receiver.ts
+++ b/packages/example/src/preload/receiver.ts
@@ -25,6 +25,7 @@ interface ReceiverUI {
   refreshBtn: HTMLButtonElement;
   connectBtn: HTMLButtonElement;
   disconnectBtn: HTMLButtonElement;
+  flipYCheckbox: HTMLInputElement;
 }
 
 const state = {
@@ -106,13 +107,23 @@ window.addEventListener("DOMContentLoaded", () => {
   const refreshBtn = document.getElementById("refreshBtn") as HTMLButtonElement | null;
   const connectBtn = document.getElementById("connectBtn") as HTMLButtonElement | null;
   const disconnectBtn = document.getElementById("disconnectBtn") as HTMLButtonElement | null;
+  const flipYCheckbox = document.getElementById("flipYCheckbox") as HTMLInputElement | null;
 
-  if (!canvas || !ctx || !info || !senderList || !refreshBtn || !connectBtn || !disconnectBtn) {
+  if (
+    !canvas ||
+    !ctx ||
+    !info ||
+    !senderList ||
+    !refreshBtn ||
+    !connectBtn ||
+    !disconnectBtn ||
+    !flipYCheckbox
+  ) {
     console.error("[receiver-test] required DOM elements missing");
     return;
   }
 
-  ui = { canvas, ctx, info, senderList, refreshBtn, connectBtn, disconnectBtn };
+  ui = { canvas, ctx, info, senderList, refreshBtn, connectBtn, disconnectBtn, flipYCheckbox };
   state.lastFpsTime = performance.now();
 
   senderList.addEventListener("change", () => {
@@ -123,13 +134,21 @@ window.addEventListener("DOMContentLoaded", () => {
     void refreshSenders();
   });
 
+  // Live-toggle the native flipY flag so the checkbox affects the running
+  // receiver immediately without a reconnect. When disconnected, the checkbox
+  // just sets the initial value used at the next connect.
+  flipYCheckbox.addEventListener("change", () => {
+    if (!state.connected) return;
+    void ipcRenderer.invoke("set-flip-y", flipYCheckbox.checked);
+  });
+
   connectBtn.addEventListener("click", async () => {
     const name = senderList.value;
     if (!name) return;
     state.currentSenderName = name;
     info.textContent = `Connecting to "${name}"...`;
     try {
-      await ipcRenderer.invoke("connect-receiver", name);
+      await ipcRenderer.invoke("connect-receiver", name, flipYCheckbox.checked);
       state.connected = true;
       connectBtn.disabled = true;
       disconnectBtn.disabled = false;

--- a/packages/example/src/renderer/receiver-test.html
+++ b/packages/example/src/renderer/receiver-test.html
@@ -70,6 +70,10 @@
       <button id="refreshBtn">Refresh</button>
       <button id="connectBtn" disabled>Connect</button>
       <button id="disconnectBtn" disabled>Disconnect</button>
+      <label
+        title="When checked, the macOS receiver applies a vertical flip when staging the IOSurface for importSharedTexture. Toggling while connected hot-swaps the native flag — the next polled frame uses the new path."
+        ><input type="checkbox" id="flipYCheckbox" checked />Flip Y (mac)</label
+      >
     </div>
     <div id="info">Select a sender to connect</div>
     <canvas id="canvas"></canvas>

--- a/packages/native/cpp/mac/syphon_bridge.h
+++ b/packages/native/cpp/mac/syphon_bridge.h
@@ -108,6 +108,14 @@ int syphon_receiver_receive_shared_iosurface(SyphonReceiverHandle handle,
                                              uint32_t* out_height,
                                              uint32_t* out_pixel_format);
 
+// Toggle the receive-side Y-flip pass on/off. flip != 0 enables the
+// fullscreen Y-flip render pipeline (default — matches PR #46 behavior, used
+// when the consumer expects Y-DOWN image-coord layout). flip == 0 falls back
+// to a straight blit that preserves orientation, for downstream apps whose
+// upstream Syphon source already publishes the orientation Electron's
+// importSharedTexture expects.
+void syphon_receiver_set_flip_y(SyphonReceiverHandle handle, int flip);
+
 // ============================================================
 // Pixel format utilities
 // ============================================================

--- a/packages/native/cpp/mac/syphon_bridge.mm
+++ b/packages/native/cpp/mac/syphon_bridge.mm
@@ -258,24 +258,28 @@ struct SyphonReceiverBridge {
     uint32_t                   sharedStagingHeight;
     MTLPixelFormat             sharedStagingPixelFormat;
 
-    // Y-flip render pipeline. Syphon senders publish with `flipped:YES`
-    // (origin top-left in publisher → Syphon stores Y-UP per convention), so
-    // receivers consuming via image-coordinate APIs (drawImage(VideoFrame),
-    // WebGPU importExternalTexture) must un-flip. MTLBlitCommandEncoder cannot
-    // express coordinate transforms, so we run a fullscreen-triangle render
-    // pass into the staging texture instead. Mirrors the row-reverse loop in
-    // syphon_receiver_receive_rgba (line ~575).
+    // Y-flip render pipeline. Compiled lazily the first time a flip-enabled
+    // frame arrives (see `ensure_y_flip_pipeline`). Used only when the
+    // `flipY` toggle is true; when false the receive path falls back to a
+    // straight `MTLBlitCommandEncoder` copy that preserves orientation.
     id<MTLLibrary>             yFlipLibrary;
     id<MTLRenderPipelineState> yFlipPipeline;
     MTLPixelFormat             yFlipPipelinePixelFormat;
+
+    // Whether the receive path should apply a vertical flip when staging the
+    // frame for Electron's `importSharedTexture`. Defaults to true to match
+    // the historical behavior shipped in PR #46 — receivers consuming via
+    // image-coord APIs (drawImage(VideoFrame), WebGPU importExternalTexture)
+    // expect Y-DOWN. Downstream apps that source Syphon frames already in
+    // Y-DOWN orientation can opt out via `syphon_receiver_set_flip_y`.
+    bool                       flipY;
 };
 
-// MSL source for the receive-side Y-flip pass. Compiled lazily per pixel format
-// in ensure_y_flip_pipeline. The Y-flip is encoded directly in the UV mapping:
-// vertex 0 (NDC bottom-left, rasterizes to pixel-row H-1) maps to UV (0, 0),
-// so the bottom of the destination receives the top of the source. The
-// fullscreen triangle covers the framebuffer with NDC (-1,-1), (3,-1), (-1,3)
-// — the rasterizer clips beyond NDC ±1.
+// MSL source for the receive-side Y-flip pass. The flip is encoded directly
+// in the UV mapping: vertex 0 (NDC bottom-left, rasterizes to pixel-row H-1)
+// maps to UV (0, 0), so the bottom of the destination receives the top of
+// the source. The fullscreen triangle covers the framebuffer with NDC
+// (-1,-1), (3,-1), (-1,3) — the rasterizer clips beyond NDC ±1.
 static NSString* const kYFlipShaderSource =
     @"#include <metal_stdlib>\n"
     @"using namespace metal;\n"
@@ -524,6 +528,7 @@ SyphonReceiverHandle syphon_receiver_create(const char* server_uuid,
         bridge->yFlipLibrary = nil;
         bridge->yFlipPipeline = nil;
         bridge->yFlipPipelinePixelFormat = (MTLPixelFormat)0;
+        bridge->flipY = true;
 
         bridge->device = MTLCreateSystemDefaultDevice();
         if (!bridge->device) {
@@ -758,32 +763,56 @@ int syphon_receiver_receive_shared_iosurface(SyphonReceiverHandle handle,
             return 2; // dimensions/format changed — caller polls again
         }
 
-        // Render Syphon's vended texture into our staging texture with a
-        // fullscreen Y-flip pass. This both decouples Electron's imported
-        // texture from Syphon's pool-recycled IOSurface (the Windows
-        // ntStaging invariant) and undoes the sender-side `flipped:YES`
-        // (Syphon stores Y-UP; drawImage(VideoFrame) / WebGPU expect Y-DOWN).
-        if (!ensure_y_flip_pipeline(bridge, sourceFmt)) {
-            return -2;
-        }
-
-        MTLRenderPassDescriptor* passDesc = [MTLRenderPassDescriptor renderPassDescriptor];
-        passDesc.colorAttachments[0].texture = bridge->sharedStagingTexture;
-        passDesc.colorAttachments[0].loadAction = MTLLoadActionDontCare;
-        passDesc.colorAttachments[0].storeAction = MTLStoreActionStore;
-
+        // Stage Syphon's vended texture into our owned staging texture so
+        // Electron's imported texture is decoupled from Syphon's
+        // pool-recycled IOSurface (the Windows ntStaging invariant).
+        //
+        // Two paths, selected by `bridge->flipY`:
+        //  - flipY=true (default):  fullscreen render pass with Y-flip.
+        //    Used when the consumer expects Y-DOWN image-coord layout
+        //    (drawImage(VideoFrame), WebGPU importExternalTexture) and the
+        //    upstream Syphon source publishes Y-UP (Syphon convention).
+        //  - flipY=false:           straight MTLBlitCommandEncoder copy.
+        //    Used when the upstream Syphon source already publishes the
+        //    orientation Electron's importSharedTexture expects (e.g. our
+        //    own example sender, which `flipped:YES`-publishes a frame
+        //    that round-trips back into another Electron window).
         id<MTLCommandBuffer> cmdBuf = [bridge->commandQueue commandBuffer];
-        id<MTLRenderCommandEncoder> enc =
-            [cmdBuf renderCommandEncoderWithDescriptor:passDesc];
-        [enc setRenderPipelineState:bridge->yFlipPipeline];
-        [enc setFragmentTexture:texture atIndex:0];
-        [enc drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
-        [enc endEncoding];
+        if (bridge->flipY) {
+            if (!ensure_y_flip_pipeline(bridge, sourceFmt)) {
+                return -2;
+            }
+
+            MTLRenderPassDescriptor* passDesc = [MTLRenderPassDescriptor renderPassDescriptor];
+            passDesc.colorAttachments[0].texture = bridge->sharedStagingTexture;
+            passDesc.colorAttachments[0].loadAction = MTLLoadActionDontCare;
+            passDesc.colorAttachments[0].storeAction = MTLStoreActionStore;
+
+            id<MTLRenderCommandEncoder> enc =
+                [cmdBuf renderCommandEncoderWithDescriptor:passDesc];
+            [enc setRenderPipelineState:bridge->yFlipPipeline];
+            [enc setFragmentTexture:texture atIndex:0];
+            [enc drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
+            [enc endEncoding];
+        } else {
+            id<MTLBlitCommandEncoder> blit = [cmdBuf blitCommandEncoder];
+            [blit copyFromTexture:texture
+                      sourceSlice:0
+                      sourceLevel:0
+                     sourceOrigin:MTLOriginMake(0, 0, 0)
+                       sourceSize:MTLSizeMake(w, h, 1)
+                        toTexture:bridge->sharedStagingTexture
+                 destinationSlice:0
+                 destinationLevel:0
+                destinationOrigin:MTLOriginMake(0, 0, 0)];
+            [blit endEncoding];
+        }
         [cmdBuf commit];
         [cmdBuf waitUntilCompleted];
 
         if (cmdBuf.error) {
-            NSLog(@"[SyphonReceiver] receive_shared_iosurface render failed: %@", cmdBuf.error);
+            NSLog(@"[SyphonReceiver] receive_shared_iosurface stage failed (flipY=%d): %@",
+                  bridge->flipY, cmdBuf.error);
             return -2;
         }
 
@@ -873,6 +902,12 @@ uint64_t syphon_map_pixel_format(uint32_t iosurface_pixel_format) {
         default:
             return 80; // MTLPixelFormatBGRA8Unorm (safe default)
     }
+}
+
+void syphon_receiver_set_flip_y(SyphonReceiverHandle handle, int flip) {
+    if (!handle) return;
+    auto* bridge = static_cast<SyphonReceiverBridge*>(handle);
+    bridge->flipY = (flip != 0);
 }
 
 int32_t native_close_shared_iosurface(uintptr_t raw_ptr) {

--- a/packages/native/index.d.ts
+++ b/packages/native/index.d.ts
@@ -166,6 +166,18 @@ export declare class TextureReceiver {
    * Repeated calls are safe and idempotent.
    */
   stop(): void
+  /**
+   * Toggle whether `receiveSharedTexture` applies a vertical flip when
+   * staging the frame for `importSharedTexture`. Defaults to `true`
+   * (matches PR #46 behavior, suitable for `drawImage(VideoFrame)` /
+   * WebGPU `importExternalTexture` consumers expecting Y-DOWN). Pass
+   * `false` when the upstream Syphon source already publishes the
+   * orientation Electron's `importSharedTexture` expects.
+   *
+   * macOS only — a no-op on Windows (Spout's receive path does not have
+   * a flip stage).
+   */
+  setFlipY(flip: boolean): void
   /** Get the current platform name. */
   platform(): string
 }

--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -473,6 +473,25 @@ impl TextureReceiver {
         Ok(())
     }
 
+    /// Toggle whether `receiveSharedTexture` applies a vertical flip when
+    /// staging the frame for `importSharedTexture`. Defaults to `true`
+    /// (matches PR #46 behavior, suitable for `drawImage(VideoFrame)` /
+    /// WebGPU `importExternalTexture` consumers expecting Y-DOWN). Pass
+    /// `false` when the upstream Syphon source already publishes the
+    /// orientation Electron's `importSharedTexture` expects.
+    ///
+    /// macOS only — a no-op on Windows (Spout's receive path does not have
+    /// a flip stage).
+    #[napi]
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+    pub fn set_flip_y(&self, flip: bool) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        if let Some(r) = &self.inner {
+            r.set_flip_y(flip);
+        }
+        Ok(())
+    }
+
     /// Returns true if native resources have been released via `stop()`.
     #[cfg(test)]
     pub fn is_stopped(&self) -> bool {

--- a/packages/native/src/mac/ffi.rs
+++ b/packages/native/src/mac/ffi.rs
@@ -52,6 +52,7 @@ extern "C" {
         out_height: *mut u32,
         out_pixel_format: *mut u32,
     ) -> i32;
+    pub fn syphon_receiver_set_flip_y(handle: SyphonReceiverHandle, flip: i32);
 
     // ---- Discovery ----
     pub fn syphon_discovery_list_servers() -> *mut c_char;

--- a/packages/native/src/mac/receiver.rs
+++ b/packages/native/src/mac/receiver.rs
@@ -220,6 +220,16 @@ impl Receiver {
             None => 0,
         }
     }
+
+    /// Toggle the receive-side Y-flip pass. See
+    /// `syphon_receiver_set_flip_y` for the semantics — `true` (default)
+    /// applies the fullscreen Y-flip render pipeline; `false` falls back to
+    /// a straight blit that preserves the upstream Syphon orientation.
+    pub fn set_flip_y(&self, flip: bool) {
+        if let Some(h) = self.handle {
+            unsafe { ffi::syphon_receiver_set_flip_y(h, if flip { 1 } else { 0 }) };
+        }
+    }
 }
 
 impl Drop for Receiver {

--- a/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
+++ b/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
@@ -11,6 +11,7 @@ type MockFrame = {
 const mockReceiver = {
   receiveSharedTexture: vi.fn<() => MockFrame | null>().mockReturnValue(null),
   stop: vi.fn(),
+  setFlipY: vi.fn<(flip: boolean) => void>(),
 };
 
 const mockImported = {
@@ -43,6 +44,7 @@ vi.mock("@napolab/texture-bridge-core", () => ({
   TextureReceiver: class MockTextureReceiver {
     receiveSharedTexture = mockReceiver.receiveSharedTexture;
     stop = mockReceiver.stop;
+    setFlipY = mockReceiver.setFlipY;
   },
   closeNativeHandle: (handle: Buffer) => mockCloseNativeHandle(handle),
 }));
@@ -454,6 +456,40 @@ describe("createSharedTextureReceiver", () => {
         target: makeMockTarget() as unknown as Electron.WebContents,
       }),
     ).not.toThrow();
+  });
+
+  // -- flipY plumbing -------------------------------------------------------
+  //
+  // The native receiver defaults flipY=true. Only call setFlipY when the
+  // caller passed an explicit value, so we don't override the native default
+  // on platforms (Windows) where the call is a documented no-op.
+
+  it("does not call setFlipY when flipY is undefined", () => {
+    createSharedTextureReceiver({
+      senderName: "test",
+      target: makeMockTarget() as unknown as Electron.WebContents,
+    });
+    expect(mockReceiver.setFlipY).not.toHaveBeenCalled();
+  });
+
+  it("calls setFlipY(false) when flipY: false is passed (opt-out)", () => {
+    createSharedTextureReceiver({
+      senderName: "test",
+      target: makeMockTarget() as unknown as Electron.WebContents,
+      flipY: false,
+    });
+    expect(mockReceiver.setFlipY).toHaveBeenCalledTimes(1);
+    expect(mockReceiver.setFlipY).toHaveBeenCalledWith(false);
+  });
+
+  it("calls setFlipY(true) when flipY: true is passed (explicit opt-in)", () => {
+    createSharedTextureReceiver({
+      senderName: "test",
+      target: makeMockTarget() as unknown as Electron.WebContents,
+      flipY: true,
+    });
+    expect(mockReceiver.setFlipY).toHaveBeenCalledTimes(1);
+    expect(mockReceiver.setFlipY).toHaveBeenCalledWith(true);
   });
 
   // -- _tick circuit breaker ------------------------------------------------

--- a/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
+++ b/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
@@ -492,6 +492,28 @@ describe("createSharedTextureReceiver", () => {
     expect(mockReceiver.setFlipY).toHaveBeenCalledWith(true);
   });
 
+  it("bridge.setFlipY() forwards to the underlying receiver for live toggle", () => {
+    const bridge = createSharedTextureReceiver({
+      senderName: "test",
+      target: makeMockTarget() as unknown as Electron.WebContents,
+    });
+    bridge.setFlipY(false);
+    bridge.setFlipY(true);
+    expect(mockReceiver.setFlipY).toHaveBeenCalledTimes(2);
+    expect(mockReceiver.setFlipY).toHaveBeenNthCalledWith(1, false);
+    expect(mockReceiver.setFlipY).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it("bridge.setFlipY() is a no-op after dispose", () => {
+    const bridge = createSharedTextureReceiver({
+      senderName: "test",
+      target: makeMockTarget() as unknown as Electron.WebContents,
+    });
+    bridge.dispose();
+    bridge.setFlipY(false);
+    expect(mockReceiver.setFlipY).not.toHaveBeenCalled();
+  });
+
   // -- _tick circuit breaker ------------------------------------------------
 
   it("stops and emits a final circuit-breaker error after 10 consecutive _tick errors", async () => {

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -110,6 +110,12 @@ export interface SharedTextureReceiverBridge {
   dispose(): void;
   [Symbol.dispose](): void;
   readonly isDisposed: boolean;
+  /**
+   * Live-toggle the receive-side Y-flip pass without recreating the
+   * receiver. Same semantics as the constructor `flipY` option. No-op on
+   * Windows.
+   */
+  setFlipY(flip: boolean): void;
 }
 
 class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedTextureReceiverBridge {
@@ -170,6 +176,11 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
 
   [Symbol.dispose](): void {
     this.dispose();
+  }
+
+  setFlipY(flip: boolean): void {
+    if (this._disposed) return;
+    this.receiver.setFlipY(flip);
   }
 
   /**

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -68,6 +68,21 @@ export interface SharedTextureReceiverOptions {
    * texture (via Electron's `sendSharedTexture(..., ...args)` varargs).
    */
   readonly extraArgs?: readonly unknown[];
+  /**
+   * Whether the receive path should apply a vertical flip when staging the
+   * frame for `importSharedTexture`. Defaults to `true` on macOS — matches
+   * the historical behavior shipped in the macOS receiver, suitable when
+   * the consumer expects Y-DOWN image-coord layout (`drawImage(VideoFrame)`,
+   * WebGPU `importExternalTexture`).
+   *
+   * Pass `false` when the upstream Syphon source already publishes the
+   * orientation Electron's `importSharedTexture` expects — e.g. if the
+   * sender lives in another Electron window that publishes via this same
+   * library and does not need an additional flip on receive.
+   *
+   * No-op on Windows (Spout's receive path does not have a flip stage).
+   */
+  readonly flipY?: boolean;
 }
 
 export interface SharedTextureReceiverBridgeEvents {
@@ -327,7 +342,15 @@ type SendResult = "delivered" | "failed" | "skipped";
 export function createSharedTextureReceiver(
   options: SharedTextureReceiverOptions,
 ): SharedTextureReceiverBridge {
-  const { senderName, appName, serverUuid, pollIntervalMs = 16, target, extraArgs = [] } = options;
+  const {
+    senderName,
+    appName,
+    serverUuid,
+    pollIntervalMs = 16,
+    target,
+    extraArgs = [],
+    flipY,
+  } = options;
 
   if (options.pollIntervalMs !== undefined) {
     if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
@@ -336,5 +359,8 @@ export function createSharedTextureReceiver(
   }
 
   const receiver = new TextureReceiver(senderName, appName, serverUuid);
+  if (flipY !== undefined) {
+    receiver.setFlipY(flipY);
+  }
   return new SharedTextureReceiverBridgeImpl(receiver, target, extraArgs, pollIntervalMs);
 }


### PR DESCRIPTION
## Summary

- macOS の受信側 Y-flip 描画パスを `createSharedTextureReceiver({ flipY: false })` で opt-out 可能にした
- デフォルト挙動は据え置き（macOS では Y-flip あり、`drawImage(VideoFrame)` / WebGPU `importExternalTexture` 向け）
- Windows では `setFlipY` は no-op（Spout の受信パスにフリップ段がないため）

## Why

PR #46 で macOS 受信側に Y-flip 描画パスを追加したのは「Syphon は Y-UP 規約で publish されるので、image-coord 系 API (drawImage(VideoFrame)) で受け取る側は un-flip が必要」という前提に基づいていた。

ただしこの前提は、上流の Syphon source が既に Electron の `importSharedTexture` が期待する向きで publish しているケースでは逆向きに作用し、実機 (vjaaaaan のような downstream Electron アプリ) で上下反転を引き起こす。

そういった downstream を救うために、フリップ自体は既定のまま、明示 opt-out を提供する形にした。

## Changes

| File | Change |
|---|---|
| `packages/native/cpp/mac/syphon_bridge.{h,mm}` | `flipY` フィールド + `syphon_receiver_set_flip_y` セッタを追加。`receive_shared_iosurface` を flag で Y-flip render pass / 単純 blit の 2 経路に分岐 |
| `packages/native/src/mac/{ffi,receiver}.rs` | extern 宣言と `Receiver::set_flip_y` を追加 |
| `packages/native/src/lib.rs` | napi `TextureReceiver.setFlipY(flip)` を公開（Windows は no-op stub） |
| `packages/renderer/src/shared-texture-receiver.ts` | `SharedTextureReceiverOptions.flipY?: boolean` を追加。明示指定時のみ `setFlipY` を呼ぶ |
| `packages/renderer/src/__tests__/shared-texture-receiver.test.ts` | flipY 未指定 / true / false の 3 ケースを追加 |

## API

```ts
createSharedTextureReceiver({
  senderName: "...",
  target: webContents,
  flipY: false,  // 上流 Syphon が既に期待向きで publish している downstream 用
});
```

- 未指定: 従来動作（macOS で Y-flip あり）
- `true`: 明示 opt-in
- `false`: opt-out。上流の向きをそのまま `importSharedTexture` に渡す
- Windows ではどの値でも no-op

## Test plan

- [x] `cargo test` (29/29) — 既存と同じ
- [x] `pnpm -r test` — core 9/9, renderer 115/115（flipY テスト 3 件追加）
- [x] `pnpm typecheck` — 4 packages clean
- [x] `pnpm lint` (`oxfmt --check` + `oxlint`) — clean
- [x] `pnpm build:native` / `build:core` / `build:renderer` 全成功
- [ ] vjaaaaan で `flipY: false` を渡して上下反転が解消されることを実機確認
- [ ] example app（flipY 未指定）で receiver-test 窓の表示が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)