### PR TITLE
refactor(renderer/client): module-level let flags + arrow factory

### DIFF
--- a/packages/renderer/src/client/index.ts
+++ b/packages/renderer/src/client/index.ts
@@ -46,7 +46,7 @@ export interface WorkerRendererHandle {
  *
  * This runs in the renderer process (browser context) only.
  */
-export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRendererHandle {
+export const createWorkerRenderer = (options: WorkerRendererOptions): WorkerRendererHandle => {
   const { worker, width, height } = options;
 
   const canvas = options.canvas ?? document.createElement("canvas");
@@ -62,17 +62,16 @@ export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRend
   const initMsg: MainToWorkerMessage = { type: "init", canvas: offscreen };
   worker.postMessage(initMsg, [offscreen]);
 
-  let lastW = width;
-  let lastH = height;
+  const lastSize = { width, height };
 
   const observer = new ResizeObserver((entries) => {
     for (const entry of entries) {
       const { width: w, height: h } = entry.contentRect;
       const rw = Math.round(w);
       const rh = Math.round(h);
-      if (rw === lastW && rh === lastH) continue;
-      lastW = rw;
-      lastH = rh;
+      if (rw === lastSize.width && rh === lastSize.height) continue;
+      lastSize.width = rw;
+      lastSize.height = rh;
       const msg: MainToWorkerMessage = { type: "resize", width: rw, height: rh };
       worker.postMessage(msg);
     }
@@ -87,4 +86,4 @@ export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRend
       observer.disconnect();
     },
   };
-}
+};

--- a/packages/renderer/src/client/shared-texture-consumer.ts
+++ b/packages/renderer/src/client/shared-texture-consumer.ts
@@ -20,6 +20,7 @@
  */
 
 import { sharedTexture } from "electron";
+import { toError } from "../to-error";
 import { createMultiDispatcher } from "./multi-dispatcher";
 
 export interface SharedTextureConsumerFrame {
@@ -64,8 +65,11 @@ const dispatcher = createMultiDispatcher<DispatchArgs, Promise<void>>({
   },
 });
 
-let receiverInstalled = false;
-let notInstalledWarningShown = false;
+/** Module-level install state. Mutable via property writes (repo bans `let`). */
+const installState = {
+  receiverInstalled: false,
+  notInstalledWarningShown: false,
+};
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -83,8 +87,8 @@ let notInstalledWarningShown = false;
  * @experimental Requires Electron 40+ `sharedTexture` module.
  */
 export const installSharedTextureReceiver = (): void => {
-  if (receiverInstalled) return;
-  receiverInstalled = true;
+  if (installState.receiverInstalled) return;
+  installState.receiverInstalled = true;
   sharedTexture.setSharedTextureReceiver(async (data, ...args) => {
     const imported = data.importedSharedTexture;
     try {
@@ -135,8 +139,8 @@ export const installSharedTextureReceiver = (): void => {
 export const consumeSharedTexture = (
   handlers: SharedTextureConsumerHandlers,
 ): SharedTextureConsumerRegistration => {
-  if (!receiverInstalled && !notInstalledWarningShown) {
-    notInstalledWarningShown = true;
+  if (!installState.receiverInstalled && !installState.notInstalledWarningShown) {
+    installState.notInstalledWarningShown = true;
     console.warn(
       "[consumeSharedTexture] Called before installSharedTextureReceiver(). Frames will not be delivered until install is called at renderer startup.",
     );
@@ -151,7 +155,7 @@ export const consumeSharedTexture = (
       // A consumer whose `onError` itself throws must not crash the outer
       // try/finally (which would leak VideoFrame.close()).
       try {
-        handlers.onError?.(err instanceof Error ? err : new Error(String(err)));
+        handlers.onError?.(toError(err));
       } catch (handlerErr) {
         console.error("[consumeSharedTexture] onError handler threw:", handlerErr);
       }
@@ -180,6 +184,6 @@ export const consumeSharedTexture = (
  */
 export const _resetSharedTextureRegistryForTesting = (): void => {
   dispatcher.reset();
-  receiverInstalled = false;
-  notInstalledWarningShown = false;
+  installState.receiverInstalled = false;
+  installState.notInstalledWarningShown = false;
 };

--- a/packages/renderer/src/client/shared-texture-consumer.ts
+++ b/packages/renderer/src/client/shared-texture-consumer.ts
@@ -65,11 +65,8 @@ const dispatcher = createMultiDispatcher<DispatchArgs, Promise<void>>({
   },
 });
 
-/** Module-level install state. Mutable via property writes (repo bans `let`). */
-const installState = {
-  receiverInstalled: false,
-  notInstalledWarningShown: false,
-};
+let receiverInstalled = false;
+let notInstalledWarningShown = false;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -87,8 +84,8 @@ const installState = {
  * @experimental Requires Electron 40+ `sharedTexture` module.
  */
 export const installSharedTextureReceiver = (): void => {
-  if (installState.receiverInstalled) return;
-  installState.receiverInstalled = true;
+  if (receiverInstalled) return;
+  receiverInstalled = true;
   sharedTexture.setSharedTextureReceiver(async (data, ...args) => {
     const imported = data.importedSharedTexture;
     try {
@@ -139,8 +136,8 @@ export const installSharedTextureReceiver = (): void => {
 export const consumeSharedTexture = (
   handlers: SharedTextureConsumerHandlers,
 ): SharedTextureConsumerRegistration => {
-  if (!installState.receiverInstalled && !installState.notInstalledWarningShown) {
-    installState.notInstalledWarningShown = true;
+  if (!receiverInstalled && !notInstalledWarningShown) {
+    notInstalledWarningShown = true;
     console.warn(
       "[consumeSharedTexture] Called before installSharedTextureReceiver(). Frames will not be delivered until install is called at renderer startup.",
     );
@@ -184,6 +181,6 @@ export const consumeSharedTexture = (
  */
 export const _resetSharedTextureRegistryForTesting = (): void => {
   dispatcher.reset();
-  installState.receiverInstalled = false;
-  installState.notInstalledWarningShown = false;
+  receiverInstalled = false;
+  notInstalledWarningShown = false;
 };


### PR DESCRIPTION
Stacked on the toError base PR (parallel to the receiver/preview PR — disjoint files).

- `client/shared-texture-consumer.ts`: `toError` adoption; module install flags stay plain `let` per review feedback
- `client/index.ts`: `createWorkerRenderer` arrow const; ResizeObserver `lastSize` state object

Verified: lint 0 errors / typecheck pass / renderer 130 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)