### PR TITLE
refactor: coding-rules compliance (phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-coding-rules-refactor.md
+++ b/docs/superpowers/plans/2026-07-15-coding-rules-refactor.md
@@ -1,0 +1,780 @@
+# Coding-Rules Compliance Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring all production TypeScript in `packages/core` and `packages/renderer` into compliance with the repo coding rules (arrow functions, no `let`, no `as`/`any`, explicit primitive conversion, exhaustive `switch`) with zero behavior change.
+
+**Architecture:** Pure refactor. Each task touches a disjoint file set so tasks run in parallel in isolated git worktrees. A shared `toError()` helper (`packages/renderer/src/to-error.ts`) already exists on the base branch — tasks only consume it. Existing vitest suites are the safety net.
+
+**Tech Stack:** TypeScript, tsdown, oxlint/oxfmt, tsgo (`pnpm typecheck`), vitest.
+
+## Global Constraints
+
+- **Zero behavior change.** This is a style/type-safety refactor only. Public API names, event ordering, and error messages must not change (except where a step explicitly says otherwise — there are none).
+- Top-level functions: arrow syntax only (`const fn = (...) => {}`). `function` expressions allowed **only** where `this` binding is required (prototype patching in Task 1).
+- `let` is forbidden. Use `const`, extracted helper functions, or a `const` object with mutated properties for genuinely mutable closure/module state.
+- `as` casts forbidden in production code (`as const` is fine). Fix the model instead.
+- Non-null assertion `!` forbidden.
+- `String(x)` → `` `${x}` ``; `Number(x)` → `parseInt(x, 10)` / `parseFloat(x)`; never `Boolean(x)` / `!!`.
+- Discriminated-union branching uses `switch` with a `default` that assigns to `never` inline (no `assertNever` helper).
+- Baseline (must still hold after every task): `pnpm lint` = 0 errors (1 pre-existing warning about an empty file is OK), `pnpm typecheck` passes, core tests 9 passed, renderer tests 130 passed (126 + 4 new `to-error` tests on base).
+- After each task: `pnpm lint && pnpm typecheck` from repo root, then the package's `pnpm test`. Commit with a conventional `refactor:` message.
+- Do NOT touch `packages/example`, `packages/native`, test files (except where a step says so), or any file not listed in your task.
+- Worktrees are fresh checkouts: run `pnpm install` once before anything else.
+
+## Pre-existing shared helper (already on base branch — do not create)
+
+`packages/renderer/src/to-error.ts`:
+
+```typescript
+export const toError = (value: unknown): Error => {
+  if (value instanceof Error) return value;
+  return new Error(`${value}`);
+};
+```
+
+---
+
+### Task 1: core package — remove `as any`, `Number()`, function declaration
+
+**Files:**
+- Modify: `packages/core/src/index.ts`
+- Test (existing, unchanged): `packages/core/src/__tests__/index.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `sendTextureFromPaintEvent` keeps the exact same exported name and signature `(sender: InstanceType<typeof TextureSender>, textureInfo: TextureInfo | undefined) => void`.
+
+- [ ] **Step 1: Run baseline tests**
+
+Run: `pnpm -C packages/core test`
+Expected: 9 passed.
+
+- [ ] **Step 2: Replace the whole file body with the compliant version**
+
+The three changes: (a) prototype patch no longer needs `as any` because the `declare module` augmentation below already types `[Symbol.dispose]` — a `function` expression with an explicit `this` parameter is required here (arrow functions cannot bind `this`); (b) `Number(bigint)` → `parseInt(`${bigint}`, 10)` (NT HANDLE values fit well under 2^53, so the string round-trip is lossless); (c) `export function` → `export const` arrow.
+
+Final content of `packages/core/src/index.ts`:
+
+```typescript
+import {
+  TextureSender,
+  TextureReceiver,
+  closeNativeHandle,
+  getPlatform,
+  listSenders,
+} from "@napolab/texture-bridge";
+import type {
+  TextureInfo,
+  PaintTexture,
+  Platform,
+  PixelFormat,
+  SenderInfo,
+  ReceivedFrame,
+} from "./types";
+
+// Attach Symbol.dispose to native classes so `using` declarations work.
+// napi-rs cannot expose symbol-named methods, so we patch the prototypes here.
+// `function` expressions (not arrows) are required for the `this` binding.
+if (typeof Symbol.dispose === "symbol") {
+  TextureSender.prototype[Symbol.dispose] = function (
+    this: InstanceType<typeof TextureSender>,
+  ) {
+    this.stop();
+  };
+  TextureReceiver.prototype[Symbol.dispose] = function (
+    this: InstanceType<typeof TextureReceiver>,
+  ) {
+    this.stop();
+  };
+}
+
+// Augment native class types with Symbol.dispose (added at runtime above).
+declare module "@napolab/texture-bridge" {
+  interface TextureSender {
+    [Symbol.dispose](): void;
+  }
+  interface TextureReceiver {
+    [Symbol.dispose](): void;
+  }
+}
+
+export { TextureSender, TextureReceiver, closeNativeHandle, getPlatform, listSenders };
+export type { TextureInfo, PaintTexture, Platform, PixelFormat, SenderInfo, ReceivedFrame };
+export type { SharedTextureFrame } from "@napolab/texture-bridge";
+
+/**
+ * Send a texture from an Electron paint event to Syphon/Spout.
+ *
+ * Handles platform detection and buffer extraction automatically.
+ */
+export const sendTextureFromPaintEvent = (
+  sender: InstanceType<typeof TextureSender>,
+  textureInfo: TextureInfo | undefined,
+): void => {
+  if (!textureInfo) return;
+  const { handle, codedSize } = textureInfo;
+
+  if (process.platform === "win32") {
+    const ntHandle = handle.ntHandle;
+    if (!ntHandle || !Buffer.isBuffer(ntHandle)) return;
+    const handleValue = parseInt(`${ntHandle.readBigInt64LE(0)}`, 10);
+    sender.send(handleValue, codedSize.width, codedSize.height);
+    return;
+  }
+
+  if (process.platform === "darwin") {
+    const ioSurface = handle.ioSurface;
+    if (!ioSurface) return;
+    sender.sendSurface(ioSurface, codedSize.width, codedSize.height);
+  }
+};
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm lint && pnpm typecheck && pnpm -C packages/core test`
+Expected: lint 0 errors, typecheck passes, 9 tests passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/index.ts
+git commit -m "refactor(core): remove as-any casts, implicit Number coercion, function declaration"
+```
+
+---
+
+### Task 2: renderer main-process trio — receiver.ts, discovery.ts, bridge.ts
+
+**Files:**
+- Modify: `packages/renderer/src/receiver.ts`
+- Modify: `packages/renderer/src/discovery.ts`
+- Modify: `packages/renderer/src/bridge.ts`
+- Tests (existing, unchanged): `packages/renderer/src/__tests__/bridge.test.ts`, `packages/renderer/src/__tests__/discovery.test.ts`
+
+**Interfaces:**
+- Consumes: `toError(value: unknown): Error` from `./to-error` (already on base branch).
+- Produces: `computeDipSize`, `buildBrowserWindowOptions`, `createTextureBridge`, `createTextureReceiver` keep identical exported names and signatures (now `const` arrows).
+
+- [ ] **Step 1: Run baseline tests**
+
+Run: `pnpm -C packages/renderer test`
+Expected: 130 passed.
+
+- [ ] **Step 2: receiver.ts — toError + arrow factory**
+
+Add import at top: `import { toError } from "./to-error";`
+
+Replace both occurrences of
+
+```typescript
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit("error", error);
+```
+
+with
+
+```typescript
+      this.emit("error", toError(err));
+```
+
+Replace the factory declaration
+
+```typescript
+export function createTextureReceiver(
+  options: TextureReceiverBridgeOptions,
+): TextureReceiverBridge {
+```
+
+with
+
+```typescript
+export const createTextureReceiver = (
+  options: TextureReceiverBridgeOptions,
+): TextureReceiverBridge => {
+```
+
+(and the closing `}` of the function becomes `};`).
+
+- [ ] **Step 3: discovery.ts — toError**
+
+Add import at top: `import { toError } from "./to-error";`
+
+In `_refresh()`, replace
+
+```typescript
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit("error", error);
+    }
+```
+
+with
+
+```typescript
+    } catch (err) {
+      this.emit("error", toError(err));
+    }
+```
+
+- [ ] **Step 4: bridge.ts — toError, arrow functions, `let` removal**
+
+Add import: `import { toError } from "./to-error";`
+
+(a) In `handlePaint`, replace
+
+```typescript
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit("error", error);
+```
+
+with
+
+```typescript
+      this.emit("error", toError(err));
+```
+
+(b) Convert `export function computeDipSize(...)` and `export function buildBrowserWindowOptions(...)` and `export async function createTextureBridge(...)` to `export const ... = (...) => {...}` arrows with unchanged parameter/return types (`createTextureBridge` stays `async`, returning `Promise<TextureBridge>`).
+
+(c) In `createTextureBridge`, replace
+
+```typescript
+  let previewManager: PreviewManager | null = null;
+  if (preview?.enabled !== false && preview) {
+    previewManager = new PreviewManager(width, height, preview);
+    previewManager.open();
+  }
+```
+
+with
+
+```typescript
+  const previewManager =
+    preview && preview.enabled !== false ? new PreviewManager(width, height, preview) : null;
+  previewManager?.open();
+```
+
+(Equivalence: when `preview` is `undefined` both versions skip; when `preview.enabled === false` both skip; otherwise both construct and open.)
+
+(d) Simplify the URL-loading chain (two identical `loadURL` branches):
+
+```typescript
+  const isUrlScheme =
+    rendererUrl.startsWith("http://") ||
+    rendererUrl.startsWith("https://") ||
+    rendererUrl.startsWith("file://");
+  if (isUrlScheme) {
+    await renderWindow.loadURL(rendererUrl);
+  } else {
+    await renderWindow.loadFile(rendererUrl);
+  }
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `pnpm lint && pnpm typecheck && pnpm -C packages/renderer test`
+Expected: lint 0 errors, typecheck passes, 130 tests passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/receiver.ts packages/renderer/src/discovery.ts packages/renderer/src/bridge.ts
+git commit -m "refactor(renderer): arrow factories, shared toError, drop let in bridge"
+```
+
+---
+
+### Task 3: shared-texture-receiver.ts — `let` removal, switch exhaustiveness, cast removal
+
+**Files:**
+- Modify: `packages/renderer/src/shared-texture-receiver.ts`
+- Test (existing, unchanged): `packages/renderer/src/__tests__/shared-texture-receiver.test.ts`
+
+**Interfaces:**
+- Consumes: `toError(value: unknown): Error` from `./to-error`.
+- Produces: `createSharedTextureReceiver` keeps identical exported name and signature (now a `const` arrow).
+
+- [ ] **Step 1: Run baseline tests**
+
+Run: `pnpm -C packages/renderer test`
+Expected: 130 passed.
+
+- [ ] **Step 2: toError import + pixel-format guard without cast**
+
+Add import: `import { toError } from "./to-error";`
+
+Replace
+
+```typescript
+const isValidPixelFormat = (value: string): value is SharedTexturePixelFormat => {
+  return (VALID_PIXEL_FORMATS as readonly string[]).includes(value);
+};
+```
+
+with
+
+```typescript
+const isValidPixelFormat = (value: string): value is SharedTexturePixelFormat => {
+  return VALID_PIXEL_FORMATS.some((format) => format === value);
+};
+```
+
+- [ ] **Step 3: `_tick` — extract try/catch helpers, switch on SendResult**
+
+Replace the whole `_tick` method body with:
+
+```typescript
+  private async _tick(): Promise<void> {
+    if (this._disposed || this._inFlight) return;
+
+    const frame = this._receiveFrame();
+    if (!frame) return;
+
+    const result = await this._sendTracked(frame);
+
+    if (this._disposed) return;
+
+    switch (result) {
+      case "failed":
+        // The error itself was already emitted inside `_send()`. Still count it
+        // toward the circuit breaker so a stuck pipeline eventually stops.
+        this._countTickError();
+        return;
+      case "skipped":
+        // Not a failure (e.g. destroyed target during teardown). Don't touch the
+        // error counter and don't tick FPS.
+        return;
+      case "delivered": {
+        // Successful frame delivery — reset the consecutive-error counter.
+        this._consecutiveErrors = 0;
+        const fps = this.fpsCounter.tick();
+        if (fps !== null) this.emit("fps", fps);
+        return;
+      }
+      default: {
+        const _exhaustive: never = result;
+        throw new Error(`unhandled send result: ${JSON.stringify(_exhaustive)}`);
+      }
+    }
+  }
+```
+
+Add these two private methods directly below `_tick` (keep the existing doc comment of `_tick` in place):
+
+```typescript
+  /**
+   * Poll the native receiver once. Errors are recorded against the circuit
+   * breaker and reported via the `"error"` event; both the no-frame and the
+   * error case return `null` (the tick has nothing further to do either way).
+   */
+  private _receiveFrame(): SharedTextureFrame | null {
+    try {
+      return this.receiver.receiveSharedTexture();
+    } catch (err) {
+      this._recordTickError(toError(err));
+      return null;
+    }
+  }
+
+  /** Run `_send()` with the `_inFlight` drop-latest flag held for its duration. */
+  private async _sendTracked(frame: SharedTextureFrame): Promise<SendResult> {
+    this._inFlight = true;
+    try {
+      return await this._send(frame);
+    } finally {
+      this._inFlight = false;
+    }
+  }
+```
+
+- [ ] **Step 4: `_send` — extract import helper to remove `let imported`**
+
+In `_send`, replace
+
+```typescript
+    let imported: Electron.SharedTextureImported;
+    try {
+      imported = sharedTexture.importSharedTexture({ textureInfo });
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit("error", error);
+      // importSharedTexture threw before taking ownership — release the handle
+      // ourselves so we don't leak a per-frame NT HANDLE / IOSurface.
+      releaseUnconsumedHandle(frame.handle);
+      return "failed";
+    }
+```
+
+with
+
+```typescript
+    const imported = this._importFrame(textureInfo, frame.handle);
+    if (!imported) return "failed";
+```
+
+and add this private method below `_send`:
+
+```typescript
+  /**
+   * Import one frame into Electron. On throw, emits the error, releases the
+   * unconsumed native handle (importSharedTexture threw before taking
+   * ownership — without this we leak a per-frame NT HANDLE / IOSurface), and
+   * returns `null`.
+   */
+  private _importFrame(
+    textureInfo: Electron.SharedTextureImportTextureInfo,
+    rawHandle: Buffer,
+  ): Electron.SharedTextureImported | null {
+    try {
+      return sharedTexture.importSharedTexture({ textureInfo });
+    } catch (err) {
+      this.emit("error", toError(err));
+      releaseUnconsumedHandle(rawHandle);
+      return null;
+    }
+  }
+```
+
+Also in `_send`'s final `try/catch` (around `sendSharedTexture`), replace
+
+```typescript
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit("error", error);
+```
+
+with
+
+```typescript
+      this.emit("error", toError(err));
+```
+
+- [ ] **Step 5: factory → arrow**
+
+Replace
+
+```typescript
+export function createSharedTextureReceiver(
+  options: SharedTextureReceiverOptions,
+): SharedTextureReceiverBridge {
+```
+
+with
+
+```typescript
+export const createSharedTextureReceiver = (
+  options: SharedTextureReceiverOptions,
+): SharedTextureReceiverBridge => {
+```
+
+(closing `}` → `};`).
+
+- [ ] **Step 6: Verify**
+
+Run: `pnpm lint && pnpm typecheck && pnpm -C packages/renderer test`
+Expected: lint 0 errors, typecheck passes, 130 tests passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/renderer/src/shared-texture-receiver.ts
+git commit -m "refactor(renderer): exhaustive SendResult switch, drop let/casts in shared-texture receiver"
+```
+
+---
+
+### Task 4: preview-manager.ts — no arrow property, no `as`, no `!`, no `String()`
+
+**Files:**
+- Modify: `packages/renderer/src/preview-manager.ts`
+
+**Interfaces:**
+- Consumes: `TextureInfo` type from `@napolab/texture-bridge-core` (structurally assignable to `Electron.SharedTextureImportTextureInfo` — verified against electron@40.2.1 typings: same `pixelFormat` union, `codedSize`/`visibleRect` shapes, and optional-Buffer `handle`).
+- Produces: `PreviewManager.sendFrame(texture: { textureInfo: TextureInfo })` — callers already pass `PaintTexture`, which satisfies this.
+
+- [ ] **Step 1: Run baseline tests**
+
+Run: `pnpm -C packages/renderer test`
+Expected: 130 passed.
+
+- [ ] **Step 2: Rewrite preview-manager.ts**
+
+Changes: (a) `function assetPath` → arrow const; (b) the `onPreviewReady` arrow **property** becomes a method (`handlePreviewReady`) plus a per-open listener stored in a field, so `ipcMain.removeListener` still gets a stable reference (class methods must use method shorthand per repo rules); (c) `String(x)` → template literals; (d) `sendFrame` parameter typed with `TextureInfo` so the `as` cast disappears; (e) `updateSize` narrows `this.win` into a local instead of `this.win!`.
+
+Final content of `packages/renderer/src/preview-manager.ts`:
+
+```typescript
+import { BrowserWindow, ipcMain, sharedTexture } from "electron";
+import path from "path";
+import type { TextureInfo } from "@napolab/texture-bridge-core";
+import type { PreviewOptions } from "./types";
+
+/**
+ * Resolves asset paths relative to dist/assets/. `__dirname` is provided
+ * natively in CJS output and injected via tsdown's `--shims` flag in ESM output
+ * (see package.json build script), so this works in both module formats.
+ */
+const assetPath = (filename: string): string => {
+  return path.join(__dirname, "assets", filename);
+};
+
+export class PreviewManager {
+  private win: BrowserWindow | null = null;
+  private ready = false;
+  private width: number;
+  private height: number;
+  private title: string;
+  private previewReadyListener: ((event: Electron.IpcMainEvent) => void) | null = null;
+
+  constructor(width: number, height: number, options?: PreviewOptions) {
+    this.width = width;
+    this.height = height;
+    this.title = options?.title ?? "Preview (GPU Zero-Copy)";
+  }
+
+  get window(): BrowserWindow | null {
+    return this.win;
+  }
+
+  get isOpen(): boolean {
+    return this.win !== null && !this.win.isDestroyed();
+  }
+
+  private handlePreviewReady(event: Electron.IpcMainEvent): void {
+    if (!this.win || this.win.isDestroyed()) return;
+    if (event.sender.id !== this.win.webContents.id) return;
+    this.ready = true;
+  }
+
+  private removePreviewReadyListener(): void {
+    if (!this.previewReadyListener) return;
+    ipcMain.removeListener("preview-ready", this.previewReadyListener);
+    this.previewReadyListener = null;
+  }
+
+  open(): void {
+    if (this.isOpen) return;
+
+    this.ready = false;
+
+    this.win = new BrowserWindow({
+      width: Math.round(this.width / 2),
+      height: Math.round(this.height / 2),
+      title: this.title,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: false,
+        preload: assetPath("preview-preload.js"),
+      },
+    });
+
+    const listener = (event: Electron.IpcMainEvent): void => {
+      this.handlePreviewReady(event);
+    };
+    this.previewReadyListener = listener;
+    ipcMain.on("preview-ready", listener);
+
+    this.win.loadFile(assetPath("preview.html"), {
+      query: { w: `${this.width}`, h: `${this.height}` },
+    });
+
+    this.win.on("closed", () => {
+      this.win = null;
+      this.ready = false;
+      this.removePreviewReadyListener();
+    });
+  }
+
+  sendFrame(texture: { textureInfo: TextureInfo }): void {
+    if (!this.win || this.win.isDestroyed() || !this.ready) return;
+
+    try {
+      const imported = sharedTexture.importSharedTexture({
+        textureInfo: texture.textureInfo,
+      });
+      if (!imported) return;
+
+      sharedTexture
+        .sendSharedTexture({
+          frame: this.win.webContents.mainFrame,
+          importedSharedTexture: imported,
+        })
+        .catch(() => {});
+    } catch {
+      // Ignore preview send errors
+    }
+  }
+
+  updateSize(width: number, height: number): void {
+    this.width = width;
+    this.height = height;
+    const win = this.win;
+    if (!win || win.isDestroyed()) return;
+    win.loadFile(assetPath("preview.html"), {
+      query: { w: `${width}`, h: `${height}` },
+    });
+  }
+
+  close(): void {
+    if (!this.win || this.win.isDestroyed()) return;
+    this.win.close();
+    this.win = null;
+    this.ready = false;
+  }
+
+  dispose(): void {
+    this.removePreviewReadyListener();
+    this.close();
+  }
+}
+```
+
+Note: if `tsgo` reports that `texture.textureInfo` is not assignable to `Electron.SharedTextureImportTextureInfo`, STOP and report the exact error instead of re-adding a cast.
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm lint && pnpm typecheck && pnpm -C packages/renderer test`
+Expected: lint 0 errors, typecheck passes, 130 tests passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/renderer/src/preview-manager.ts
+git commit -m "refactor(renderer): rule-compliant PreviewManager (no arrow property, cast, non-null assertion)"
+```
+
+---
+
+### Task 5: client — shared-texture-consumer.ts, client/index.ts
+
+**Files:**
+- Modify: `packages/renderer/src/client/shared-texture-consumer.ts`
+- Modify: `packages/renderer/src/client/index.ts`
+- Tests (existing, unchanged): `packages/renderer/src/__tests__/shared-texture-consumer.test.ts`
+
+**Interfaces:**
+- Consumes: `toError(value: unknown): Error` from `../to-error` (tsdown bundles it into the client entry).
+- Produces: `installSharedTextureReceiver`, `consumeSharedTexture`, `_resetSharedTextureRegistryForTesting`, `createWorkerRenderer` keep identical exported names and signatures.
+
+- [ ] **Step 1: Run baseline tests**
+
+Run: `pnpm -C packages/renderer test`
+Expected: 130 passed.
+
+- [ ] **Step 2: shared-texture-consumer.ts — module `let` flags → const state object, toError**
+
+Add import: `import { toError } from "../to-error";`
+
+Replace
+
+```typescript
+let receiverInstalled = false;
+let notInstalledWarningShown = false;
+```
+
+with
+
+```typescript
+/** Module-level install state. Mutable via property writes (repo bans `let`). */
+const installState = {
+  receiverInstalled: false,
+  notInstalledWarningShown: false,
+};
+```
+
+Then update every reference:
+- In `installSharedTextureReceiver`: `if (installState.receiverInstalled) return;` and `installState.receiverInstalled = true;`
+- In `consumeSharedTexture`: `if (!installState.receiverInstalled && !installState.notInstalledWarningShown) { installState.notInstalledWarningShown = true; ... }`
+- In `_resetSharedTextureRegistryForTesting`: `installState.receiverInstalled = false; installState.notInstalledWarningShown = false;`
+
+Replace
+
+```typescript
+        handlers.onError?.(err instanceof Error ? err : new Error(String(err)));
+```
+
+with
+
+```typescript
+        handlers.onError?.(toError(err));
+```
+
+- [ ] **Step 3: client/index.ts — arrow factory, `let lastW/lastH` → const object**
+
+Replace
+
+```typescript
+export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRendererHandle {
+```
+
+with
+
+```typescript
+export const createWorkerRenderer = (options: WorkerRendererOptions): WorkerRendererHandle => {
+```
+
+(closing `}` → `};`).
+
+Replace
+
+```typescript
+  let lastW = width;
+  let lastH = height;
+
+  const observer = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const { width: w, height: h } = entry.contentRect;
+      const rw = Math.round(w);
+      const rh = Math.round(h);
+      if (rw === lastW && rh === lastH) continue;
+      lastW = rw;
+      lastH = rh;
+      const msg: MainToWorkerMessage = { type: "resize", width: rw, height: rh };
+      worker.postMessage(msg);
+    }
+  });
+```
+
+with
+
+```typescript
+  const lastSize = { width, height };
+
+  const observer = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const { width: w, height: h } = entry.contentRect;
+      const rw = Math.round(w);
+      const rh = Math.round(h);
+      if (rw === lastSize.width && rh === lastSize.height) continue;
+      lastSize.width = rw;
+      lastSize.height = rh;
+      const msg: MainToWorkerMessage = { type: "resize", width: rw, height: rh };
+      worker.postMessage(msg);
+    }
+  });
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `pnpm lint && pnpm typecheck && pnpm -C packages/renderer test`
+Expected: lint 0 errors, typecheck passes, 130 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/renderer/src/client/shared-texture-consumer.ts packages/renderer/src/client/index.ts
+git commit -m "refactor(renderer/client): drop module-level let, arrow factory, shared toError"
+```
+
+---
+
+## Out of Scope
+
+- `packages/example` (private demo app; worker-global `let` state is a larger redesign).
+- Test files' `as unknown as` mock casts and `let` fixtures — standard vitest mock patterns; churning them adds risk without production value.
+- `packages/native` (Rust/C++).
+
+## Integration (orchestrator)
+
+After all 5 task branches complete: merge each into `refactor/coding-rules-compliance`, run `pnpm lint && pnpm typecheck && pnpm -C packages/core test && pnpm -C packages/renderer test`, expect 9 + 130 passed, then `pnpm build` as a final smoke check.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,11 +16,14 @@ import type {
 
 // Attach Symbol.dispose to native classes so `using` declarations work.
 // napi-rs cannot expose symbol-named methods, so we patch the prototypes here.
+// `function` expressions (not arrows) are required for the `this` binding.
 if (typeof Symbol.dispose === "symbol") {
-  (TextureSender.prototype as any)[Symbol.dispose] = function () {
+  TextureSender.prototype[Symbol.dispose] = function (this: InstanceType<typeof TextureSender>) {
     this.stop();
   };
-  (TextureReceiver.prototype as any)[Symbol.dispose] = function () {
+  TextureReceiver.prototype[Symbol.dispose] = function (
+    this: InstanceType<typeof TextureReceiver>,
+  ) {
     this.stop();
   };
 }
@@ -44,17 +47,17 @@ export type { SharedTextureFrame } from "@napolab/texture-bridge";
  *
  * Handles platform detection and buffer extraction automatically.
  */
-export function sendTextureFromPaintEvent(
+export const sendTextureFromPaintEvent = (
   sender: InstanceType<typeof TextureSender>,
   textureInfo: TextureInfo | undefined,
-): void {
+): void => {
   if (!textureInfo) return;
   const { handle, codedSize } = textureInfo;
 
   if (process.platform === "win32") {
     const ntHandle = handle.ntHandle;
     if (!ntHandle || !Buffer.isBuffer(ntHandle)) return;
-    const handleValue = Number(ntHandle.readBigInt64LE(0));
+    const handleValue = parseInt(`${ntHandle.readBigInt64LE(0)}`, 10);
     sender.send(handleValue, codedSize.width, codedSize.height);
     return;
   }
@@ -64,4 +67,4 @@ export function sendTextureFromPaintEvent(
     if (!ioSurface) return;
     sender.sendSurface(ioSurface, codedSize.width, codedSize.height);
   }
-}
+};

--- a/packages/renderer/src/__tests__/to-error.test.ts
+++ b/packages/renderer/src/__tests__/to-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { toError } from "../to-error";
+
+describe("toError", () => {
+  it("returns Error instances unchanged", () => {
+    const error = new Error("boom");
+    expect(toError(error)).toBe(error);
+  });
+
+  it("returns Error subclasses unchanged", () => {
+    const error = new TypeError("bad type");
+    expect(toError(error)).toBe(error);
+  });
+
+  it("wraps a string into an Error with the string as message", () => {
+    expect(toError("boom").message).toBe("boom");
+  });
+
+  it("wraps non-string primitives via stringification", () => {
+    expect(toError(42).message).toBe("42");
+    expect(toError(undefined).message).toBe("undefined");
+    expect(toError(null).message).toBe("null");
+  });
+});

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -8,6 +8,7 @@ import {
 import { PreviewManager } from "./preview-manager";
 import { FpsCounter } from "./fps-counter";
 import type { TextureBridgeOptions, TextureBridge } from "./types";
+import { toError } from "./to-error";
 
 /**
  * Convert a pixel-space size to a device-independent (DIP) size for a given
@@ -19,11 +20,11 @@ import type { TextureBridgeOptions, TextureBridge } from "./types";
  * 1097.14 → 1097 → 1097 × 1.75 = 1919.75, which Chromium typically rounds
  * back to 1920).
  */
-export function computeDipSize(
+export const computeDipSize = (
   pixelWidth: number,
   pixelHeight: number,
   scaleFactor: number,
-): { width: number; height: number } {
+): { width: number; height: number } => {
   if (scaleFactor <= 0) {
     return { width: Math.max(1, pixelWidth), height: Math.max(1, pixelHeight) };
   }
@@ -31,7 +32,7 @@ export function computeDipSize(
     width: Math.max(1, Math.round(pixelWidth / scaleFactor)),
     height: Math.max(1, Math.round(pixelHeight / scaleFactor)),
   };
-}
+};
 
 interface PaintEvent extends Event {
   texture?: PaintTexture;
@@ -88,8 +89,7 @@ class TextureBridgeImpl extends EventEmitter implements TextureBridge {
       sendTextureFromPaintEvent(this.sender, texture.textureInfo);
       this.previewManager?.sendFrame(texture);
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     } finally {
       texture.release?.();
     }
@@ -191,9 +191,9 @@ class TextureBridgeImpl extends EventEmitter implements TextureBridge {
  * shared texture. The page itself must use a transparent background
  * (`html, body { background: transparent }`) for the alpha to mean anything.
  */
-export function buildBrowserWindowOptions(
+export const buildBrowserWindowOptions = (
   options: TextureBridgeOptions,
-): Electron.BrowserWindowConstructorOptions {
+): Electron.BrowserWindowConstructorOptions => {
   const { width, height, webPreferences, includeAlpha, pixelExact } = options;
 
   return {
@@ -217,7 +217,7 @@ export function buildBrowserWindowOptions(
     // so both keys must be applied together.
     ...(includeAlpha ? { transparent: true, backgroundColor: "#00000000" } : {}),
   };
-}
+};
 
 /**
  * Create a fully-wired texture bridge: offscreen window, native sender,
@@ -225,7 +225,9 @@ export function buildBrowserWindowOptions(
  *
  * Must be called after `app.whenReady()`.
  */
-export async function createTextureBridge(options: TextureBridgeOptions): Promise<TextureBridge> {
+export const createTextureBridge = async (
+  options: TextureBridgeOptions,
+): Promise<TextureBridge> => {
   if (!app.isReady()) {
     throw new Error("createTextureBridge() must be called after app.whenReady()");
   }
@@ -247,11 +249,9 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
   const sender = new TextureSender(name, width, height);
 
   // ---- Preview ----
-  let previewManager: PreviewManager | null = null;
-  if (preview?.enabled !== false && preview) {
-    previewManager = new PreviewManager(width, height, preview);
-    previewManager.open();
-  }
+  const previewManager =
+    preview && preview.enabled !== false ? new PreviewManager(width, height, preview) : null;
+  previewManager?.open();
 
   // ---- Bridge instance ----
   const bridge = new TextureBridgeImpl(renderWindow, sender, previewManager, options);
@@ -264,9 +264,11 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
   renderWindow.webContents.setFrameRate(frameRate);
 
   // ---- Load renderer URL ----
-  if (rendererUrl.startsWith("http://") || rendererUrl.startsWith("https://")) {
-    await renderWindow.loadURL(rendererUrl);
-  } else if (rendererUrl.startsWith("file://")) {
+  const isUrlScheme =
+    rendererUrl.startsWith("http://") ||
+    rendererUrl.startsWith("https://") ||
+    rendererUrl.startsWith("file://");
+  if (isUrlScheme) {
     await renderWindow.loadURL(rendererUrl);
   } else {
     await renderWindow.loadFile(rendererUrl);
@@ -275,4 +277,4 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
   bridge.emit("ready");
 
   return bridge;
-}
+};

--- a/packages/renderer/src/client/index.ts
+++ b/packages/renderer/src/client/index.ts
@@ -46,7 +46,7 @@ export interface WorkerRendererHandle {
  *
  * This runs in the renderer process (browser context) only.
  */
-export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRendererHandle {
+export const createWorkerRenderer = (options: WorkerRendererOptions): WorkerRendererHandle => {
   const { worker, width, height } = options;
 
   const canvas = options.canvas ?? document.createElement("canvas");
@@ -62,17 +62,16 @@ export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRend
   const initMsg: MainToWorkerMessage = { type: "init", canvas: offscreen };
   worker.postMessage(initMsg, [offscreen]);
 
-  let lastW = width;
-  let lastH = height;
+  const lastSize = { width, height };
 
   const observer = new ResizeObserver((entries) => {
     for (const entry of entries) {
       const { width: w, height: h } = entry.contentRect;
       const rw = Math.round(w);
       const rh = Math.round(h);
-      if (rw === lastW && rh === lastH) continue;
-      lastW = rw;
-      lastH = rh;
+      if (rw === lastSize.width && rh === lastSize.height) continue;
+      lastSize.width = rw;
+      lastSize.height = rh;
       const msg: MainToWorkerMessage = { type: "resize", width: rw, height: rh };
       worker.postMessage(msg);
     }
@@ -87,4 +86,4 @@ export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRend
       observer.disconnect();
     },
   };
-}
+};

--- a/packages/renderer/src/client/shared-texture-consumer.ts
+++ b/packages/renderer/src/client/shared-texture-consumer.ts
@@ -20,6 +20,7 @@
  */
 
 import { sharedTexture } from "electron";
+import { toError } from "../to-error";
 import { createMultiDispatcher } from "./multi-dispatcher";
 
 export interface SharedTextureConsumerFrame {
@@ -64,8 +65,11 @@ const dispatcher = createMultiDispatcher<DispatchArgs, Promise<void>>({
   },
 });
 
-let receiverInstalled = false;
-let notInstalledWarningShown = false;
+/** Module-level install state. Mutable via property writes (repo bans `let`). */
+const installState = {
+  receiverInstalled: false,
+  notInstalledWarningShown: false,
+};
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -83,8 +87,8 @@ let notInstalledWarningShown = false;
  * @experimental Requires Electron 40+ `sharedTexture` module.
  */
 export const installSharedTextureReceiver = (): void => {
-  if (receiverInstalled) return;
-  receiverInstalled = true;
+  if (installState.receiverInstalled) return;
+  installState.receiverInstalled = true;
   sharedTexture.setSharedTextureReceiver(async (data, ...args) => {
     const imported = data.importedSharedTexture;
     try {
@@ -135,8 +139,8 @@ export const installSharedTextureReceiver = (): void => {
 export const consumeSharedTexture = (
   handlers: SharedTextureConsumerHandlers,
 ): SharedTextureConsumerRegistration => {
-  if (!receiverInstalled && !notInstalledWarningShown) {
-    notInstalledWarningShown = true;
+  if (!installState.receiverInstalled && !installState.notInstalledWarningShown) {
+    installState.notInstalledWarningShown = true;
     console.warn(
       "[consumeSharedTexture] Called before installSharedTextureReceiver(). Frames will not be delivered until install is called at renderer startup.",
     );
@@ -151,7 +155,7 @@ export const consumeSharedTexture = (
       // A consumer whose `onError` itself throws must not crash the outer
       // try/finally (which would leak VideoFrame.close()).
       try {
-        handlers.onError?.(err instanceof Error ? err : new Error(String(err)));
+        handlers.onError?.(toError(err));
       } catch (handlerErr) {
         console.error("[consumeSharedTexture] onError handler threw:", handlerErr);
       }
@@ -180,6 +184,6 @@ export const consumeSharedTexture = (
  */
 export const _resetSharedTextureRegistryForTesting = (): void => {
   dispatcher.reset();
-  receiverInstalled = false;
-  notInstalledWarningShown = false;
+  installState.receiverInstalled = false;
+  installState.notInstalledWarningShown = false;
 };

--- a/packages/renderer/src/discovery.ts
+++ b/packages/renderer/src/discovery.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { listSenders } from "@napolab/texture-bridge-core";
 import type { SenderInfo } from "@napolab/texture-bridge-core";
+import { toError } from "./to-error";
 
 export interface SenderDiscoveryEvents {
   updated: [senders: SenderInfo[]];
@@ -68,8 +69,7 @@ export class SenderDiscovery extends EventEmitter {
         this.emit("updated", current);
       }
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     }
   }
 

--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
+import type { TextureInfo } from "@napolab/texture-bridge-core";
 import type { PreviewOptions } from "./types";
 
 /**
@@ -7,9 +8,9 @@ import type { PreviewOptions } from "./types";
  * natively in CJS output and injected via tsdown's `--shims` flag in ESM output
  * (see package.json build script), so this works in both module formats.
  */
-function assetPath(filename: string): string {
+const assetPath = (filename: string): string => {
   return path.join(__dirname, "assets", filename);
-}
+};
 
 export class PreviewManager {
   private win: BrowserWindow | null = null;
@@ -17,6 +18,7 @@ export class PreviewManager {
   private width: number;
   private height: number;
   private title: string;
+  private previewReadyListener: ((event: Electron.IpcMainEvent) => void) | null = null;
 
   constructor(width: number, height: number, options?: PreviewOptions) {
     this.width = width;
@@ -32,11 +34,17 @@ export class PreviewManager {
     return this.win !== null && !this.win.isDestroyed();
   }
 
-  private onPreviewReady = (_event: Electron.IpcMainEvent): void => {
+  private handlePreviewReady(event: Electron.IpcMainEvent): void {
     if (!this.win || this.win.isDestroyed()) return;
-    if (_event.sender.id !== this.win.webContents.id) return;
+    if (event.sender.id !== this.win.webContents.id) return;
     this.ready = true;
-  };
+  }
+
+  private removePreviewReadyListener(): void {
+    if (!this.previewReadyListener) return;
+    ipcMain.removeListener("preview-ready", this.previewReadyListener);
+    this.previewReadyListener = null;
+  }
 
   open(): void {
     if (this.isOpen) return;
@@ -55,25 +63,29 @@ export class PreviewManager {
       },
     });
 
-    ipcMain.on("preview-ready", this.onPreviewReady);
+    const listener = (event: Electron.IpcMainEvent): void => {
+      this.handlePreviewReady(event);
+    };
+    this.previewReadyListener = listener;
+    ipcMain.on("preview-ready", listener);
 
     this.win.loadFile(assetPath("preview.html"), {
-      query: { w: String(this.width), h: String(this.height) },
+      query: { w: `${this.width}`, h: `${this.height}` },
     });
 
     this.win.on("closed", () => {
       this.win = null;
       this.ready = false;
-      ipcMain.removeListener("preview-ready", this.onPreviewReady);
+      this.removePreviewReadyListener();
     });
   }
 
-  sendFrame(texture: { textureInfo: unknown }): void {
+  sendFrame(texture: { textureInfo: TextureInfo }): void {
     if (!this.win || this.win.isDestroyed() || !this.ready) return;
 
     try {
       const imported = sharedTexture.importSharedTexture({
-        textureInfo: texture.textureInfo as Electron.SharedTextureImportTextureInfo,
+        textureInfo: texture.textureInfo,
       });
       if (!imported) return;
 
@@ -91,9 +103,10 @@ export class PreviewManager {
   updateSize(width: number, height: number): void {
     this.width = width;
     this.height = height;
-    if (!this.isOpen) return;
-    this.win!.loadFile(assetPath("preview.html"), {
-      query: { w: String(width), h: String(height) },
+    const win = this.win;
+    if (!win || win.isDestroyed()) return;
+    win.loadFile(assetPath("preview.html"), {
+      query: { w: `${width}`, h: `${height}` },
     });
   }
 
@@ -105,7 +118,7 @@ export class PreviewManager {
   }
 
   dispose(): void {
-    ipcMain.removeListener("preview-ready", this.onPreviewReady);
+    this.removePreviewReadyListener();
     this.close();
   }
 }

--- a/packages/renderer/src/receiver.ts
+++ b/packages/renderer/src/receiver.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { TextureReceiver } from "@napolab/texture-bridge-core";
 import type { ReceivedFrame } from "@napolab/texture-bridge-core";
 import { FpsCounter } from "./fps-counter";
+import { toError } from "./to-error";
 
 export interface TextureReceiverBridgeOptions {
   senderName: string;
@@ -96,8 +97,7 @@ class TextureReceiverBridgeImpl extends EventEmitter implements TextureReceiverB
         this.emit("fps", fps);
       }
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     }
   }
 
@@ -109,16 +109,15 @@ class TextureReceiverBridgeImpl extends EventEmitter implements TextureReceiverB
       if (!frame) return;
       this._onFrame(frame);
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     }
   }
 }
 
-export function createTextureReceiver(
+export const createTextureReceiver = (
   options: TextureReceiverBridgeOptions,
-): TextureReceiverBridge {
+): TextureReceiverBridge => {
   const { senderName, appName, serverUuid, pollIntervalMs = 16 } = options;
   const receiver = new TextureReceiver(senderName, appName, serverUuid);
   return new TextureReceiverBridgeImpl(receiver, pollIntervalMs);
-}
+};

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -14,6 +14,7 @@ import type { WebContents } from "electron";
 import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge-core";
 import type { SharedTextureFrame } from "@napolab/texture-bridge-core";
 import { FpsCounter } from "./fps-counter";
+import { toError } from "./to-error";
 
 /**
  * Safely release a native shared-texture handle that was minted by the native
@@ -41,7 +42,7 @@ type SharedTexturePixelFormat = "bgra" | "rgba" | "rgbaf16";
 const VALID_PIXEL_FORMATS: readonly SharedTexturePixelFormat[] = ["bgra", "rgba", "rgbaf16"];
 
 const isValidPixelFormat = (value: string): value is SharedTexturePixelFormat => {
-  return (VALID_PIXEL_FORMATS as readonly string[]).includes(value);
+  return VALID_PIXEL_FORMATS.some((format) => format === value);
 };
 
 /**
@@ -221,44 +222,59 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   private async _tick(): Promise<void> {
     if (this._disposed || this._inFlight) return;
 
-    let frame: SharedTextureFrame | null;
-    try {
-      frame = this.receiver.receiveSharedTexture();
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this._recordTickError(error);
-      return;
-    }
+    const frame = this._receiveFrame();
     if (!frame) return;
 
-    this._inFlight = true;
-    let result: SendResult;
-    try {
-      result = await this._send(frame);
-    } finally {
-      this._inFlight = false;
-    }
+    const result = await this._sendTracked(frame);
 
     if (this._disposed) return;
 
-    if (result === "failed") {
-      // The error itself was already emitted inside `_send()`. Still count it
-      // toward the circuit breaker so a stuck pipeline eventually stops.
-      this._countTickError();
-      return;
+    switch (result) {
+      case "failed":
+        // The error itself was already emitted inside `_send()`. Still count it
+        // toward the circuit breaker so a stuck pipeline eventually stops.
+        this._countTickError();
+        return;
+      case "skipped":
+        // Not a failure (e.g. destroyed target during teardown). Don't touch the
+        // error counter and don't tick FPS.
+        return;
+      case "delivered": {
+        // Successful frame delivery — reset the consecutive-error counter.
+        this._consecutiveErrors = 0;
+        const fps = this.fpsCounter.tick();
+        if (fps !== null) this.emit("fps", fps);
+        return;
+      }
+      default: {
+        const _exhaustive: never = result;
+        throw new Error(`unhandled send result: ${JSON.stringify(_exhaustive)}`);
+      }
     }
+  }
 
-    if (result === "skipped") {
-      // Not a failure (e.g. destroyed target during teardown). Don't touch the
-      // error counter and don't tick FPS.
-      return;
+  /**
+   * Poll the native receiver once. Errors are recorded against the circuit
+   * breaker and reported via the `"error"` event; both the no-frame and the
+   * error case return `null` (the tick has nothing further to do either way).
+   */
+  private _receiveFrame(): SharedTextureFrame | null {
+    try {
+      return this.receiver.receiveSharedTexture();
+    } catch (err) {
+      this._recordTickError(toError(err));
+      return null;
     }
+  }
 
-    // Successful frame delivery — reset the consecutive-error counter.
-    this._consecutiveErrors = 0;
-
-    const fps = this.fpsCounter.tick();
-    if (fps !== null) this.emit("fps", fps);
+  /** Run `_send()` with the `_inFlight` drop-latest flag held for its duration. */
+  private async _sendTracked(frame: SharedTextureFrame): Promise<SendResult> {
+    this._inFlight = true;
+    try {
+      return await this._send(frame);
+    } finally {
+      this._inFlight = false;
+    }
   }
 
   private async _send(frame: SharedTextureFrame): Promise<SendResult> {
@@ -292,17 +308,8 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       pixelFormat: frame.pixelFormat,
     };
 
-    let imported: Electron.SharedTextureImported;
-    try {
-      imported = sharedTexture.importSharedTexture({ textureInfo });
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
-      // importSharedTexture threw before taking ownership — release the handle
-      // ourselves so we don't leak a per-frame NT HANDLE / IOSurface.
-      releaseUnconsumedHandle(frame.handle);
-      return "failed";
-    }
+    const imported = this._importFrame(textureInfo, frame.handle);
+    if (!imported) return "failed";
 
     const targetFrame = this.target.mainFrame;
     if (!targetFrame) {
@@ -318,11 +325,29 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       return "delivered";
     } catch (err) {
       if (this._disposed) return "skipped";
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
       return "failed";
     } finally {
       imported.release();
+    }
+  }
+
+  /**
+   * Import one frame into Electron. On throw, emits the error, releases the
+   * unconsumed native handle (importSharedTexture threw before taking
+   * ownership — without this we leak a per-frame NT HANDLE / IOSurface), and
+   * returns `null`.
+   */
+  private _importFrame(
+    textureInfo: Electron.SharedTextureImportTextureInfo,
+    rawHandle: Buffer,
+  ): Electron.SharedTextureImported | null {
+    try {
+      return sharedTexture.importSharedTexture({ textureInfo });
+    } catch (err) {
+      this.emit("error", toError(err));
+      releaseUnconsumedHandle(rawHandle);
+      return null;
     }
   }
 }
@@ -350,9 +375,9 @@ type SendResult = "delivered" | "failed" | "skipped";
  *
  * @experimental Requires Electron 40+ `sharedTexture` module.
  */
-export function createSharedTextureReceiver(
+export const createSharedTextureReceiver = (
   options: SharedTextureReceiverOptions,
-): SharedTextureReceiverBridge {
+): SharedTextureReceiverBridge => {
   const {
     senderName,
     appName,
@@ -374,4 +399,4 @@ export function createSharedTextureReceiver(
     receiver.setFlipY(flipY);
   }
   return new SharedTextureReceiverBridgeImpl(receiver, target, extraArgs, pollIntervalMs);
-}
+};

--- a/packages/renderer/src/to-error.ts
+++ b/packages/renderer/src/to-error.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalize an unknown `catch` value into an `Error` instance. Non-Error
+ * values are stringified into the message. Shared by every bridge that emits
+ * `"error"` events from a `catch` block.
+ */
+export const toError = (value: unknown): Error => {
+  if (value instanceof Error) return value;
+  return new Error(`${value}`);
+};

--- a/tasks.md
+++ b/tasks.md
@@ -5,3 +5,4 @@ Implementation plans that exist but are not yet completed.
 - [x] [Receiver API Bugfixes](/Users/napochaan/ghq/github.com/naporin0624/electron-texture-bridge/docs/superpowers/plans/2026-03-18-receiver-bugfixes.md)
 - [x] [Explicit Native Disposal](/Users/napochaan/ghq/github.com/naporin0624/electron-texture-bridge/docs/superpowers/plans/2026-03-18-explicit-native-disposal.md)
 - [x] [macOS Metal Shared-Texture Receiver](/Users/napochaan/ghq/github.com/naporin0624/electron-texture-bridge/docs/superpowers/plans/2026-04-22-mac-metal-shared-texture-receiver.md)
+- [ ] [Coding-Rules Compliance Refactor](/Users/napochaan/ghq/github.com/naporin0624/electron-texture-bridge/docs/superpowers/plans/2026-07-15-coding-rules-refactor.md)


### PR DESCRIPTION
## Summary

Phase 1 of 2 (phase 2: #56, stacked on this branch). Behavior-preserving refactor bringing `packages/core` and `packages/renderer` production sources into compliance with the repo coding rules. Public APIs and all emitted error messages are unchanged.

- Remove every `as any` / `as` cast, `Number()` / `String()` implicit coercion, `let`, non-null assertion, class arrow-property, and top-level `function` declaration
- New shared `toError()` helper (`packages/renderer/src/to-error.ts`) for catch-value normalization, with unit tests
- `SendResult` branching converted to an exhaustive `switch` with an inline `never` default; try/catch blocks extracted into single-purpose helpers (`_receiveFrame` / `_sendTracked` / `_importFrame`)
- `PreviewManager`: arrow-property listener replaced with a method + stored listener reference; `sendFrame` typed via core's `TextureInfo` (structurally assignable to `Electron.SharedTextureImportTextureInfo`) instead of an `as` cast; `this.win!` replaced with a narrowed local
- core: `Symbol.dispose` prototype patch typed via the existing module augmentation (no `as any`); NT-handle conversion via explicit `parseInt`

Plan: `docs/superpowers/plans/2026-07-15-coding-rules-refactor.md`

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm -C packages/core test` — 9 passed
- [x] `pnpm -C packages/renderer test` — 130 passed (126 existing + 4 new `toError` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)