### PR TITLE
refactor(core): fold native send throw through fromThrowable + match (TextureSendError)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@napolab/texture-bridge": "workspace:*"
+    "@napolab/texture-bridge": "workspace:*",
+    "neverthrow": "^8.2.0"
   },
   "peerDependencies": {
     "electron": ">=40.0.0"

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -158,106 +158,35 @@ describe("sendTextureFromPaintEvent", () => {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
   });
-});
-
-describe("sendTextureFromPaintEventResult", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockSend.mockReset();
-    mockSendSurface.mockReset();
-    mockStop.mockReset();
-  });
-
-  const makeTextureInfo = () => ({
-    pixelFormat: "bgra" as const,
-    codedSize: { width: 1920, height: 1080 },
-    visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
-    handle: { ioSurface: Buffer.alloc(8) },
-  });
-
-  it("returns ok and calls sendSurface on darwin", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: "darwin" });
-
-    try {
-      const { sendTextureFromPaintEventResult, TextureSender } = await import("../index");
-      const sender = new TextureSender("Test", 1920, 1080);
-      const textureInfo = makeTextureInfo();
-
-      const result = sendTextureFromPaintEventResult(sender, textureInfo);
-
-      expect(result.isOk()).toBe(true);
-      expect(mockSendSurface).toHaveBeenCalledWith(textureInfo.handle.ioSurface, 1920, 1080);
-    } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
-    }
-  });
-
-  it("returns ok as a no-op when textureInfo is undefined", async () => {
-    const { sendTextureFromPaintEventResult, TextureSender } = await import("../index");
-    const sender = new TextureSender("Test", 1920, 1080);
-
-    const result = sendTextureFromPaintEventResult(sender, undefined);
-
-    expect(result.isOk()).toBe(true);
-    expect(mockSend).not.toHaveBeenCalled();
-    expect(mockSendSurface).not.toHaveBeenCalled();
-  });
-
-  it("returns err(TextureSendError) when the native send throws", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: "darwin" });
-
-    try {
-      const { sendTextureFromPaintEventResult, TextureSendError, TextureSender } =
-        await import("../index");
-      const sender = new TextureSender("Test", 1920, 1080);
-
-      const nativeError = new Error("TextureSender has been stopped");
-      mockSendSurface.mockImplementation(() => {
-        throw nativeError;
-      });
-
-      const result = sendTextureFromPaintEventResult(sender, makeTextureInfo());
-
-      expect(result.isErr()).toBe(true);
-      result.match(
-        () => expect.unreachable("expected err"),
-        (error) => {
-          expect(error).toBeInstanceOf(TextureSendError);
-          expect(error.message).toBe("TextureSender has been stopped");
-          expect(error.cause).toBe(nativeError);
-        },
-      );
-    } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
-    }
-  });
 
   it("wraps non-Error thrown values with stringified message and cause", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
 
     try {
-      const { sendTextureFromPaintEventResult, TextureSendError, TextureSender } =
+      const { sendTextureFromPaintEvent, TextureSendError, TextureSender } =
         await import("../index");
       const sender = new TextureSender("Test", 1920, 1080);
 
       mockSendSurface.mockImplementation(() => {
-        // eslint-disable-next-line no-throw-literal
         throw "native boom";
       });
 
-      const result = sendTextureFromPaintEventResult(sender, makeTextureInfo());
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
 
-      result.match(
-        () => expect.unreachable("expected err"),
-        (error) => {
-          expect(error).toBeInstanceOf(TextureSendError);
-          expect(error.message).toBe("native boom");
-          expect(error.cause).toBe("native boom");
-        },
-      );
+      try {
+        sendTextureFromPaintEvent(sender, textureInfo);
+        expect.unreachable("sendTextureFromPaintEvent should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TextureSendError);
+        expect((err as Error).message).toBe("native boom");
+        expect((err as Error).cause).toBe("native boom");
+      }
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -96,6 +96,40 @@ describe("sendTextureFromPaintEvent", () => {
     expect(mockSendSurface).not.toHaveBeenCalled();
   });
 
+  it("wraps the thrown value in TextureSendError preserving message and cause", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSendError, TextureSender } =
+        await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const nativeError = new Error("TextureSender has been stopped");
+      mockSendSurface.mockImplementation(() => {
+        throw nativeError;
+      });
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
+
+      try {
+        sendTextureFromPaintEvent(sender, textureInfo);
+        expect.unreachable("sendTextureFromPaintEvent should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TextureSendError);
+        expect((err as Error).message).toBe("TextureSender has been stopped");
+        expect((err as Error).cause).toBe(nativeError);
+      }
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
   it("surfaces stopped-sender error instead of swallowing it", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
@@ -119,6 +153,110 @@ describe("sendTextureFromPaintEvent", () => {
 
       expect(() => sendTextureFromPaintEvent(sender, textureInfo)).toThrow(
         "TextureSender has been stopped",
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+});
+
+describe("sendTextureFromPaintEventResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockReset();
+    mockSendSurface.mockReset();
+    mockStop.mockReset();
+  });
+
+  const makeTextureInfo = () => ({
+    pixelFormat: "bgra" as const,
+    codedSize: { width: 1920, height: 1080 },
+    visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+    handle: { ioSurface: Buffer.alloc(8) },
+  });
+
+  it("returns ok and calls sendSurface on darwin", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEventResult, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+      const textureInfo = makeTextureInfo();
+
+      const result = sendTextureFromPaintEventResult(sender, textureInfo);
+
+      expect(result.isOk()).toBe(true);
+      expect(mockSendSurface).toHaveBeenCalledWith(textureInfo.handle.ioSurface, 1920, 1080);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns ok as a no-op when textureInfo is undefined", async () => {
+    const { sendTextureFromPaintEventResult, TextureSender } = await import("../index");
+    const sender = new TextureSender("Test", 1920, 1080);
+
+    const result = sendTextureFromPaintEventResult(sender, undefined);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockSendSurface).not.toHaveBeenCalled();
+  });
+
+  it("returns err(TextureSendError) when the native send throws", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEventResult, TextureSendError, TextureSender } =
+        await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const nativeError = new Error("TextureSender has been stopped");
+      mockSendSurface.mockImplementation(() => {
+        throw nativeError;
+      });
+
+      const result = sendTextureFromPaintEventResult(sender, makeTextureInfo());
+
+      expect(result.isErr()).toBe(true);
+      result.match(
+        () => expect.unreachable("expected err"),
+        (error) => {
+          expect(error).toBeInstanceOf(TextureSendError);
+          expect(error.message).toBe("TextureSender has been stopped");
+          expect(error.cause).toBe(nativeError);
+        },
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("wraps non-Error thrown values with stringified message and cause", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEventResult, TextureSendError, TextureSender } =
+        await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      mockSendSurface.mockImplementation(() => {
+        // eslint-disable-next-line no-throw-literal
+        throw "native boom";
+      });
+
+      const result = sendTextureFromPaintEventResult(sender, makeTextureInfo());
+
+      result.match(
+        () => expect.unreachable("expected err"),
+        (error) => {
+          expect(error).toBeInstanceOf(TextureSendError);
+          expect(error.message).toBe("native boom");
+          expect(error.cause).toBe("native boom");
+        },
       );
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Error classes for the core package's error channel (see
+ * .claude/skills/modeling-errors-as-classes). `name` is a stable wire/log
+ * discriminator; in-process discrimination uses `instanceof`.
+ */
+
+/** The native sender's `send()` / `sendSurface()` threw. */
+export class TextureSendError extends Error {
+  override name = "TextureSendError";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+import { Result, ok } from "neverthrow";
 import {
   TextureSender,
   TextureReceiver,
@@ -5,6 +6,7 @@ import {
   getPlatform,
   listSenders,
 } from "@napolab/texture-bridge";
+import { TextureSendError } from "./errors";
 import type {
   TextureInfo,
   PaintTexture,
@@ -39,19 +41,19 @@ declare module "@napolab/texture-bridge" {
 }
 
 export { TextureSender, TextureReceiver, closeNativeHandle, getPlatform, listSenders };
+export { TextureSendError } from "./errors";
 export type { TextureInfo, PaintTexture, Platform, PixelFormat, SenderInfo, ReceivedFrame };
 export type { SharedTextureFrame } from "@napolab/texture-bridge";
 
 /**
- * Send a texture from an Electron paint event to Syphon/Spout.
- *
- * Handles platform detection and buffer extraction automatically.
+ * Platform dispatch onto the native sender. `send()` / `sendSurface()` can
+ * throw (e.g. "TextureSender has been stopped") — callers go through the
+ * `Result`-returning wrapper below.
  */
-export const sendTextureFromPaintEvent = (
+const dispatchSend = (
   sender: InstanceType<typeof TextureSender>,
-  textureInfo: TextureInfo | undefined,
+  textureInfo: TextureInfo,
 ): void => {
-  if (!textureInfo) return;
   const { handle, codedSize } = textureInfo;
 
   switch (process.platform) {
@@ -69,4 +71,45 @@ export const sendTextureFromPaintEvent = (
       return;
     }
   }
+};
+
+/**
+ * Send a texture from an Electron paint event to Syphon/Spout, with the
+ * native `send()` / `sendSurface()` throw folded into a typed `Result`.
+ *
+ * Handles platform detection and buffer extraction automatically. On failure
+ * the original message is preserved and the thrown value rides on
+ * `Error.cause`. A missing `textureInfo` or handle is a no-op `ok`, matching
+ * the void variant.
+ */
+export const sendTextureFromPaintEventResult = (
+  sender: InstanceType<typeof TextureSender>,
+  textureInfo: TextureInfo | undefined,
+): Result<void, TextureSendError> => {
+  if (!textureInfo) return ok(undefined);
+  return Result.fromThrowable(
+    () => {
+      dispatchSend(sender, textureInfo);
+    },
+    (cause) => new TextureSendError(cause instanceof Error ? cause.message : `${cause}`, { cause }),
+  )();
+};
+
+/**
+ * Send a texture from an Electron paint event to Syphon/Spout.
+ *
+ * Handles platform detection and buffer extraction automatically. Throwing
+ * variant kept for backward compatibility — prefer
+ * `sendTextureFromPaintEventResult` and `.match` at your consumption edge.
+ */
+export const sendTextureFromPaintEvent = (
+  sender: InstanceType<typeof TextureSender>,
+  textureInfo: TextureInfo | undefined,
+): void => {
+  sendTextureFromPaintEventResult(sender, textureInfo).match(
+    () => undefined,
+    (error) => {
+      throw error;
+    },
+  );
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { Result, ok } from "neverthrow";
+import { Result } from "neverthrow";
 import {
   TextureSender,
   TextureReceiver,
@@ -47,8 +47,8 @@ export type { SharedTextureFrame } from "@napolab/texture-bridge";
 
 /**
  * Platform dispatch onto the native sender. `send()` / `sendSurface()` can
- * throw (e.g. "TextureSender has been stopped") — callers go through the
- * `Result`-returning wrapper below.
+ * throw (e.g. "TextureSender has been stopped") — the public entry point
+ * below folds that throw through `Result.fromThrowable`.
  */
 const dispatchSend = (
   sender: InstanceType<typeof TextureSender>,
@@ -74,39 +74,25 @@ const dispatchSend = (
 };
 
 /**
- * Send a texture from an Electron paint event to Syphon/Spout, with the
- * native `send()` / `sendSurface()` throw folded into a typed `Result`.
- *
- * Handles platform detection and buffer extraction automatically. On failure
- * the original message is preserved and the thrown value rides on
- * `Error.cause`. A missing `textureInfo` or handle is a no-op `ok`, matching
- * the void variant.
- */
-export const sendTextureFromPaintEventResult = (
-  sender: InstanceType<typeof TextureSender>,
-  textureInfo: TextureInfo | undefined,
-): Result<void, TextureSendError> => {
-  if (!textureInfo) return ok(undefined);
-  return Result.fromThrowable(
-    () => {
-      dispatchSend(sender, textureInfo);
-    },
-    (cause) => new TextureSendError(cause instanceof Error ? cause.message : `${cause}`, { cause }),
-  )();
-};
-
-/**
  * Send a texture from an Electron paint event to Syphon/Spout.
  *
- * Handles platform detection and buffer extraction automatically. Throwing
- * variant kept for backward compatibility — prefer
- * `sendTextureFromPaintEventResult` and `.match` at your consumption edge.
+ * Handles platform detection and buffer extraction automatically. The native
+ * `send()` / `sendSurface()` throw is wrapped with `Result.fromThrowable` and
+ * consumed here with `.match` — the `Result` never crosses the public API. On
+ * failure a `TextureSendError` is thrown with the original message preserved
+ * and the thrown value on `Error.cause`.
  */
 export const sendTextureFromPaintEvent = (
   sender: InstanceType<typeof TextureSender>,
   textureInfo: TextureInfo | undefined,
 ): void => {
-  sendTextureFromPaintEventResult(sender, textureInfo).match(
+  if (!textureInfo) return;
+  Result.fromThrowable(
+    () => {
+      dispatchSend(sender, textureInfo);
+    },
+    (cause) => new TextureSendError(cause instanceof Error ? cause.message : `${cause}`, { cause }),
+  )().match(
     () => undefined,
     (error) => {
       throw error;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,15 @@ const dispatchSend = (
 };
 
 /**
+ * `dispatchSend` with its throw folded into `Result<void, TextureSendError>`.
+ * Bound once at module scope — `Result.fromThrowable` forwards the arguments.
+ */
+const safeDispatchSend = Result.fromThrowable(
+  dispatchSend,
+  (cause) => new TextureSendError(cause instanceof Error ? cause.message : `${cause}`, { cause }),
+);
+
+/**
  * Send a texture from an Electron paint event to Syphon/Spout.
  *
  * Handles platform detection and buffer extraction automatically. The native
@@ -87,12 +96,7 @@ export const sendTextureFromPaintEvent = (
   textureInfo: TextureInfo | undefined,
 ): void => {
   if (!textureInfo) return;
-  Result.fromThrowable(
-    () => {
-      dispatchSend(sender, textureInfo);
-    },
-    (cause) => new TextureSendError(cause instanceof Error ? cause.message : `${cause}`, { cause }),
-  )().match(
+  safeDispatchSend(sender, textureInfo).match(
     () => undefined,
     (error) => {
       throw error;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["ES2020", "ESNext.Disposable"]
+    "lib": ["ES2020", "ES2022.Error", "ESNext.Disposable"]
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       electron:
         specifier: '>=40.0.0'
         version: 40.2.1
+      neverthrow:
+        specifier: ^8.2.0
+        version: 8.2.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2018,6 +2021,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neverthrow@8.2.0:
+    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
+    engines: {node: '>=18'}
 
   node-abi@4.26.0:
     resolution: {integrity: sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==}
@@ -4567,6 +4574,10 @@ snapshots:
   nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
+
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
 
   node-abi@4.26.0:
     dependencies:


### PR DESCRIPTION
Stacked on #58. Per review: **Result/ResultAsync never cross the public API** — they are consumed with `.match` at the terminal edge inside the library.

- `sendTextureFromPaintEvent` keeps its public signature (`void`, throwing). Internally the throwable `sender.send()` / `sender.sendSurface()` platform dispatch is wrapped once with `Result.fromThrowable` and consumed immediately with `.match` — the ok branch is a no-op, the err branch rethrows
- Failures throw the new exported `TextureSendError` (`override name`, message preserved byte-for-byte from the thrown value, original value on `Error.cause`)
- neverthrow added to `@napolab/texture-bridge-core` (internal use only); `ES2022.Error` added to core lib for `{ cause }`

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — pass
- [x] `pnpm -C packages/core test` — 11 passed (9 existing + 2 new: TextureSendError message/cause preservation for Error and non-Error thrown values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)