### PR TITLE
refactor(renderer): exhaustive SendResult switch + rule-compliant PreviewManager

### DIFF
--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
+import type { TextureInfo } from "@napolab/texture-bridge-core";
 import type { PreviewOptions } from "./types";
 
 /**
@@ -7,9 +8,9 @@ import type { PreviewOptions } from "./types";
  * natively in CJS output and injected via tsdown's `--shims` flag in ESM output
  * (see package.json build script), so this works in both module formats.
  */
-function assetPath(filename: string): string {
+const assetPath = (filename: string): string => {
   return path.join(__dirname, "assets", filename);
-}
+};
 
 export class PreviewManager {
   private win: BrowserWindow | null = null;
@@ -17,6 +18,7 @@ export class PreviewManager {
   private width: number;
   private height: number;
   private title: string;
+  private previewReadyListener: ((event: Electron.IpcMainEvent) => void) | null = null;
 
   constructor(width: number, height: number, options?: PreviewOptions) {
     this.width = width;
@@ -32,11 +34,17 @@ export class PreviewManager {
     return this.win !== null && !this.win.isDestroyed();
   }
 
-  private onPreviewReady = (_event: Electron.IpcMainEvent): void => {
+  private handlePreviewReady(event: Electron.IpcMainEvent): void {
     if (!this.win || this.win.isDestroyed()) return;
-    if (_event.sender.id !== this.win.webContents.id) return;
+    if (event.sender.id !== this.win.webContents.id) return;
     this.ready = true;
-  };
+  }
+
+  private removePreviewReadyListener(): void {
+    if (!this.previewReadyListener) return;
+    ipcMain.removeListener("preview-ready", this.previewReadyListener);
+    this.previewReadyListener = null;
+  }
 
   open(): void {
     if (this.isOpen) return;
@@ -55,25 +63,29 @@ export class PreviewManager {
       },
     });
 
-    ipcMain.on("preview-ready", this.onPreviewReady);
+    const listener = (event: Electron.IpcMainEvent): void => {
+      this.handlePreviewReady(event);
+    };
+    this.previewReadyListener = listener;
+    ipcMain.on("preview-ready", listener);
 
     this.win.loadFile(assetPath("preview.html"), {
-      query: { w: String(this.width), h: String(this.height) },
+      query: { w: `${this.width}`, h: `${this.height}` },
     });
 
     this.win.on("closed", () => {
       this.win = null;
       this.ready = false;
-      ipcMain.removeListener("preview-ready", this.onPreviewReady);
+      this.removePreviewReadyListener();
     });
   }
 
-  sendFrame(texture: { textureInfo: unknown }): void {
+  sendFrame(texture: { textureInfo: TextureInfo }): void {
     if (!this.win || this.win.isDestroyed() || !this.ready) return;
 
     try {
       const imported = sharedTexture.importSharedTexture({
-        textureInfo: texture.textureInfo as Electron.SharedTextureImportTextureInfo,
+        textureInfo: texture.textureInfo,
       });
       if (!imported) return;
 
@@ -91,9 +103,10 @@ export class PreviewManager {
   updateSize(width: number, height: number): void {
     this.width = width;
     this.height = height;
-    if (!this.isOpen) return;
-    this.win!.loadFile(assetPath("preview.html"), {
-      query: { w: String(width), h: String(height) },
+    const win = this.win;
+    if (!win || win.isDestroyed()) return;
+    win.loadFile(assetPath("preview.html"), {
+      query: { w: `${width}`, h: `${height}` },
     });
   }
 
@@ -105,7 +118,7 @@ export class PreviewManager {
   }
 
   dispose(): void {
-    ipcMain.removeListener("preview-ready", this.onPreviewReady);
+    this.removePreviewReadyListener();
     this.close();
   }
 }

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -14,6 +14,7 @@ import type { WebContents } from "electron";
 import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge-core";
 import type { SharedTextureFrame } from "@napolab/texture-bridge-core";
 import { FpsCounter } from "./fps-counter";
+import { toError } from "./to-error";
 
 /**
  * Safely release a native shared-texture handle that was minted by the native
@@ -41,7 +42,7 @@ type SharedTexturePixelFormat = "bgra" | "rgba" | "rgbaf16";
 const VALID_PIXEL_FORMATS: readonly SharedTexturePixelFormat[] = ["bgra", "rgba", "rgbaf16"];
 
 const isValidPixelFormat = (value: string): value is SharedTexturePixelFormat => {
-  return (VALID_PIXEL_FORMATS as readonly string[]).includes(value);
+  return VALID_PIXEL_FORMATS.some((format) => format === value);
 };
 
 /**
@@ -221,44 +222,59 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   private async _tick(): Promise<void> {
     if (this._disposed || this._inFlight) return;
 
-    let frame: SharedTextureFrame | null;
-    try {
-      frame = this.receiver.receiveSharedTexture();
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this._recordTickError(error);
-      return;
-    }
+    const frame = this._receiveFrame();
     if (!frame) return;
 
-    this._inFlight = true;
-    let result: SendResult;
-    try {
-      result = await this._send(frame);
-    } finally {
-      this._inFlight = false;
-    }
+    const result = await this._sendTracked(frame);
 
     if (this._disposed) return;
 
-    if (result === "failed") {
-      // The error itself was already emitted inside `_send()`. Still count it
-      // toward the circuit breaker so a stuck pipeline eventually stops.
-      this._countTickError();
-      return;
+    switch (result) {
+      case "failed":
+        // The error itself was already emitted inside `_send()`. Still count it
+        // toward the circuit breaker so a stuck pipeline eventually stops.
+        this._countTickError();
+        return;
+      case "skipped":
+        // Not a failure (e.g. destroyed target during teardown). Don't touch the
+        // error counter and don't tick FPS.
+        return;
+      case "delivered": {
+        // Successful frame delivery — reset the consecutive-error counter.
+        this._consecutiveErrors = 0;
+        const fps = this.fpsCounter.tick();
+        if (fps !== null) this.emit("fps", fps);
+        return;
+      }
+      default: {
+        const _exhaustive: never = result;
+        throw new Error(`unhandled send result: ${JSON.stringify(_exhaustive)}`);
+      }
     }
+  }
 
-    if (result === "skipped") {
-      // Not a failure (e.g. destroyed target during teardown). Don't touch the
-      // error counter and don't tick FPS.
-      return;
+  /**
+   * Poll the native receiver once. Errors are recorded against the circuit
+   * breaker and reported via the `"error"` event; both the no-frame and the
+   * error case return `null` (the tick has nothing further to do either way).
+   */
+  private _receiveFrame(): SharedTextureFrame | null {
+    try {
+      return this.receiver.receiveSharedTexture();
+    } catch (err) {
+      this._recordTickError(toError(err));
+      return null;
     }
+  }
 
-    // Successful frame delivery — reset the consecutive-error counter.
-    this._consecutiveErrors = 0;
-
-    const fps = this.fpsCounter.tick();
-    if (fps !== null) this.emit("fps", fps);
+  /** Run `_send()` with the `_inFlight` drop-latest flag held for its duration. */
+  private async _sendTracked(frame: SharedTextureFrame): Promise<SendResult> {
+    this._inFlight = true;
+    try {
+      return await this._send(frame);
+    } finally {
+      this._inFlight = false;
+    }
   }
 
   private async _send(frame: SharedTextureFrame): Promise<SendResult> {
@@ -292,17 +308,8 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       pixelFormat: frame.pixelFormat,
     };
 
-    let imported: Electron.SharedTextureImported;
-    try {
-      imported = sharedTexture.importSharedTexture({ textureInfo });
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
-      // importSharedTexture threw before taking ownership — release the handle
-      // ourselves so we don't leak a per-frame NT HANDLE / IOSurface.
-      releaseUnconsumedHandle(frame.handle);
-      return "failed";
-    }
+    const imported = this._importFrame(textureInfo, frame.handle);
+    if (!imported) return "failed";
 
     const targetFrame = this.target.mainFrame;
     if (!targetFrame) {
@@ -318,11 +325,29 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       return "delivered";
     } catch (err) {
       if (this._disposed) return "skipped";
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
       return "failed";
     } finally {
       imported.release();
+    }
+  }
+
+  /**
+   * Import one frame into Electron. On throw, emits the error, releases the
+   * unconsumed native handle (importSharedTexture threw before taking
+   * ownership — without this we leak a per-frame NT HANDLE / IOSurface), and
+   * returns `null`.
+   */
+  private _importFrame(
+    textureInfo: Electron.SharedTextureImportTextureInfo,
+    rawHandle: Buffer,
+  ): Electron.SharedTextureImported | null {
+    try {
+      return sharedTexture.importSharedTexture({ textureInfo });
+    } catch (err) {
+      this.emit("error", toError(err));
+      releaseUnconsumedHandle(rawHandle);
+      return null;
     }
   }
 }
@@ -350,9 +375,9 @@ type SendResult = "delivered" | "failed" | "skipped";
  *
  * @experimental Requires Electron 40+ `sharedTexture` module.
  */
-export function createSharedTextureReceiver(
+export const createSharedTextureReceiver = (
   options: SharedTextureReceiverOptions,
-): SharedTextureReceiverBridge {
+): SharedTextureReceiverBridge => {
   const {
     senderName,
     appName,
@@ -374,4 +399,4 @@ export function createSharedTextureReceiver(
     receiver.setFlipY(flipY);
   }
   return new SharedTextureReceiverBridgeImpl(receiver, target, extraArgs, pollIntervalMs);
-}
+};


### PR DESCRIPTION
Stacked on the toError base PR.

- `shared-texture-receiver.ts`: `let` removal via `_receiveFrame` / `_sendTracked` / `_importFrame` helpers; `SendResult` branching as exhaustive `switch` with inline `never` default; cast-free `isValidPixelFormat`
- `preview-manager.ts`: arrow-property listener → method + stored reference; `sendFrame` typed via core's `TextureInfo` (structurally assignable to `Electron.SharedTextureImportTextureInfo`, no `as`); `this.win!` → narrowed local; `String()` → template literals

Verified: lint 0 errors / typecheck pass / renderer 130 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)