### PR TITLE
feat: make silent paint drops observable (frameDropped) + guard ESM __dirname shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ interface TextureBridge {
   on(event: "fps", listener: (fps: number) => void): this;
   on(event: "ready", listener: () => void): this;
   on(event: "error", listener: (error: Error) => void): this;
+  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
   on(event: "resize", listener: (width: number, height: number) => void): this;
   on(event: "disposed", listener: () => void): this;
 
@@ -601,8 +602,18 @@ interface TextureBridge {
   readonly renderWindow: BrowserWindow;
   readonly previewWindow: BrowserWindow | null;
   readonly isDisposed: boolean;
+  readonly droppedReason: PaintDefect["reason"] | null;
 }
 ```
+
+`frameDropped` fires when a paint frame is dropped before reaching the sender
+(`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`).
+It is not an error — but if it fires persistently, receivers see black output.
+Consecutive drops with the same reason are deduped: the event fires once, and
+again only after a successful send or a reason change. If a drop latches
+before your listener is attached (e.g. while the renderer page is still
+loading), read `bridge.droppedReason` — it holds the latest drop reason, or
+`null` after a successful send.
 
 #### `createWorkerRenderer(options)` (from `renderer/client`)
 
@@ -760,6 +771,12 @@ Low-level convenience function that handles platform-specific texture handle ext
 
 - **macOS**: Reads `handle.ioSurface` buffer → calls `sender.sendSurface()`
 - **Windows**: Reads `handle.ntHandle` buffer as BigInt64LE → calls `sender.send()`
+
+Returns `undefined` when the frame was handed to the sender, or a `PaintDefect`
+(`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`)
+when the frame was dropped. Drops are normal no-ops, not errors — surface them
+in your own paint loop the same way `createTextureBridge` does with its
+`frameDropped` event. Native send failures still throw.
 
 #### `TextureSender`
 
@@ -989,6 +1006,10 @@ electron-texture-bridge/
 - **Isolate Electron vs. the bridge** with the [no-Electron sanity check](#minimal-sanity-check-no-electron) — if `sendRgbaBuffer` shows up in your VJ app, the native side is fine and the problem is in the Electron OSR path.
 - `preserveDrawingBuffer` is not needed (Chromium compositor reads directly)
 - Check pixel format mismatch: Chromium outputs BGRA, ensure the receiver expects BGRA
+- Subscribe to `bridge.on("frameDropped", ...)` (or check the return value of
+  `sendTextureFromPaintEvent`) — a persistent `no-nt-handle` / `no-io-surface`
+  reason means Chromium is not delivering a shareable GPU handle, which
+  otherwise manifests only as black output.
 
 ### Syphon receiver not showing output (macOS)
 

--- a/README.md
+++ b/README.md
@@ -773,7 +773,8 @@ Low-level convenience function that handles platform-specific texture handle ext
 - **Windows**: Reads `handle.ntHandle` buffer as BigInt64LE → calls `sender.send()`
 
 Returns `undefined` when the frame was handed to the sender, or a `PaintDefect`
-(`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`)
+(`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`;
+the `unsupported-platform` variant also carries the offending `platform`)
 when the frame was dropped. Drops are normal no-ops, not errors — surface them
 in your own paint loop the same way `createTextureBridge` does with its
 `frameDropped` event. Native send failures still throw.

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -356,6 +356,7 @@ interface TextureBridge {
   on(event: "fps", listener: (fps: number) => void): this;
   on(event: "ready", listener: () => void): this;
   on(event: "error", listener: (error: Error) => void): this;
+  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
   on(event: "resize", listener: (width: number, height: number) => void): this;
   on(event: "disposed", listener: () => void): this;
 
@@ -367,8 +368,18 @@ interface TextureBridge {
   readonly renderWindow: BrowserWindow;
   readonly previewWindow: BrowserWindow | null;
   readonly isDisposed: boolean;
+  readonly droppedReason: PaintDefect["reason"] | null;
 }
 ```
+
+`frameDropped` は、paint フレームがセンダーに届く前にドロップされたときに発火します
+（`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`）。
+エラーではありませんが、継続的に発火する場合はレシーバー側で黒画面になります。
+同じ理由が連続する場合はデデュープされます：イベントは最初の発生時に一度発火し、
+成功した送信または理由の変化があった後に再び発火します。リスナーをアタッチする前に
+ドロップが確定していた場合（例: レンダラーページがまだロード中の場合）は、
+`bridge.droppedReason` を読んでください — 最新のドロップ理由、または成功した送信の後は
+`null` を保持します。
 
 #### `createWorkerRenderer(options)`（`renderer/client` から）
 
@@ -407,6 +418,13 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
 
 - **macOS**: `handle.ioSurface` バッファを読み取り → `sender.sendSurface()` を呼び出し
 - **Windows**: `handle.ntHandle` バッファを BigInt64LE として読み取り → `sender.send()` を呼び出し
+
+フレームがセンダーに渡された場合は `undefined` を返し、フレームがドロップされた場合は
+`PaintDefect`（`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`；
+`unsupported-platform` バリアントには該当する `platform` も含まれます）を返します。
+ドロップは通常のノーオペレーションであり、エラーではありません — `createTextureBridge` が
+`frameDropped` イベントで行っているのと同様に、自前の paint ループでも表面化させてください。
+ネイティブの送信失敗は引き続き throw されます。
 
 #### `TextureSender`
 
@@ -556,6 +574,10 @@ electron-texture-bridge/
 - **Electron とブリッジの切り分け**には[Electron 無しの最小サニティチェック](#electron-無しの最小サニティチェック)を使ってください — `sendRgbaBuffer` が VJ アプリに映ればネイティブ側は健全で、問題は Electron OSR 経路にあります。
 - `preserveDrawingBuffer` は不要（Chromium のコンポジターが直接読み取る）
 - ピクセルフォーマットの不一致を確認：Chromium は BGRA を出力するので、レシーバー側も BGRA を期待しているか確認
+- `bridge.on("frameDropped", ...)` を購読する（または `sendTextureFromPaintEvent` の
+  戻り値を確認する）— `no-nt-handle` / `no-io-surface` の理由が継続する場合、
+  Chromium が共有可能な GPU ハンドルを配信していないことを意味し、
+  それ以外では黒画面としてのみ現れます。
 
 ### Syphon レシーバーに表示されない（macOS）
 

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -86,14 +86,106 @@ describe("sendTextureFromPaintEvent", () => {
     }
   });
 
-  it("does nothing when textureInfo is undefined", async () => {
+  it("returns a no-texture defect when textureInfo is undefined", async () => {
     const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
     const sender = new TextureSender("Test", 1920, 1080);
 
-    // Should not throw
-    sendTextureFromPaintEvent(sender, undefined);
+    const defect = sendTextureFromPaintEvent(sender, undefined);
+    expect(defect).toEqual({ reason: "no-texture" });
     expect(mockSend).not.toHaveBeenCalled();
     expect(mockSendSurface).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined on successful darwin send", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toBeUndefined();
+      expect(mockSendSurface).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns a no-io-surface defect on darwin when the handle lacks ioSurface", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: {},
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toEqual({ reason: "no-io-surface" });
+      expect(mockSendSurface).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns a no-nt-handle defect on win32 when the handle lacks ntHandle", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: {},
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toEqual({ reason: "no-nt-handle" });
+      expect(mockSend).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns an unsupported-platform defect on linux", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toEqual({
+        reason: "unsupported-platform",
+        platform: "linux",
+      });
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockSendSurface).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
   });
 
   it("surfaces stopped-sender error instead of swallowing it", async () => {

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -118,6 +118,28 @@ describe("sendTextureFromPaintEvent", () => {
     }
   });
 
+  it("returns undefined on successful win32 send", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ntHandle: Buffer.alloc(8) },
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toBeUndefined();
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
   it("returns a no-io-surface defect on darwin when the handle lacks ioSurface", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ import type {
   PixelFormat,
   SenderInfo,
   ReceivedFrame,
+  PaintDefect,
 } from "./types";
 
 // Attach Symbol.dispose to native classes so `using` declarations work.
@@ -36,32 +37,49 @@ declare module "@napolab/texture-bridge" {
 }
 
 export { TextureSender, TextureReceiver, closeNativeHandle, getPlatform, listSenders };
-export type { TextureInfo, PaintTexture, Platform, PixelFormat, SenderInfo, ReceivedFrame };
+export type {
+  TextureInfo,
+  PaintTexture,
+  Platform,
+  PixelFormat,
+  SenderInfo,
+  ReceivedFrame,
+  PaintDefect,
+};
 export type { SharedTextureFrame } from "@napolab/texture-bridge";
 
 /**
  * Send a texture from an Electron paint event to Syphon/Spout.
  *
  * Handles platform detection and buffer extraction automatically.
+ *
+ * @returns `undefined` when the texture was handed to the sender, or a
+ * {@link PaintDefect} describing why the frame was dropped. Drops are normal
+ * no-ops (e.g. Chromium delivered a paint without a shareable handle), not
+ * errors — but callers should surface them instead of letting output go
+ * silently black. Native send failures still throw as before.
  */
 export function sendTextureFromPaintEvent(
   sender: InstanceType<typeof TextureSender>,
   textureInfo: TextureInfo | undefined,
-): void {
-  if (!textureInfo) return;
+): PaintDefect | undefined {
+  if (!textureInfo) return { reason: "no-texture" };
   const { handle, codedSize } = textureInfo;
 
   if (process.platform === "win32") {
     const ntHandle = handle.ntHandle;
-    if (!ntHandle || !Buffer.isBuffer(ntHandle)) return;
+    if (!ntHandle || !Buffer.isBuffer(ntHandle)) return { reason: "no-nt-handle" };
     const handleValue = Number(ntHandle.readBigInt64LE(0));
     sender.send(handleValue, codedSize.width, codedSize.height);
-    return;
+    return undefined;
   }
 
   if (process.platform === "darwin") {
     const ioSurface = handle.ioSurface;
-    if (!ioSurface) return;
+    if (!ioSurface) return { reason: "no-io-surface" };
     sender.sendSurface(ioSurface, codedSize.width, codedSize.height);
+    return undefined;
   }
+
+  return { reason: "unsupported-platform", platform: process.platform };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,10 @@ export interface ReceivedFrame {
  * This is a modeled no-op, not an error: the paint pipeline continues, but the
  * frame was dropped. Callers may surface it (e.g. the high-level bridge emits
  * it as a `frameDropped` event) instead of the drop being silent.
+ *
+ * This union may gain new variants in a minor release — consumers switching
+ * exhaustively on reason should tolerate unknown reasons if they need
+ * forward compatibility across upgrades.
  */
 export type PaintDefect =
   | { readonly reason: "no-texture" }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,3 +34,16 @@ export interface ReceivedFrame {
   width: number;
   height: number;
 }
+
+/**
+ * Reason a paint event could not be forwarded to the sender.
+ *
+ * This is a modeled no-op, not an error: the paint pipeline continues, but the
+ * frame was dropped. Callers may surface it (e.g. the high-level bridge emits
+ * it as a `frameDropped` event) instead of the drop being silent.
+ */
+export type PaintDefect =
+  | { readonly reason: "no-texture" }
+  | { readonly reason: "no-nt-handle" }
+  | { readonly reason: "no-io-surface" }
+  | { readonly reason: "unsupported-platform"; readonly platform: NodeJS.Platform };

--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -52,6 +52,10 @@ app.whenReady().then(async () => {
     console.error("[example] bridge error:", err.message);
   });
 
+  bridge.on("frameDropped", (defect) => {
+    console.warn(`[bridge] frame dropped: ${defect.reason}`);
+  });
+
   bridge.renderWindow.webContents.on("did-fail-load", (_event, errorCode, errorDesc) => {
     console.error("[example] did-fail-load:", errorCode, errorDesc);
   });

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -25,7 +25,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsdown && cp -r src/assets dist/assets",
+    "build": "tsdown && cp -r src/assets dist/assets && node scripts/esm-shim-guard.mjs",
     "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/renderer/scripts/esm-shim-guard.d.mts
+++ b/packages/renderer/scripts/esm-shim-guard.d.mts
@@ -1,0 +1,3 @@
+export declare const findUnshimmedSources: (
+  sources: readonly { readonly path: string; readonly content: string }[],
+) => string[];

--- a/packages/renderer/scripts/esm-shim-guard.mjs
+++ b/packages/renderer/scripts/esm-shim-guard.mjs
@@ -25,6 +25,12 @@ if (invokedAsScript) {
   const distDir = new URL("../dist/", import.meta.url);
   const entries = await readdir(distDir, { recursive: true });
   const mjsPaths = entries.filter((entry) => entry.endsWith(".mjs"));
+  if (mjsPaths.length === 0) {
+    console.error(
+      "[esm-shim-guard] no .mjs files found under dist/ — the guard has nothing to check, failing loudly.",
+    );
+    process.exit(1);
+  }
   const sources = await Promise.all(
     mjsPaths.map(async (entryPath) => ({
       path: entryPath,

--- a/packages/renderer/scripts/esm-shim-guard.mjs
+++ b/packages/renderer/scripts/esm-shim-guard.mjs
@@ -1,0 +1,43 @@
+/**
+ * Regression guard for the ESM `__dirname` shim (renderer 0.13.1 fix).
+ *
+ * PreviewManager resolves bundled assets via `__dirname`, which only exists in
+ * the ESM output because tsdown injects a shim (`shims: true` in
+ * tsdown.config.mts). If that flag is ever dropped, the .mjs build throws
+ * `ReferenceError: __dirname is not defined` at import time under an ESM
+ * Electron main — exactly the 0.13.0 bug consumers had to patch around.
+ *
+ * Invariant checked here: every dist .mjs that references `__dirname` must
+ * also define it (`const __dirname = ...` — the shape of tsdown's shim).
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const findUnshimmedSources = (sources) =>
+  sources
+    .filter(({ content }) => /\b__dirname\b/.test(content) && !/const __dirname\s*=/.test(content))
+    .map(({ path }) => path);
+
+const invokedAsScript =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsScript) {
+  const distDir = new URL("../dist/", import.meta.url);
+  const entries = await readdir(distDir, { recursive: true });
+  const mjsPaths = entries.filter((entry) => entry.endsWith(".mjs"));
+  const sources = await Promise.all(
+    mjsPaths.map(async (entryPath) => ({
+      path: entryPath,
+      content: await readFile(new URL(entryPath, distDir), "utf8"),
+    })),
+  );
+  const offenders = findUnshimmedSources(sources);
+  if (offenders.length > 0) {
+    console.error(
+      `[esm-shim-guard] ESM output references __dirname without a shim: ${offenders.join(", ")}\n` +
+        `[esm-shim-guard] Check that tsdown.config.mts still sets \`shims: true\`.`,
+    );
+    process.exit(1);
+  }
+  console.log(`[esm-shim-guard] OK — ${mjsPaths.length} .mjs file(s) checked`);
+}

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -6,14 +6,21 @@ import { describe, expect, it, vi } from "vitest";
 // real native module.
 vi.mock("electron", () => ({
   app: { isReady: () => true },
-  BrowserWindow: class MockBrowserWindow {},
+  BrowserWindow: class MockBrowserWindow {
+    isDestroyed(): boolean {
+      return false;
+    }
+    close(): void {}
+  },
   screen: {
     getPrimaryDisplay: () => ({ scaleFactor: 1 }),
   },
 }));
 
 vi.mock("@napolab/texture-bridge-core", () => ({
-  TextureSender: class MockTextureSender {},
+  TextureSender: class MockTextureSender {
+    stop(): void {}
+  },
   sendTextureFromPaintEvent: vi.fn(),
 }));
 
@@ -282,6 +289,28 @@ describe("TextureBridgeImpl.handlePaint — frameDropped", () => {
 
     expect(release).toHaveBeenCalledTimes(1);
     expect(dropped).toEqual([{ reason: "no-texture" }]);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("drops a post-dispose paint without emitting frameDropped or mutating droppedReason", () => {
+    // Once disposed, the underlying sender has been stopped — calling into it
+    // would throw for every in-flight paint. The guard must run before the
+    // no-texture branch too, since a post-dispose paint can still arrive
+    // without a texture and would otherwise latch a spurious drop reason.
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    bridge.dispose();
+    // Attach the listener after dispose() — dispose() calls
+    // removeAllListeners(), so a listener added beforehand would not observe
+    // any (incorrect) emission and the assertion would be a false negative.
+    const dropped = collectDropped(bridge);
+    const texture = makeTexture();
+
+    bridge.handlePaint({ texture });
+
+    expect(dropped).toEqual([]);
+    expect(bridge.droppedReason).toBeNull();
+    expect(texture.release).toHaveBeenCalledTimes(1);
     expect(sendMock).not.toHaveBeenCalled();
   });
 

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -20,8 +20,9 @@ vi.mock("@napolab/texture-bridge-core", () => ({
 import { buildBrowserWindowOptions, computeDipSize, TextureBridgeImpl } from "../bridge";
 import { BrowserWindow } from "electron";
 import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
-import type { PaintDefect } from "@napolab/texture-bridge-core";
+import type { PaintDefect, PaintTexture } from "@napolab/texture-bridge-core";
 import type { TextureBridgeOptions } from "../types";
+import type { PreviewManager } from "../preview-manager";
 
 const baseOpts: TextureBridgeOptions = {
   name: "test",
@@ -252,5 +253,56 @@ describe("TextureBridgeImpl.handlePaint — frameDropped", () => {
 
     expect(dropped).toEqual([]);
     expect(texture.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the latched drop reason via droppedReason", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    expect(bridge.droppedReason).toBeNull();
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+    expect(bridge.droppedReason).toBe("no-nt-handle");
+
+    sendMock.mockReturnValue(undefined);
+    bridge.handlePaint({ texture: makeTexture() });
+    expect(bridge.droppedReason).toBeNull();
+  });
+
+  it("releases a texture that arrives without textureInfo", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+    const release = vi.fn();
+    // The runtime guard exists precisely because Electron can deliver a
+    // texture without textureInfo — a state PaintTexture's type cannot
+    // express, hence the two-step cast.
+    const defective: unknown = { release };
+    bridge.handlePaint({ texture: defective as PaintTexture });
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(dropped).toEqual([{ reason: "no-texture" }]);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("still forwards the frame to the preview manager on a defect", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    const sendFrame = vi.fn();
+    // PreviewManager has private fields, so a structural stub cannot satisfy
+    // its class type — the two-step cast injects the test double.
+    const previewStub: unknown = { sendFrame };
+    const bridge = new TextureBridgeImpl(
+      new BrowserWindow(),
+      new TextureSender("t", 16, 9),
+      previewStub as PreviewManager,
+      baseOpts,
+    );
+    const texture = makeTexture();
+
+    bridge.handlePaint({ texture });
+
+    expect(sendFrame).toHaveBeenCalledTimes(1);
+    expect(sendFrame).toHaveBeenCalledWith(texture);
   });
 });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -17,7 +17,10 @@ vi.mock("@napolab/texture-bridge-core", () => ({
   sendTextureFromPaintEvent: vi.fn(),
 }));
 
-import { buildBrowserWindowOptions, computeDipSize } from "../bridge";
+import { buildBrowserWindowOptions, computeDipSize, TextureBridgeImpl } from "../bridge";
+import { BrowserWindow } from "electron";
+import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
+import type { PaintDefect } from "@napolab/texture-bridge-core";
 import type { TextureBridgeOptions } from "../types";
 
 const baseOpts: TextureBridgeOptions = {
@@ -143,5 +146,111 @@ describe("computeDipSize", () => {
     // Infinity and crash the BrowserWindow constructor.
     expect(computeDipSize(1920, 1080, 0)).toEqual({ width: 1920, height: 1080 });
     expect(computeDipSize(1920, 1080, -1)).toEqual({ width: 1920, height: 1080 });
+  });
+});
+
+describe("TextureBridgeImpl.handlePaint — frameDropped", () => {
+  const sendMock = vi.mocked(sendTextureFromPaintEvent);
+
+  const makeBridge = () =>
+    new TextureBridgeImpl(new BrowserWindow(), new TextureSender("t", 16, 9), null, baseOpts);
+
+  const makeTexture = () => ({
+    textureInfo: {
+      pixelFormat: "bgra" as const,
+      codedSize: { width: 16, height: 9 },
+      visibleRect: { x: 0, y: 0, width: 16, height: 9 },
+      handle: {},
+    },
+    release: vi.fn(),
+  });
+
+  const collectDropped = (bridge: TextureBridgeImpl) => {
+    const dropped: PaintDefect[] = [];
+    bridge.on("frameDropped", (defect) => {
+      dropped.push(defect);
+    });
+    return dropped;
+  };
+
+  it("emits a no-texture defect when the paint event has no texture", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    bridge.handlePaint({ texture: undefined });
+
+    expect(dropped).toEqual([{ reason: "no-texture" }]);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("emits the defect returned by sendTextureFromPaintEvent and still releases the texture", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+    const texture = makeTexture();
+
+    bridge.handlePaint({ texture });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }]);
+    expect(texture.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes consecutive defects with the same reason", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }]);
+  });
+
+  it("re-emits after a successful send resets the dedupe state", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    sendMock.mockReturnValue(undefined);
+    bridge.handlePaint({ texture: makeTexture() });
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }, { reason: "no-nt-handle" }]);
+  });
+
+  it("emits immediately when the defect reason changes", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    sendMock.mockReturnValue({ reason: "no-io-surface" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }, { reason: "no-io-surface" }]);
+  });
+
+  it("does not emit frameDropped on a successful send", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+    const texture = makeTexture();
+
+    bridge.handlePaint({ texture });
+
+    expect(dropped).toEqual([]);
+    expect(texture.release).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/renderer/src/__tests__/esm-shim-guard.test.ts
+++ b/packages/renderer/src/__tests__/esm-shim-guard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { findUnshimmedSources } from "../../scripts/esm-shim-guard.mjs";
+
+const SHIMMED = `
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+const getFilename = () => fileURLToPath(import.meta.url);
+const getDirname = () => path.dirname(getFilename());
+const __dirname = /* @__PURE__ */ getDirname();
+const asset = path.join(__dirname, "assets", "preview.html");
+`;
+
+const UNSHIMMED = `
+import path from "path";
+const asset = path.join(__dirname, "assets", "preview.html");
+`;
+
+const NO_DIRNAME = `
+export const add = (a, b) => a + b;
+`;
+
+describe("findUnshimmedSources", () => {
+  it("flags a source that references __dirname without defining it", () => {
+    const result = findUnshimmedSources([{ path: "index.mjs", content: UNSHIMMED }]);
+    expect(result).toEqual(["index.mjs"]);
+  });
+
+  it("passes a source whose __dirname reference is backed by a shim definition", () => {
+    const result = findUnshimmedSources([{ path: "index.mjs", content: SHIMMED }]);
+    expect(result).toEqual([]);
+  });
+
+  it("passes a source that never references __dirname", () => {
+    const result = findUnshimmedSources([{ path: "util.mjs", content: NO_DIRNAME }]);
+    expect(result).toEqual([]);
+  });
+
+  it("reports only the offending files among a mixed set", () => {
+    const result = findUnshimmedSources([
+      { path: "a.mjs", content: SHIMMED },
+      { path: "b.mjs", content: UNSHIMMED },
+      { path: "c.mjs", content: NO_DIRNAME },
+    ]);
+    expect(result).toEqual(["b.mjs"]);
+  });
+});

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -87,18 +87,18 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
   /** Handle a paint event from the offscreen BrowserWindow. */
   handlePaint(event: { texture?: PaintTexture }): void {
     const texture = event.texture;
-    if (!texture?.textureInfo) {
-      texture?.release?.();
-      this.emitFrameDropped({ reason: "no-texture" });
-      return;
-    }
-
     // If we've been disposed between the paint event and this callback, the
     // underlying sender has been stopped and calling into it would throw
     // "TextureSender has been stopped" for every in-flight paint. Drop the
     // texture cleanly instead of emitting a stream of teardown errors.
     if (this._disposed) {
-      texture.release?.();
+      texture?.release?.();
+      return;
+    }
+
+    if (!texture?.textureInfo) {
+      texture?.release?.();
+      this.emitFrameDropped({ reason: "no-texture" });
       return;
     }
 

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -73,6 +73,10 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     return this._disposed;
   }
 
+  get droppedReason(): PaintDefect["reason"] | null {
+    return this.lastDropReason;
+  }
+
   /** Emit `frameDropped`, deduping consecutive drops with the same reason. */
   private emitFrameDropped(defect: PaintDefect): void {
     if (defect.reason === this.lastDropReason) return;

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -4,6 +4,7 @@ import {
   TextureSender,
   sendTextureFromPaintEvent,
   type PaintTexture,
+  type PaintDefect,
 } from "@napolab/texture-bridge-core";
 import { PreviewManager } from "./preview-manager";
 import { FpsCounter } from "./fps-counter";
@@ -37,12 +38,14 @@ interface PaintEvent extends Event {
   texture?: PaintTexture;
 }
 
-class TextureBridgeImpl extends EventEmitter implements TextureBridge {
+/** Exported for unit tests — not part of the package's public entry point. */
+export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
   private _renderWindow: BrowserWindow;
   private sender: InstanceType<typeof TextureSender>;
   private previewManager: PreviewManager | null;
   private fpsCounter = new FpsCounter();
   private _disposed = false;
+  private lastDropReason: PaintDefect["reason"] | null = null;
   private options: TextureBridgeOptions;
 
   constructor(
@@ -70,10 +73,21 @@ class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     return this._disposed;
   }
 
+  /** Emit `frameDropped`, deduping consecutive drops with the same reason. */
+  private emitFrameDropped(defect: PaintDefect): void {
+    if (defect.reason === this.lastDropReason) return;
+    this.lastDropReason = defect.reason;
+    this.emit("frameDropped", defect);
+  }
+
   /** Handle a paint event from the offscreen BrowserWindow. */
-  handlePaint(event: PaintEvent): void {
+  handlePaint(event: { texture?: PaintTexture }): void {
     const texture = event.texture;
-    if (!texture?.textureInfo) return;
+    if (!texture?.textureInfo) {
+      texture?.release?.();
+      this.emitFrameDropped({ reason: "no-texture" });
+      return;
+    }
 
     // If we've been disposed between the paint event and this callback, the
     // underlying sender has been stopped and calling into it would throw
@@ -85,7 +99,12 @@ class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     }
 
     try {
-      sendTextureFromPaintEvent(this.sender, texture.textureInfo);
+      const defect = sendTextureFromPaintEvent(this.sender, texture.textureInfo);
+      if (defect === undefined) {
+        this.lastDropReason = null;
+      } else {
+        this.emitFrameDropped(defect);
+      }
       this.previewManager?.sendFrame(texture);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -14,3 +14,4 @@ export type {
   SharedTextureReceiverBridgeEvents,
 } from "./shared-texture-receiver";
 export type { SenderDiscoveryEvents } from "./discovery";
+export type { PaintDefect } from "@napolab/texture-bridge-core";

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -84,7 +84,9 @@ export interface BridgeEvents {
    * this fires persistently the output is black on the receiving side.
    * Consecutive drops with the same reason are deduped: the event fires on
    * the first occurrence and again only after a successful send or a reason
-   * change.
+   * change. A thrown native send failure (surfaced via the "error" event)
+   * neither emits frameDropped nor resets the dedupe state — droppedReason
+   * keeps the last drop reason until a successful send or a reason change.
    */
   frameDropped: [defect: PaintDefect];
   disposed: [];

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -113,6 +113,14 @@ export interface TextureBridge {
   /** Whether the bridge has been disposed */
   readonly isDisposed: boolean;
 
+  /**
+   * Reason of the most recently dropped frame, or `null` after a successful
+   * send (or before the first paint). Lets callers observe a drop that
+   * latched before their `frameDropped` listener was attached (e.g. while
+   * the renderer page was still loading).
+   */
+  readonly droppedReason: PaintDefect["reason"] | null;
+
   /** Tear down all resources. Terminal operation — the bridge cannot be reused afterward. */
   dispose(): void;
 

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from "electron";
+import type { PaintDefect } from "@napolab/texture-bridge-core";
 
 /** Options for the preview window */
 export interface PreviewOptions {
@@ -77,6 +78,15 @@ export interface BridgeEvents {
   fps: [fps: number];
   ready: [];
   error: [error: Error];
+  /**
+   * A paint frame was dropped before reaching the sender (missing texture /
+   * missing platform handle / unsupported platform). Not an error — but if
+   * this fires persistently the output is black on the receiving side.
+   * Consecutive drops with the same reason are deduped: the event fires on
+   * the first occurrence and again only after a successful send or a reason
+   * change.
+   */
+  frameDropped: [defect: PaintDefect];
   disposed: [];
   resize: [width: number, height: number];
 }


### PR DESCRIPTION
## Summary

Genovese / Cannelloni 調査レポート（`reports/2026-08-10-simple-core-api-abstraction.md`）の backlog #1 残作業と #2 を実装。

### ESM `__dirname` shim 回帰ガード（backlog #1 残作業）
- `packages/renderer/scripts/esm-shim-guard.mjs` — 「dist の `.mjs` が `__dirname` を参照するなら同ファイル内に shim 定義（`const __dirname =`）が必ずある」を build 最終段で検査。tsdown の `shims: true` が消えたらビルドが落ちる（0.13.0 で Cannelloni が patch を当てる羽目になったバグの再発防止）
- `.mjs` が 0 件でも fail-loud。純関数はユニットテスト 4 件でカバー

### silent drop の観測可能化（backlog #2）
- **core**: `sendTextureFromPaintEvent` が `void` の代わりに `PaintDefect | undefined` を返す
  - `PaintDefect` = `no-texture` / `no-nt-handle` / `no-io-surface` / `unsupported-platform`（+`platform`）の tagged union（Result は公開 API に出さない）
  - 呼び出し側は後方互換。native throw の挙動は不変。未マージ PR #58/#64 との衝突最小化のため既存行・スタイルは不変更
- **renderer**: `BridgeEvents` に `frameDropped: [defect: PaintDefect]` を追加
  - 連続同一 reason はデデュープ（60fps でのイベントスパム防止）、送出成功でリセット、reason 変化で即 emit
  - `droppedReason: PaintDefect["reason"] | null` getter — リスナー登録前（ページロード中）に latch した defect も観測可能
  - 副産物のリーク修正: textureInfo 欠落 texture も `release()` されるように
- README（EN + ja ミラー）、example アプリに `frameDropped` の dogfood 追加

## Test plan
- core 14/14 pass（platform 別の defect 返り値・成功パス win32/darwin・throw 透過）
- renderer 140/140 pass（emit / dedupe / reset / reason 変化 / dispose 後 / release / preview 継続 / getter）
- `pnpm lint`（0 errors）/ `pnpm typecheck` / 両パッケージ build（`[esm-shim-guard] OK`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)