### PR TITLE
fix(renderer): ESM __dirname shim + docs feedback (EN/JA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,39 @@
 
 A napi-rs native addon for bidirectional GPU texture sharing with Electron. **Send** textures from Electron's offscreen rendering (`useSharedTexture`) to VJ software, or **receive** textures from external Syphon/Spout servers into your Electron app. Works with Resolume Arena, VDMX, OBS, TouchDesigner, and other Syphon/Spout-compatible applications.
 
+## Install
+
+```bash
+npm i @napolab/texture-bridge-renderer
+```
+
+> **The repository name is not the npm package name.** `electron-texture-bridge` is the GitHub repo; there is **no** npm package by that name (`npm view electron-texture-bridge` → 404). The code ships as several `@napolab/*` packages:
+
+| Use case | Package | What it gives you |
+|----------|---------|-------------------|
+| **High-level (recommended)** | [`@napolab/texture-bridge-renderer`](https://www.npmjs.com/package/@napolab/texture-bridge-renderer) | `createTextureBridge()` — window + paint + sender + preview, all wired |
+| Low-level (manual paint loop) | [`@napolab/texture-bridge-core`](https://www.npmjs.com/package/@napolab/texture-bridge-core) | `TextureSender` + `sendTextureFromPaintEvent()` |
+| Native binding | [`@napolab/texture-bridge`](https://www.npmjs.com/package/@napolab/texture-bridge) | Raw napi-rs classes (`TextureSender`, `TextureReceiver`) |
+| Prebuilt binary | `@napolab/texture-bridge-darwin-arm64`, etc. | Platform `.node`, resolved automatically via `optionalDependencies` |
+
+Dependency direction: `texture-bridge-renderer` → `texture-bridge-core` → `texture-bridge` → `texture-bridge-<platform>`. Installing `-renderer` pulls in the whole chain — you normally depend on just one package.
+
+## Which API should I use?
+
+```
+Do you just want OSR (useSharedTexture) → Syphon/Spout, and let the library own the window?
+  YES → createTextureBridge()  (@napolab/texture-bridge-renderer)
+        Handles BrowserWindow, paint wiring, DPR/pixelExact, preview, FPS. Start here.
+
+Do you have your own BrowserWindow / paint loop you want to bolt sending onto?
+  YES → TextureSender + sendTextureFromPaintEvent()  (@napolab/texture-bridge-core)
+        You own DPR correctness yourself — see the Retina/DPI warning below (§ "macOS Retina / Windows DPI").
+
+Do you want to push raw RGBA without Electron at all (test / CI / sanity check)?
+  YES → new TextureSender(...).sendRgbaBuffer()  (@napolab/texture-bridge-core)
+        See "Minimal sanity check (no Electron)" below.
+```
+
 ## Architecture
 
 ### Sending (Electron → VJ Software)
@@ -198,6 +231,25 @@ app.whenReady().then(async () => {
 </script>
 ```
 
+### Capturing an external page (`rendererUrl` + `webPreferences`)
+
+`rendererUrl` is not limited to local HTML — pass any `http(s)://` URL to capture a live web page (e.g. a YouTube watch page) and forward it to Syphon/Spout. `webPreferences` is merged into the offscreen `BrowserWindow`, so you can set a `partition` (for an isolated/logged-in session), relax `autoplayPolicy`, or disable the sandbox as needed.
+
+```typescript
+const bridge = await createTextureBridge({
+  name: "WebCapture",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "https://www.youtube.com/watch?v=...",
+  preview: { enabled: true },            // open a preview window for instant eyeballing
+  webPreferences: {
+    partition: "persist:capture",        // isolated session (cookies/login persist here)
+    autoplayPolicy: "no-user-gesture-required",
+    sandbox: false,
+  },
+});
+```
+
 ### Sending with transparency (`includeAlpha`)
 
 Pass `includeAlpha: true` to forward the page's per-pixel alpha into the shared BGRA texture. VJ software (Resolume, VDMX, etc.) will then receive the layer with its transparency mask intact, so it can be composited over other layers.
@@ -287,6 +339,82 @@ win.webContents.on("paint", (event) => {
 
 win.webContents.setFrameRate(60);
 ```
+
+#### Electron version note: the `paint` event shape
+
+This library targets **Electron 40+** (the first version with `useSharedTexture` paint events). On current Electron (42+) the listener receives a single event object and the texture release method is **non-optional**:
+
+```typescript
+win.webContents.on("paint", (details) => {
+  const texture = details.texture;
+  if (texture === undefined) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release();   // Electron 42: non-optional. (Older typings exposed `release?`.)
+  }
+});
+```
+
+Older examples that destructure `(event, dirtyRect, image, texture)` are from a pre-40 API and will not type-check against current Electron. If you build against `electron@>=42` types, drop the optional chaining on `release`.
+
+> ### macOS Retina and Windows DPI scaling
+>
+> ⚠️ **This is the #1 cause of a black or garbled output.** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer actually delivered to the shared texture is `width × height × display.scaleFactor`. On a **macOS Retina** display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture — the sender's declared size and the real framebuffer disagree, and the receiver shows black/garbled output. Windows display scaling (150% / 175%) causes the same mismatch.
+>
+> - **High-level `createTextureBridge`** absorbs this for you via the **`pixelExact: true`** option (see [`TextureBridgeOptions`](#createtexturebridgeoptions-promisetexturebridge)): it sizes the BrowserWindow in DIP so the framebuffer lands on exactly `width × height`, and registers the sender at the requested pixel size.
+> - **Low-level core** (manual `BrowserWindow` + `paint`) has **no such absorption** — *you* must keep the sender's declared size and the actual framebuffer size in agreement. Either declare the sender at the true framebuffer size (`declared = logical × scaleFactor`), or neutralize DPR with `webContents.setZoomFactor` / a fixed-scale display, or move to `createTextureBridge({ pixelExact: true })`.
+
+### Minimal sanity check (no Electron)
+
+`TextureSender.sendRgbaBuffer()` does **not** require Electron — you can stand up a Syphon/Spout server from plain Node (e.g. via `tsx`) and push raw RGBA. This is the fastest way to isolate a problem: if this shows up in your VJ app, the native binding and Syphon/Spout publishing are healthy and the issue is on the Electron OSR side.
+
+```typescript
+// sanity.ts — run with: npx tsx sanity.ts
+import { TextureSender, getPlatform } from "@napolab/texture-bridge-core";
+
+const W = 512;
+const H = 512;
+const sender = new TextureSender("CHECK", W, H);
+console.log(getPlatform(), sender.platform()); // e.g. "syphon-metal" "syphon-metal"
+
+const buf = Buffer.alloc(W * H * 4);
+let t = 0;
+setInterval(() => {
+  t += 1;
+  for (let i = 0; i < W * H; i++) {
+    buf[i * 4 + 0] = (i + t) & 0xff; // R
+    buf[i * 4 + 1] = (i * 2 + t) & 0xff; // G
+    buf[i * 4 + 2] = t & 0xff; // B
+    buf[i * 4 + 3] = 0xff; // A
+  }
+  sender.sendRgbaBuffer(buf, W, H);
+}, 1000 / 30);
+```
+
+Open your VJ app (or any Syphon/Spout monitor) and look for a sender named **CHECK** animating. `sendRgbaBuffer` involves a CPU→GPU copy, so it is a debugging/fallback path — not the zero-copy production path — but it is invaluable for splitting "is it Electron or is it the bridge?".
+
+## Using with electron-vite (ESM)
+
+If your app is ESM (`"type": "module"` in `package.json`) and built with **electron-vite**, a few integration details matter:
+
+- **External-ize the native packages.** Add `externalizeDepsPlugin()` to both `main` and `preload` configs so the `.node` binary is never bundled:
+
+  ```typescript
+  // electron.vite.config.ts
+  import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+
+  export default defineConfig({
+    main: { plugins: [externalizeDepsPlugin()] },
+    preload: { plugins: [externalizeDepsPlugin()] },
+    renderer: {},
+  });
+  ```
+
+- **Preload is emitted as `.mjs` in ESM mode.** electron-vite outputs the preload as `index.mjs` (not `index.js`), so reference it accordingly from main: `path.join(import.meta.dirname, "../preload/index.mjs")`. A stale `../preload/index.js` reference produces a "preload not found" failure.
+- **`import.meta.dirname` is auto-injected** by electron-vite for ESM main, so you don't need a `__dirname` shim in your own main code.
+- **Prebuilt binaries resolve via `optionalDependencies`.** With pnpm 10 you may need to approve the native package's build in `onlyBuiltDependencies` (`pnpm.onlyBuiltDependencies` / `allowBuilds`) the first time.
+- **Preview works in ESM.** `createTextureBridge({ preview: { enabled: true } })`'s asset resolution is ESM-safe (the renderer package ships `__dirname` shims in its ESM build), so the preview window opens under `"type": "module"`.
 
 ## Receiving textures from Spout/Syphon
 
@@ -440,6 +568,7 @@ interface TextureBridgeOptions {
   preview?: PreviewOptions;
   webPreferences?: Electron.WebPreferences;
   includeAlpha?: boolean;  // Forward per-pixel alpha into the shared texture (default: false)
+  pixelExact?: boolean;    // Pin the framebuffer to exactly width×height regardless of display DPR (default: false)
 }
 
 interface PreviewOptions {
@@ -449,6 +578,8 @@ interface PreviewOptions {
   title?: string;          // Preview window title
 }
 ```
+
+**`pixelExact`** — when `true`, the offscreen framebuffer is pinned to exactly `width × height` pixels regardless of the host display's device pixel ratio. Without it, a Retina (scaleFactor 2) or Windows-scaled (150% / 175%) display produces a framebuffer larger than the declared sender size, which typically shows up as black/garbled output in the receiver (see the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling)). The sender is always registered at the requested pixel size, so receivers see the dimensions you asked for. Note: non-divisible scale ratios (e.g. `1920 / 1.75`) can leave a 1-pixel discrepancy, and only the primary display's scaleFactor at construction time is honored — call `resize()` to re-apply after a DPI change.
 
 #### `TextureBridge`
 
@@ -718,6 +849,14 @@ function listSenders(): Array<{ name: string; appName?: string; uuid?: string }>
 function getPlatform(): "spout" | "syphon-metal" | "unsupported";
 ```
 
+`getPlatform()` and the instance method `sender.platform()` / `receiver.platform()` return the same string set:
+
+| Value | Meaning |
+|-------|---------|
+| `"syphon-metal"` | macOS — Syphon Metal backend active |
+| `"spout"` | Windows — Spout backend active |
+| `"unsupported"` | Platform without a backend (no-op sends/receives) |
+
 #### Types
 
 ```typescript
@@ -786,6 +925,8 @@ pnpm --filter @napolab/texture-bridge-example run build:mac
 pnpm --filter @napolab/texture-bridge-example run build:win
 ```
 
+> **Packaging your own app.** Native `.node` addons cannot load from inside an ASAR archive, so add `asarUnpack: "node_modules/@napolab/texture-bridge*"` to your electron-builder config, and on macOS bundle + codesign `Syphon.framework` into `Frameworks/`. Copy-pasteable electron-builder / electron-forge snippets are in [docs/INSTALLATION.md → Packaging for Distribution](docs/INSTALLATION.md#packaging-for-distribution).
+
 ## Project Structure
 
 ```
@@ -844,6 +985,8 @@ electron-texture-bridge/
 
 ### Black texture output
 
+- **DPR / Retina size mismatch (most common).** On a Retina display or under Windows display scaling, the real framebuffer is `width × height × scaleFactor`, so a sender declared at the logical size disagrees with it and the receiver goes black/garbled. Use `createTextureBridge({ pixelExact: true })`, or — on the low-level core path — declare the sender at the true framebuffer size or neutralize DPR yourself. See the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling).
+- **Isolate Electron vs. the bridge** with the [no-Electron sanity check](#minimal-sanity-check-no-electron) — if `sendRgbaBuffer` shows up in your VJ app, the native side is fine and the problem is in the Electron OSR path.
 - `preserveDrawingBuffer` is not needed (Chromium compositor reads directly)
 - Check pixel format mismatch: Chromium outputs BGRA, ensure the receiver expects BGRA
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A napi-rs native addon for bidirectional GPU texture sharing with Electron. **Se
 npm i @napolab/texture-bridge-renderer
 ```
 
-> **The repository name is not the npm package name.** `electron-texture-bridge` is the GitHub repo; there is **no** npm package by that name (`npm view electron-texture-bridge` → 404). The code ships as several `@napolab/*` packages:
+The code ships as several `@napolab/*` packages:
 
 | Use case | Package | What it gives you |
 |----------|---------|-------------------|

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -9,6 +9,39 @@
 
 Electron のオフスクリーンレンダリング（`useSharedTexture`）から GPU テクスチャをキャプチャし、Resolume Arena、VDMX、OBS、TouchDesigner などの Syphon/Spout 対応アプリケーションへ CPU リードバックなしで共有する napi-rs ネイティブアドオンです。
 
+## インストール
+
+```bash
+npm i @napolab/texture-bridge-renderer
+```
+
+> **リポジトリ名は npm パッケージ名ではありません。** `electron-texture-bridge` は GitHub のリポジトリ名で、その名前の npm パッケージは**存在しません**（`npm view electron-texture-bridge` → 404）。実体は複数の `@napolab/*` パッケージとして公開されています：
+
+| 用途 | パッケージ | 提供するもの |
+|------|-----------|-------------|
+| **高レベル（推奨）** | [`@napolab/texture-bridge-renderer`](https://www.npmjs.com/package/@napolab/texture-bridge-renderer) | `createTextureBridge()` — ウィンドウ・paint・センダー・プレビューを全配線 |
+| 低レベル（手動 paint ループ） | [`@napolab/texture-bridge-core`](https://www.npmjs.com/package/@napolab/texture-bridge-core) | `TextureSender` + `sendTextureFromPaintEvent()` |
+| ネイティブバインディング | [`@napolab/texture-bridge`](https://www.npmjs.com/package/@napolab/texture-bridge) | napi-rs の生クラス（`TextureSender`, `TextureReceiver`） |
+| プリビルドバイナリ | `@napolab/texture-bridge-darwin-arm64` 他 | プラットフォーム別 `.node`。`optionalDependencies` で自動解決 |
+
+依存方向: `texture-bridge-renderer` → `texture-bridge-core` → `texture-bridge` → `texture-bridge-<platform>`。`-renderer` を入れれば連鎖がすべて入るので、通常は1パッケージに依存するだけで済みます。
+
+## どの API を使うべきか
+
+```
+OSR(useSharedTexture) を Syphon/Spout に出したいだけで、ウィンドウ管理もライブラリに任せたい？
+  YES → createTextureBridge()  (@napolab/texture-bridge-renderer)
+        BrowserWindow・paint 配線・DPR/pixelExact・プレビュー・FPS まで面倒を見る。まずここから。
+
+自前の BrowserWindow / paint ループに後付けで送信だけ足したい？
+  YES → TextureSender + sendTextureFromPaintEvent()  (@napolab/texture-bridge-core)
+        DPR の整合は自分で担保する（後述の「macOS Retina / Windows DPI」警告を参照）。
+
+Electron 無しで生 RGBA を流したい（テスト / CI / サニティチェック）？
+  YES → new TextureSender(...).sendRgbaBuffer()  (@napolab/texture-bridge-core)
+        後述の「Electron 無しの最小サニティチェック」を参照。
+```
+
 ## アーキテクチャ
 
 ```
@@ -157,6 +190,25 @@ app.whenReady().then(async () => {
 </script>
 ```
 
+### 外部ページのキャプチャ（`rendererUrl` + `webPreferences`）
+
+`rendererUrl` はローカル HTML に限りません。`http(s)://` の URL を渡せば、稼働中の Web ページ（例: YouTube の視聴ページ）をキャプチャして Syphon/Spout へ流せます。`webPreferences` はオフスクリーン `BrowserWindow` にマージされるので、`partition`（隔離済み/ログイン済みセッション）の指定、`autoplayPolicy` の緩和、サンドボックスの無効化などが可能です。
+
+```typescript
+const bridge = await createTextureBridge({
+  name: "WebCapture",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "https://www.youtube.com/watch?v=...",
+  preview: { enabled: true },            // プレビューウィンドウで即座に目視確認
+  webPreferences: {
+    partition: "persist:capture",        // 隔離セッション（Cookie/ログインがここに永続化）
+    autoplayPolicy: "no-user-gesture-required",
+    sandbox: false,
+  },
+});
+```
+
 ### 低レベル: Core API
 
 パイプラインを完全に制御する場合は `@napolab/texture-bridge-core` を直接使用します。
@@ -189,6 +241,82 @@ win.webContents.on("paint", (event) => {
 win.webContents.setFrameRate(60);
 ```
 
+#### Electron バージョン別の `paint` イベント形
+
+本ライブラリは **Electron 40+**（`useSharedTexture` paint イベントが入った最初のバージョン）を対象とします。現行 Electron（42+）ではリスナの引数は単一のイベントオブジェクトで、テクスチャの release メソッドは **非 optional** です：
+
+```typescript
+win.webContents.on("paint", (details) => {
+  const texture = details.texture;
+  if (texture === undefined) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release();   // Electron 42: 非 optional（古い型定義では `release?` だった）
+  }
+});
+```
+
+古い例にある `(event, dirtyRect, image, texture)` の分割代入は 40 以前の API で、現行 Electron の型に対しては型エラーになります。`electron@>=42` の型でビルドする場合は `release` のオプショナルチェーンを外してください。
+
+> ### macOS Retina と Windows DPI スケーリング
+>
+> ⚠️ **黒画面・崩れた出力の最大の原因です。** Chromium はオフスクリーン面を **DIP（デバイス非依存ピクセル）** でサイズ指定するため、共有テクスチャに実際に渡されるフレームバッファは `width × height × display.scaleFactor` になります。**macOS Retina**（scaleFactor 2）では `new TextureSender("X", 1280, 720)` と宣言したつもりが **2560×1440** のテクスチャを生成してしまい、センダーの宣言サイズと実フレームバッファが食い違って、レシーバー側が黒や崩れた表示になります。Windows のディスプレイスケーリング（150% / 175%）でも同じ不一致が起きます。
+>
+> - **高レベル `createTextureBridge`** は **`pixelExact: true`** オプション（[`TextureBridgeOptions`](#createtexturebridgeoptions-promisetexturebridge) 参照）でこれを吸収します。BrowserWindow を DIP でサイズ指定してフレームバッファをちょうど `width × height` に着地させ、センダーを要求ピクセルサイズで登録します。
+> - **低レベル core**（手動 `BrowserWindow` + `paint`）には**吸収機構がありません** — センダーの宣言サイズと実フレームバッファサイズの整合は*自分で*取る必要があります。センダーを実フレームバッファサイズ（`宣言 = 論理 × scaleFactor`）で宣言するか、`webContents.setZoomFactor` / 固定スケールのディスプレイで DPR を打ち消すか、`createTextureBridge({ pixelExact: true })` に移行してください。
+
+### Electron 無しの最小サニティチェック
+
+`TextureSender.sendRgbaBuffer()` は Electron を**必要としません** — plain Node（例: `tsx`）から Syphon/Spout サーバを立てて生 RGBA を流せます。問題の切り分けに最速です。これが VJ アプリに映れば、ネイティブバインディングと Syphon/Spout の発行は健全で、問題は Electron OSR 側に確定できます。
+
+```typescript
+// sanity.ts — 実行: npx tsx sanity.ts
+import { TextureSender, getPlatform } from "@napolab/texture-bridge-core";
+
+const W = 512;
+const H = 512;
+const sender = new TextureSender("CHECK", W, H);
+console.log(getPlatform(), sender.platform()); // 例: "syphon-metal" "syphon-metal"
+
+const buf = Buffer.alloc(W * H * 4);
+let t = 0;
+setInterval(() => {
+  t += 1;
+  for (let i = 0; i < W * H; i++) {
+    buf[i * 4 + 0] = (i + t) & 0xff; // R
+    buf[i * 4 + 1] = (i * 2 + t) & 0xff; // G
+    buf[i * 4 + 2] = t & 0xff; // B
+    buf[i * 4 + 3] = 0xff; // A
+  }
+  sender.sendRgbaBuffer(buf, W, H);
+}, 1000 / 30);
+```
+
+VJ アプリ（または任意の Syphon/Spout モニタ）を開き、**CHECK** という名前のセンダーがアニメーションしているか確認します。`sendRgbaBuffer` は CPU→GPU コピーを伴うのでデバッグ/フォールバック用途であり、ゼロコピーの本番経路ではありませんが、「Electron が悪いのかブリッジが悪いのか」の切り分けに非常に有効です。
+
+## electron-vite（ESM）との統合
+
+アプリが ESM（`package.json` の `"type": "module"`）で **electron-vite** ビルドの場合、いくつかの統合上の注意点があります：
+
+- **ネイティブパッケージを external 化する。** `main` と `preload` の両方に `externalizeDepsPlugin()` を入れ、`.node` バイナリが bundle されないようにします：
+
+  ```typescript
+  // electron.vite.config.ts
+  import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+
+  export default defineConfig({
+    main: { plugins: [externalizeDepsPlugin()] },
+    preload: { plugins: [externalizeDepsPlugin()] },
+    renderer: {},
+  });
+  ```
+
+- **ESM モードでは preload は `.mjs` で排出される。** electron-vite は preload を `index.mjs`（`index.js` ではない）として出力するため、main からは `path.join(import.meta.dirname, "../preload/index.mjs")` のように参照します。古い `../preload/index.js` 参照は「preload not found」系の失敗になります。
+- **`import.meta.dirname` は electron-vite が自動注入**するので、自分の main コードに `__dirname` シムは不要です。
+- **プリビルドバイナリは `optionalDependencies` で解決される。** pnpm 10 では初回にネイティブパッケージのビルドを `onlyBuiltDependencies`（`pnpm.onlyBuiltDependencies` / `allowBuilds`）で承認する必要がある場合があります。
+- **プレビューは ESM でも動作する。** `createTextureBridge({ preview: { enabled: true } })` のアセット解決は ESM セーフです（renderer パッケージは ESM ビルドに `__dirname` シムを同梱）。`"type": "module"` 下でもプレビューウィンドウが開きます。
+
 ## API リファレンス
 
 ### `@napolab/texture-bridge-renderer`
@@ -206,6 +334,7 @@ interface TextureBridgeOptions {
   rendererUrl: string;     // 読み込む URL（ファイルパス、file://、http://）
   preview?: PreviewOptions;
   webPreferences?: Electron.WebPreferences;
+  pixelExact?: boolean;    // ディスプレイ DPR に関係なくフレームバッファを正確に width×height に固定（デフォルト: false）
 }
 
 interface PreviewOptions {
@@ -215,6 +344,8 @@ interface PreviewOptions {
   title?: string;          // プレビューウィンドウタイトル
 }
 ```
+
+**`pixelExact`** — `true` のとき、ホストディスプレイの DPR に関係なくオフスクリーンフレームバッファを正確に `width × height` ピクセルに固定します。指定しないと Retina（scaleFactor 2）や Windows スケーリング（150% / 175%）のディスプレイでは宣言したセンダーサイズより大きいフレームバッファが生成され、多くの場合レシーバーで黒画面/崩れになります（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。センダーは常に要求ピクセルサイズで登録されるため、レシーバーは指定どおりの寸法を受け取ります。注意: 割り切れないスケール比（例: `1920 / 1.75`）では 1 ピクセルの誤差が残ることがあり、構築時のプライマリディスプレイの scaleFactor のみが反映されます — DPI 変更後は `resize()` で再適用してください。
 
 #### `TextureBridge`
 
@@ -298,6 +429,14 @@ class TextureSender {
 function getPlatform(): "spout" | "syphon-metal" | "unsupported";
 ```
 
+`getPlatform()` とインスタンスメソッド `sender.platform()` / `receiver.platform()` は同じ文字列集合を返します：
+
+| 値 | 意味 |
+|----|------|
+| `"syphon-metal"` | macOS — Syphon Metal バックエンド有効 |
+| `"spout"` | Windows — Spout バックエンド有効 |
+| `"unsupported"` | バックエンドのないプラットフォーム（送受信は no-op） |
+
 #### 型定義
 
 ```typescript
@@ -355,6 +494,8 @@ pnpm --filter @napolab/texture-bridge-example run build:mac
 pnpm --filter @napolab/texture-bridge-example run build:win
 ```
 
+> **自分のアプリのパッケージング。** ネイティブ `.node` アドオンは ASAR アーカイブ内からロードできないため、electron-builder 設定に `asarUnpack: "node_modules/@napolab/texture-bridge*"` を追加し、macOS では `Syphon.framework` を `Frameworks/` に同梱して codesign してください。コピペできる electron-builder / electron-forge のスニペットは [docs/ja/INSTALLATION.md](../../docs/ja/INSTALLATION.md) にあります。
+
 ## プロジェクト構成
 
 ```
@@ -411,6 +552,8 @@ electron-texture-bridge/
 
 ### テクスチャが真っ黒
 
+- **DPR / Retina のサイズ不一致（最も多い）。** Retina ディスプレイや Windows のディスプレイスケーリング下では実フレームバッファが `width × height × scaleFactor` になり、論理サイズで宣言したセンダーと食い違ってレシーバーが黒/崩れになります。`createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路ではセンダーを実フレームバッファサイズで宣言するか自分で DPR を打ち消してください（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。
+- **Electron とブリッジの切り分け**には[Electron 無しの最小サニティチェック](#electron-無しの最小サニティチェック)を使ってください — `sendRgbaBuffer` が VJ アプリに映ればネイティブ側は健全で、問題は Electron OSR 経路にあります。
 - `preserveDrawingBuffer` は不要（Chromium のコンポジターが直接読み取る）
 - ピクセルフォーマットの不一致を確認：Chromium は BGRA を出力するので、レシーバー側も BGRA を期待しているか確認
 

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -15,7 +15,7 @@ Electron のオフスクリーンレンダリング（`useSharedTexture`）か�
 npm i @napolab/texture-bridge-renderer
 ```
 
-> **リポジトリ名は npm パッケージ名ではありません。** `electron-texture-bridge` は GitHub のリポジトリ名で、その名前の npm パッケージは**存在しません**（`npm view electron-texture-bridge` → 404）。実体は複数の `@napolab/*` パッケージとして公開されています：
+実体は複数の `@napolab/*` パッケージとして公開されています：
 
 | 用途 | パッケージ | 提供するもの |
 |------|-----------|-------------|

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -25,7 +25,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/client/index.ts src/client/worker-protocol.ts --format cjs,esm --dts && cp -r src/assets dist/assets",
+    "build": "tsdown && cp -r src/assets dist/assets",
     "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -2,7 +2,11 @@ import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
 import type { PreviewOptions } from "./types";
 
-/** Resolves asset paths relative to dist/assets/ regardless of CJS/ESM */
+/**
+ * Resolves asset paths relative to dist/assets/. `__dirname` is provided
+ * natively in CJS output and injected via tsdown's `--shims` flag in ESM output
+ * (see package.json build script), so this works in both module formats.
+ */
 function assetPath(filename: string): string {
   return path.join(__dirname, "assets", filename);
 }

--- a/packages/renderer/tsdown.config.mts
+++ b/packages/renderer/tsdown.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/client/index.ts", "src/client/worker-protocol.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  // Inject `__dirname`/`__filename` shims into the ESM output. PreviewManager
+  // resolves bundled assets via `__dirname`, which is undefined in ESM scope
+  // without this. The shim is derived from `import.meta.url`.
+  shims: true,
+  // The shim helper is inlined from tsdown's own package; this is intentional,
+  // so silence the "dependency bundled" warning (which would fail CI on warn).
+  inlineOnly: false,
+});


### PR DESCRIPTION
Addresses integration feedback collected while introducing `@napolab/texture-bridge*` into a capture spike.

## Bug fix (consumer-facing)

`PreviewManager.assetPath()` referenced `__dirname`, which is undefined in ESM scope. ESM apps (`"type": "module"`) calling `createTextureBridge({ preview: { enabled: true } })` crashed with `ReferenceError: __dirname is not defined`.

- Moved tsdown config to `packages/renderer/tsdown.config.mts` and enabled `shims: true`, so the ESM build derives `__dirname` from `import.meta.url`.
- Set `inlineOnly: false` to silence the (intentional) shim-inlining warning — it would otherwise fail CI under tsdown's `failOnWarn: "ci-only"`.
- Verified: `dist/index.mjs` now contains the `fileURLToPath`-based `__dirname`; `CI=true pnpm build` succeeds; renderer 126 tests green; typecheck + lint clean.

## Docs (README.md + lang/ja/README.md)

| # | Feedback | Change |
|---|----------|--------|
| 1 | repo name ≠ npm name | Install one-liner + package relationship table |
| 2 | high vs low level | "which API should I use?" decision tree |
| 3 | pixelExact / DPR black screen | warning box + `pixelExact` in `TextureBridgeOptions` + troubleshooting entry |
| 4 | Electron version paint shape | Electron 40+/42 snippet, non-optional `release()` |
| 5 | no-Electron sanity check | `sendRgbaBuffer` tsx example |
| 6 | electron-vite (ESM) | externalize / `.mjs` preload / pnpm 10 approval; preview now works in ESM |
| 7 | external URL / webPreferences | `rendererUrl` https + `partition`/`autoplayPolicy`/`sandbox` example |
| 8 | platform strings / packaging | `getPlatform()` return table + packaging pointer |

Item 6b from the feedback (the ESM `__dirname` crash) is the bug fixed above, so the README documents preview as working under ESM rather than as a known limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)