### PR TITLE
refactor(example): coding-rules compliance for the demo app

### DIFF
--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -65,13 +65,12 @@ const bootstrap = async (): Promise<void> => {
   // `VideoFrame` and draws it via `drawImage`, which hits the GPU path
   // without any CPU readback or IPC pixel copy.
   type SharedTextureReceiver = ReturnType<typeof createSharedTextureReceiver>;
-  /** Single mutable slot for the currently connected receiver (repo bans `let`). */
-  const receiverSlot = { active: null as SharedTextureReceiver | null };
+  let activeReceiver: SharedTextureReceiver | null = null;
 
   const stopActiveReceiver = (): void => {
-    if (!receiverSlot.active) return;
-    receiverSlot.active.dispose();
-    receiverSlot.active = null;
+    if (!activeReceiver) return;
+    activeReceiver.dispose();
+    activeReceiver = null;
   };
 
   // Receiver window needs `nodeIntegration: true` + `contextIsolation: false`
@@ -129,17 +128,17 @@ const bootstrap = async (): Promise<void> => {
       console.error("[receiver-test] bridge error:", err.message);
     });
     receiver.start();
-    receiverSlot.active = receiver;
+    activeReceiver = receiver;
   });
 
   ipcMain.handle("set-flip-y", (_event, flipY: boolean) => {
-    if (!receiverSlot.active) return;
-    receiverSlot.active.setFlipY(flipY);
+    if (!activeReceiver) return;
+    activeReceiver.setFlipY(flipY);
     console.log(`[receiver-test] live toggle flipY=${flipY}`);
   });
 
   ipcMain.handle("disconnect-receiver", () => {
-    if (receiverSlot.active) {
+    if (activeReceiver) {
       stopActiveReceiver();
       console.log("[receiver-test] disconnected");
     }

--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -14,14 +14,14 @@ import { listSenders } from "@napolab/texture-bridge";
 app.commandLine.appendSwitch("enable-features", "SharedArrayBuffer");
 app.commandLine.appendSwitch("force-device-scale-factor", "1");
 
-function getRendererUrl(): string {
+const getRendererUrl = (): string => {
   if (process.env.ELECTRON_RENDERER_URL) {
     return `${process.env.ELECTRON_RENDERER_URL}/index.html`;
   }
   return path.join(__dirname, "../renderer/index.html");
-}
+};
 
-app.whenReady().then(async () => {
+const bootstrap = async (): Promise<void> => {
   console.log("[example] app ready");
   console.log(`[example] Electron: ${process.versions.electron}`);
 
@@ -65,13 +65,13 @@ app.whenReady().then(async () => {
   // `VideoFrame` and draws it via `drawImage`, which hits the GPU path
   // without any CPU readback or IPC pixel copy.
   type SharedTextureReceiver = ReturnType<typeof createSharedTextureReceiver>;
-  let activeReceiver: SharedTextureReceiver | null = null;
+  /** Single mutable slot for the currently connected receiver (repo bans `let`). */
+  const receiverSlot = { active: null as SharedTextureReceiver | null };
 
-  const stopActiveReceiver = () => {
-    if (activeReceiver) {
-      activeReceiver.dispose();
-      activeReceiver = null;
-    }
+  const stopActiveReceiver = (): void => {
+    if (!receiverSlot.active) return;
+    receiverSlot.active.dispose();
+    receiverSlot.active = null;
   };
 
   // Receiver window needs `nodeIntegration: true` + `contextIsolation: false`
@@ -114,31 +114,32 @@ app.whenReady().then(async () => {
     stopActiveReceiver();
     console.log(`[receiver-test] connecting to "${senderName}" (zero-copy, flipY=${flipY})`);
 
-    activeReceiver = createSharedTextureReceiver({
+    const receiver = createSharedTextureReceiver({
       senderName,
       target: receiverWindow.webContents,
       pollIntervalMs: 8,
       flipY,
     });
-    activeReceiver.on("fps", (fps) => {
+    receiver.on("fps", (fps) => {
       if (!receiverWindow.isDestroyed()) {
         receiverWindow.webContents.send("receiver-fps", fps);
       }
     });
-    activeReceiver.on("error", (err) => {
+    receiver.on("error", (err) => {
       console.error("[receiver-test] bridge error:", err.message);
     });
-    activeReceiver.start();
+    receiver.start();
+    receiverSlot.active = receiver;
   });
 
   ipcMain.handle("set-flip-y", (_event, flipY: boolean) => {
-    if (!activeReceiver) return;
-    activeReceiver.setFlipY(flipY);
+    if (!receiverSlot.active) return;
+    receiverSlot.active.setFlipY(flipY);
     console.log(`[receiver-test] live toggle flipY=${flipY}`);
   });
 
   ipcMain.handle("disconnect-receiver", () => {
-    if (activeReceiver) {
+    if (receiverSlot.active) {
       stopActiveReceiver();
       console.log("[receiver-test] disconnected");
     }
@@ -151,7 +152,9 @@ app.whenReady().then(async () => {
     ipcMain.removeHandler("set-flip-y");
     ipcMain.removeHandler("disconnect-receiver");
   });
-});
+};
+
+void app.whenReady().then(bootstrap);
 
 app.on("window-all-closed", () => {
   app.quit();

--- a/packages/example/src/preload/receiver.ts
+++ b/packages/example/src/preload/receiver.ts
@@ -37,9 +37,11 @@ const state = {
   mainFps: 0,
 };
 
-let ui: ReceiverUI | null = null;
+/** Mutable slot filled on DOMContentLoaded (repo bans `let`). */
+const uiSlot = { current: null as ReceiverUI | null };
 
 const formatInfo = () => {
+  const ui = uiSlot.current;
   if (!ui) return;
   ui.info.textContent =
     `${ui.canvas.width}x${ui.canvas.height} | render ${state.renderFps.toFixed(1)} fps | ` +
@@ -54,6 +56,7 @@ const formatInfo = () => {
 // vsync of latency without reducing GPU work.
 consumeSharedTexture({
   onFrame: ({ videoFrame }) => {
+    const ui = uiSlot.current;
     if (!ui) return;
     if (
       ui.canvas.width !== videoFrame.displayWidth ||
@@ -87,6 +90,7 @@ ipcRenderer.on("receiver-fps", (_event, fps: number) => {
 });
 
 const refreshSenders = async (): Promise<void> => {
+  const ui = uiSlot.current;
   if (!ui) return;
   const senders: SenderEntry[] = await ipcRenderer.invoke("list-senders");
   ui.senderList.innerHTML = '<option value="">-- Select Sender --</option>';
@@ -99,15 +103,20 @@ const refreshSenders = async (): Promise<void> => {
   }
 };
 
+const getElement = <T extends HTMLElement>(id: string, ctor: new () => T): T | null => {
+  const element = document.getElementById(id);
+  return element instanceof ctor ? element : null;
+};
+
 window.addEventListener("DOMContentLoaded", () => {
-  const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
+  const canvas = getElement("canvas", HTMLCanvasElement);
   const ctx = canvas?.getContext("2d");
-  const info = document.getElementById("info") as HTMLDivElement | null;
-  const senderList = document.getElementById("senderList") as HTMLSelectElement | null;
-  const refreshBtn = document.getElementById("refreshBtn") as HTMLButtonElement | null;
-  const connectBtn = document.getElementById("connectBtn") as HTMLButtonElement | null;
-  const disconnectBtn = document.getElementById("disconnectBtn") as HTMLButtonElement | null;
-  const flipYCheckbox = document.getElementById("flipYCheckbox") as HTMLInputElement | null;
+  const info = getElement("info", HTMLDivElement);
+  const senderList = getElement("senderList", HTMLSelectElement);
+  const refreshBtn = getElement("refreshBtn", HTMLButtonElement);
+  const connectBtn = getElement("connectBtn", HTMLButtonElement);
+  const disconnectBtn = getElement("disconnectBtn", HTMLButtonElement);
+  const flipYCheckbox = getElement("flipYCheckbox", HTMLInputElement);
 
   if (
     !canvas ||
@@ -123,7 +132,16 @@ window.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  ui = { canvas, ctx, info, senderList, refreshBtn, connectBtn, disconnectBtn, flipYCheckbox };
+  uiSlot.current = {
+    canvas,
+    ctx,
+    info,
+    senderList,
+    refreshBtn,
+    connectBtn,
+    disconnectBtn,
+    flipYCheckbox,
+  };
   state.lastFpsTime = performance.now();
 
   senderList.addEventListener("change", () => {
@@ -155,7 +173,7 @@ window.addEventListener("DOMContentLoaded", () => {
       senderList.disabled = true;
       formatInfo();
     } catch (err) {
-      info.textContent = `Error: ${(err as Error).message}`;
+      info.textContent = `Error: ${err instanceof Error ? err.message : `${err}`}`;
     }
   });
 

--- a/packages/example/src/preload/receiver.ts
+++ b/packages/example/src/preload/receiver.ts
@@ -37,11 +37,9 @@ const state = {
   mainFps: 0,
 };
 
-/** Mutable slot filled on DOMContentLoaded (repo bans `let`). */
-const uiSlot = { current: null as ReceiverUI | null };
+let ui: ReceiverUI | null = null;
 
 const formatInfo = () => {
-  const ui = uiSlot.current;
   if (!ui) return;
   ui.info.textContent =
     `${ui.canvas.width}x${ui.canvas.height} | render ${state.renderFps.toFixed(1)} fps | ` +
@@ -56,7 +54,6 @@ const formatInfo = () => {
 // vsync of latency without reducing GPU work.
 consumeSharedTexture({
   onFrame: ({ videoFrame }) => {
-    const ui = uiSlot.current;
     if (!ui) return;
     if (
       ui.canvas.width !== videoFrame.displayWidth ||
@@ -90,7 +87,6 @@ ipcRenderer.on("receiver-fps", (_event, fps: number) => {
 });
 
 const refreshSenders = async (): Promise<void> => {
-  const ui = uiSlot.current;
   if (!ui) return;
   const senders: SenderEntry[] = await ipcRenderer.invoke("list-senders");
   ui.senderList.innerHTML = '<option value="">-- Select Sender --</option>';
@@ -132,7 +128,7 @@ window.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  uiSlot.current = {
+  ui = {
     canvas,
     ctx,
     info,

--- a/packages/example/src/renderer/render-worker.ts
+++ b/packages/example/src/renderer/render-worker.ts
@@ -17,12 +17,20 @@ declare const self: DedicatedWorkerGlobalScope;
 // Worker State
 // ============================================================================
 
-let renderer: THREE.WebGLRenderer | null = null;
-let scene: THREE.Scene | null = null;
-let camera: THREE.OrthographicCamera | null = null;
-let material: THREE.ShaderMaterial | null = null;
-let startTime: number = 0;
-let canvasSize = { width: 1920, height: 1080 };
+/** Everything `init()` creates — present together or not at all. */
+interface RenderContext {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.OrthographicCamera;
+  material: THREE.ShaderMaterial;
+}
+
+/** Module-level mutable state; property writes only (repo bans `let`). */
+const worker = {
+  context: null as RenderContext | null,
+  startTime: 0,
+  canvasSize: { width: 1920, height: 1080 },
+};
 
 const audioData = {
   bass: 0,
@@ -32,46 +40,47 @@ const audioData = {
 };
 
 // ============================================================================
-// Message Handler
+// Rendering
 // ============================================================================
 
-self.onmessage = (e: MessageEvent) => {
-  const { type, ...data } = e.data;
-
-  switch (type) {
-    case "init":
-      init(data.canvas as OffscreenCanvas);
-      break;
-
-    case "resize":
-      resize(data.width, data.height);
-      break;
-
-    case "audio":
-      audioData.bass = lerp(audioData.bass, data.bass ?? audioData.bass, 0.3);
-      audioData.mid = lerp(audioData.mid, data.mid ?? audioData.mid, 0.3);
-      audioData.high = lerp(audioData.high, data.high ?? audioData.high, 0.3);
-      break;
-
-    case "beat":
-      audioData.beat = 1.0;
-      break;
-  }
+const lerp = (a: number, b: number, t: number): number => {
+  return a + (b - a) * t;
 };
 
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
+const animate = (): void => {
+  requestAnimationFrame(animate);
 
-// ============================================================================
-// Three.js Initialization
-// ============================================================================
+  const context = worker.context;
+  if (!context) return;
 
-function init(canvas: OffscreenCanvas) {
-  canvasSize = { width: canvas.width, height: canvas.height };
-  startTime = performance.now();
+  const elapsed = (performance.now() - worker.startTime) / 1000;
+  context.material.uniforms.u_time.value = elapsed;
+  context.material.uniforms.u_bass.value = audioData.bass;
+  context.material.uniforms.u_mid.value = audioData.mid;
+  context.material.uniforms.u_high.value = audioData.high;
+  context.material.uniforms.u_beat.value = audioData.beat;
 
-  renderer = new THREE.WebGLRenderer({
+  audioData.beat *= 0.92;
+
+  context.renderer.render(context.scene, context.camera);
+};
+
+const resize = (width: number, height: number): void => {
+  const context = worker.context;
+  if (!context) return;
+
+  worker.canvasSize = { width, height };
+  context.renderer.setSize(width, height, false);
+  context.material.uniforms.u_resolution.value.set(width, height);
+
+  console.log(`[render-worker] Resized to ${width}x${height}`);
+};
+
+const init = (canvas: OffscreenCanvas): void => {
+  worker.canvasSize = { width: canvas.width, height: canvas.height };
+  worker.startTime = performance.now();
+
+  const renderer = new THREE.WebGLRenderer({
     canvas: canvas as unknown as HTMLCanvasElement,
     antialias: true,
     // alpha:true + clearAlpha:0 lets the fragment shader's gl_FragColor.a
@@ -84,21 +93,21 @@ function init(canvas: OffscreenCanvas) {
   });
 
   // updateStyle: false is required for OffscreenCanvas (no style property)
-  renderer.setSize(canvasSize.width, canvasSize.height, false);
+  renderer.setSize(worker.canvasSize.width, worker.canvasSize.height, false);
   renderer.setPixelRatio(1);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.setClearColor(0x000000, 0);
 
-  scene = new THREE.Scene();
-  camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
-  material = new THREE.ShaderMaterial({
+  const material = new THREE.ShaderMaterial({
     vertexShader,
     fragmentShader,
     uniforms: {
       u_time: { value: 0.0 },
       u_resolution: {
-        value: new THREE.Vector2(canvasSize.width, canvasSize.height),
+        value: new THREE.Vector2(worker.canvasSize.width, worker.canvasSize.height),
       },
       u_bass: { value: 0.0 },
       u_mid: { value: 0.0 },
@@ -113,38 +122,48 @@ function init(canvas: OffscreenCanvas) {
   const mesh = new THREE.Mesh(geometry, material);
   scene.add(mesh);
 
+  worker.context = { renderer, scene, camera, material };
+
   animate();
 
   console.log("[render-worker] Three.js initialized with raymarching shader");
-}
-
-function resize(width: number, height: number) {
-  if (!renderer || !material) return;
-
-  canvasSize = { width, height };
-  renderer.setSize(width, height, false);
-  material.uniforms.u_resolution.value.set(width, height);
-
-  console.log(`[render-worker] Resized to ${width}x${height}`);
-}
+};
 
 // ============================================================================
-// Animation Loop
+// Message Handler
 // ============================================================================
 
-function animate() {
-  requestAnimationFrame(animate);
+type WorkerEvent =
+  | { type: "init"; canvas: OffscreenCanvas }
+  | { type: "resize"; width: number; height: number }
+  | { type: "audio"; bass?: number; mid?: number; high?: number }
+  | { type: "beat" };
 
-  if (!renderer || !scene || !camera || !material) return;
+self.onmessage = (e: MessageEvent<WorkerEvent>) => {
+  const msg = e.data;
 
-  const elapsed = (performance.now() - startTime) / 1000;
-  material.uniforms.u_time.value = elapsed;
-  material.uniforms.u_bass.value = audioData.bass;
-  material.uniforms.u_mid.value = audioData.mid;
-  material.uniforms.u_high.value = audioData.high;
-  material.uniforms.u_beat.value = audioData.beat;
+  switch (msg.type) {
+    case "init":
+      init(msg.canvas);
+      break;
 
-  audioData.beat *= 0.92;
+    case "resize":
+      resize(msg.width, msg.height);
+      break;
 
-  renderer.render(scene, camera);
-}
+    case "audio":
+      audioData.bass = lerp(audioData.bass, msg.bass ?? audioData.bass, 0.3);
+      audioData.mid = lerp(audioData.mid, msg.mid ?? audioData.mid, 0.3);
+      audioData.high = lerp(audioData.high, msg.high ?? audioData.high, 0.3);
+      break;
+
+    case "beat":
+      audioData.beat = 1.0;
+      break;
+
+    default: {
+      const _exhaustive: never = msg;
+      throw new Error(`unhandled worker message: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+};


### PR DESCRIPTION
Standalone (no dependencies — only touches `packages/example`).

- `render-worker.ts`: nullable `let` globals modeled as a present-together `RenderContext`; message dispatch typed and exhaustive with inline `never` default; arrow functions
- `main/index.ts`: named `bootstrap`, arrow `getRendererUrl`, plain `let activeReceiver` (per review)
- `preload/receiver.ts`: DOM `as` casts → `instanceof`-checking `getElement` helper; `(err as Error)` → `instanceof` guard; plain `let ui` (per review)

Verified: lint 0 errors / typecheck pass (example has no test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)