### PR TITLE
feat: version-aware OSR scale policy (pin deviceScaleFactor on Electron 41+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Older examples that destructure `(event, dirtyRect, image, texture)` are from a 
 >
 > ⚠️ **This is the #1 cause of a black or garbled output on Electron ≤ 40.** How the offscreen framebuffer relates to your requested `width × height` depends on the Electron version:
 >
-> - **Electron ≥ 41:** `createTextureBridge` pins `webPreferences.offscreen.deviceScaleFactor` to `1`, so the framebuffer is always exactly `width × height` pixels — display scaling does not affect the texture. (`Electron 42` changed the OSR default device scale factor to `1.0`; the bridge sets it explicitly from 41, where the option first appeared.) `pixelExact` is trivially satisfied and effectively a no-op.
+> - **Electron ≥ 41:** `createTextureBridge` pins `webPreferences.offscreen.deviceScaleFactor` to `1`, so the framebuffer is always exactly `width × height` pixels — display scaling does not affect the texture. (`Electron 42` changed the OSR default device scale factor to `1.0`; the bridge sets it explicitly from 41, where the option first appeared.) `pixelExact` is trivially satisfied and effectively a no-op. Verified on macOS; Windows display-scaling verification is pending (the investigation report lists it as an open item) — if you hit clamping on Windows, size down or verify with the [probe script](packages/renderer/scripts/osr-scale-probe.cjs).
 > - **Electron 40:** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer delivered to the shared texture is `width × height × display.scaleFactor`. On a macOS Retina display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture. Use `createTextureBridge({ pixelExact: true })` to absorb this, or handle DPR yourself on the low-level core path.
 >
 > **Low-level core** (manual `BrowserWindow` + `paint`) has no absorption on any version — on Electron ≥ 41 pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself; on Electron 40 keep the sender's declared size and the actual framebuffer size in agreement manually.
@@ -1005,7 +1005,7 @@ electron-texture-bridge/
 
 ### Black texture output
 
-- **DPR / Retina size mismatch (most common).** On a Retina display or under Windows display scaling, the real framebuffer is `width × height × scaleFactor`, so a sender declared at the logical size disagrees with it and the receiver goes black/garbled. Use `createTextureBridge({ pixelExact: true })`, or — on the low-level core path — declare the sender at the true framebuffer size or neutralize DPR yourself. See the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling).
+- **DPR / Retina size mismatch (most common).** **Electron ≤ 40:** on a Retina display or under Windows display scaling, the real framebuffer is `width × height × scaleFactor`, so a sender declared at the logical size disagrees with it and the receiver goes black/garbled. Use `createTextureBridge({ pixelExact: true })`, or — on the low-level core path — declare the sender at the true framebuffer size or neutralize DPR yourself. **Electron ≥ 41:** `createTextureBridge` pins the OSR device scale factor to `1`, so this mismatch no longer occurs — see [Migration: Electron 42 / OSR device scale](#migration-electron-42--osr-device-scale); on the low-level core path, pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself. See the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling).
 - **Isolate Electron vs. the bridge** with the [no-Electron sanity check](#minimal-sanity-check-no-electron) — if `sendRgbaBuffer` shows up in your VJ app, the native side is fine and the problem is in the Electron OSR path.
 - `preserveDrawingBuffer` is not needed (Chromium compositor reads directly)
 - Check pixel format mismatch: Chromium outputs BGRA, ensure the receiver expects BGRA
@@ -1055,9 +1055,9 @@ win.webContents.on("paint", (event) => {
 
 Electron 42 changed offscreen rendering's default device scale factor to `1.0`
 ([breaking change](https://www.electronjs.org/docs/latest/breaking-changes)).
-From the release containing this change, `createTextureBridge` pins
-`offscreen.deviceScaleFactor: 1` on Electron ≥ 41, making `width`/`height`
-mean exact pixels on every display.
+From the texture-bridge release that includes this change (see CHANGELOG),
+`createTextureBridge` pins `offscreen.deviceScaleFactor: 1` on Electron ≥ 41,
+making `width`/`height` mean exact pixels on every display.
 
 - **If you used `pixelExact: true`** (e.g. on Electron 40): keep it — it is a
   no-op on Electron ≥ 41 and still required on 40.

--- a/README.md
+++ b/README.md
@@ -360,10 +360,12 @@ Older examples that destructure `(event, dirtyRect, image, texture)` are from a 
 
 > ### macOS Retina and Windows DPI scaling
 >
-> ⚠️ **This is the #1 cause of a black or garbled output.** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer actually delivered to the shared texture is `width × height × display.scaleFactor`. On a **macOS Retina** display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture — the sender's declared size and the real framebuffer disagree, and the receiver shows black/garbled output. Windows display scaling (150% / 175%) causes the same mismatch.
+> ⚠️ **This is the #1 cause of a black or garbled output on Electron ≤ 40.** How the offscreen framebuffer relates to your requested `width × height` depends on the Electron version:
 >
-> - **High-level `createTextureBridge`** absorbs this for you via the **`pixelExact: true`** option (see [`TextureBridgeOptions`](#createtexturebridgeoptions-promisetexturebridge)): it sizes the BrowserWindow in DIP so the framebuffer lands on exactly `width × height`, and registers the sender at the requested pixel size.
-> - **Low-level core** (manual `BrowserWindow` + `paint`) has **no such absorption** — *you* must keep the sender's declared size and the actual framebuffer size in agreement. Either declare the sender at the true framebuffer size (`declared = logical × scaleFactor`), or neutralize DPR with `webContents.setZoomFactor` / a fixed-scale display, or move to `createTextureBridge({ pixelExact: true })`.
+> - **Electron ≥ 41:** `createTextureBridge` pins `webPreferences.offscreen.deviceScaleFactor` to `1`, so the framebuffer is always exactly `width × height` pixels — display scaling does not affect the texture. (`Electron 42` changed the OSR default device scale factor to `1.0`; the bridge sets it explicitly from 41, where the option first appeared.) `pixelExact` is trivially satisfied and effectively a no-op.
+> - **Electron 40:** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer delivered to the shared texture is `width × height × display.scaleFactor`. On a macOS Retina display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture. Use `createTextureBridge({ pixelExact: true })` to absorb this, or handle DPR yourself on the low-level core path.
+>
+> **Low-level core** (manual `BrowserWindow` + `paint`) has no absorption on any version — on Electron ≥ 41 pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself; on Electron 40 keep the sender's declared size and the actual framebuffer size in agreement manually.
 
 ### Minimal sanity check (no Electron)
 
@@ -579,7 +581,7 @@ interface PreviewOptions {
 }
 ```
 
-**`pixelExact`** — when `true`, the offscreen framebuffer is pinned to exactly `width × height` pixels regardless of the host display's device pixel ratio. Without it, a Retina (scaleFactor 2) or Windows-scaled (150% / 175%) display produces a framebuffer larger than the declared sender size, which typically shows up as black/garbled output in the receiver (see the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling)). The sender is always registered at the requested pixel size, so receivers see the dimensions you asked for. Note: non-divisible scale ratios (e.g. `1920 / 1.75`) can leave a 1-pixel discrepancy, and only the primary display's scaleFactor at construction time is honored — call `resize()` to re-apply after a DPI change.
+**`pixelExact`** — when `true`, the offscreen framebuffer is pinned to exactly `width × height` pixels regardless of the host display's device pixel ratio. **Electron ≥ 41:** trivially satisfied and effectively a no-op — `createTextureBridge` already pins `offscreen.deviceScaleFactor: 1`, so the framebuffer is always exact whether or not this option is set. **Electron 40:** without it, a Retina (scaleFactor 2) or Windows-scaled (150% / 175%) display produces a framebuffer larger than the declared sender size, which typically shows up as black/garbled output in the receiver (see the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling)). The sender is always registered at the requested pixel size, so receivers see the dimensions you asked for. Note: non-divisible scale ratios (e.g. `1920 / 1.75`) can leave a 1-pixel discrepancy, and only the primary display's scaleFactor at construction time is honored — call `resize()` to re-apply after a DPI change.
 
 #### `TextureBridge`
 
@@ -1048,6 +1050,25 @@ win.webContents.on("paint", (event) => {
   }
 });
 ```
+
+## Migration: Electron 42 / OSR device scale
+
+Electron 42 changed offscreen rendering's default device scale factor to `1.0`
+([breaking change](https://www.electronjs.org/docs/latest/breaking-changes)).
+From the release containing this change, `createTextureBridge` pins
+`offscreen.deviceScaleFactor: 1` on Electron ≥ 41, making `width`/`height`
+mean exact pixels on every display.
+
+- **If you used `pixelExact: true`** (e.g. on Electron 40): keep it — it is a
+  no-op on Electron ≥ 41 and still required on 40.
+- **If you worked around scaling yourself** (`force-device-scale-factor=1`,
+  manual DIP math, removing `pixelExact` after a quarter-resolution output on
+  Electron 42): those workarounds are no longer needed once you upgrade.
+- **If you intentionally want a scaled framebuffer**, pass your own
+  `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` —
+  a user-supplied `offscreen` block always wins.
+
+Empirical background: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`.
 
 ## Migration: Explicit Disposal (v0.6+)
 

--- a/docs/superpowers/plans/2026-08-11-esm-shim-guard-and-frame-dropped.md
+++ b/docs/superpowers/plans/2026-08-11-esm-shim-guard-and-frame-dropped.md
@@ -1,0 +1,859 @@
+# ESM Shim Guard + frameDropped Event Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (a) ESM ビルドの `__dirname` shim が消えたらビルドが落ちる回帰ガードを追加し、(b) paint フレームの silent drop を `PaintDefect` union + `frameDropped` イベントとして観測可能にする。
+
+**Architecture:** ガードは「dist の `.mjs` に `__dirname` 参照があるなら同ファイル内に shim 定義（`const __dirname =`）が必ずある」という不変条件を build スクリプト最終段で検査する純関数 + CLI。#2 は core の `sendTextureFromPaintEvent` の返り値を `void → PaintDefect | undefined` に変え（呼び出し側後方互換）、renderer の `handlePaint` が defect を受けて連続同一 reason をデデュープしつつ `frameDropped` を emit する。公開 API に neverthrow Result は出さない（プレーンな tagged union のみ）。
+
+**Tech Stack:** pnpm workspace / vitest / tsdown（`shims: true` 済み）/ tsgo（`pnpm typecheck`）/ oxlint+oxfmt（`pnpm lint` / `pnpm fmt`）
+
+## Global Constraints
+
+- ベースは **main**。開始前に `git fetch origin main && git pull --ff-only origin main`（`.claude/rules/git-workflow.md`）
+- ブランチ名: `feat/frame-dropped-event`
+- **未マージ stacked PR #58–#64 が `packages/core/src/index.ts` の同関数を触っている。** 衝突を最小化するため、`sendTextureFromPaintEvent` の diff は必要最小限にし、既存の `function` 宣言スタイル・`Number(...)`・`String(err)` 等の既存行は**変更しない**（スタイル移行は PR #58/#64 の領分）
+- **neverthrow をこの作業で導入しない**（PR #64 の領分）。defect は素の tagged union で表現
+- 公開 API から neverthrow `Result` を返さない（memory: neverthrow-api-boundary）
+- 各タスク完了時に `pnpm lint && pnpm typecheck` を通すこと（`.claude/rules/coding-rules.md`）。`npx tsc` 直接実行は禁止
+- コミットは本計画に書かれたステップでのみ行う。main への直接コミット禁止。マージ・push は指示があるまで行わない
+- 実装完了後は difit を起動してユーザーにレビュー依頼する（Task 5）
+
+## File Structure
+
+| ファイル | 役割 |
+|---|---|
+| `packages/renderer/scripts/esm-shim-guard.mjs` | 新規。純関数 `findUnshimmedSources` + CLI（build 最終段で実行） |
+| `packages/renderer/scripts/esm-shim-guard.d.mts` | 新規。上記の型宣言（tsgo 用） |
+| `packages/renderer/src/__tests__/esm-shim-guard.test.ts` | 新規。純関数のユニットテスト |
+| `packages/renderer/package.json` | 変更。`build` スクリプトにガード実行を追加 |
+| `packages/core/src/types.ts` | 変更。`PaintDefect` union を追加 |
+| `packages/core/src/index.ts` | 変更。`sendTextureFromPaintEvent` が defect を返す。`PaintDefect` を re-export |
+| `packages/core/src/__tests__/index.test.ts` | 変更。返り値のテストを追加 |
+| `packages/renderer/src/types.ts` | 変更。`BridgeEvents` に `frameDropped` を追加 |
+| `packages/renderer/src/bridge.ts` | 変更。`TextureBridgeImpl` を export（テスト seam）、`handlePaint` の defect 配線 + デデュープ |
+| `packages/renderer/src/__tests__/bridge.test.ts` | 変更。`handlePaint` の frameDropped テストを追加 |
+| `packages/renderer/src/index.ts` | 変更。`PaintDefect` 型を re-export |
+| `README.md` | 変更。`frameDropped` / 返り値のドキュメント |
+
+---
+
+### Task 1: ブランチ準備 + ESM shim 回帰ガード
+
+**Files:**
+- Create: `packages/renderer/scripts/esm-shim-guard.mjs`
+- Create: `packages/renderer/scripts/esm-shim-guard.d.mts`
+- Test: `packages/renderer/src/__tests__/esm-shim-guard.test.ts`
+- Modify: `packages/renderer/package.json`（`scripts.build`）
+
+**Interfaces:**
+- Produces: `findUnshimmedSources(sources: readonly { path: string; content: string }[]): string[]` — `__dirname` を参照するのに `const __dirname =` 定義を持たない source の path 一覧を返す
+
+- [ ] **Step 1: main を最新化してブランチ作成**
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+git switch -c feat/frame-dropped-event
+```
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`packages/renderer/src/__tests__/esm-shim-guard.test.ts` を新規作成:
+
+```typescript
+import { describe, expect, it } from "vitest";
+
+import { findUnshimmedSources } from "../../scripts/esm-shim-guard.mjs";
+
+const SHIMMED = `
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+const getFilename = () => fileURLToPath(import.meta.url);
+const getDirname = () => path.dirname(getFilename());
+const __dirname = /* @__PURE__ */ getDirname();
+const asset = path.join(__dirname, "assets", "preview.html");
+`;
+
+const UNSHIMMED = `
+import path from "path";
+const asset = path.join(__dirname, "assets", "preview.html");
+`;
+
+const NO_DIRNAME = `
+export const add = (a, b) => a + b;
+`;
+
+describe("findUnshimmedSources", () => {
+  it("flags a source that references __dirname without defining it", () => {
+    const result = findUnshimmedSources([{ path: "index.mjs", content: UNSHIMMED }]);
+    expect(result).toEqual(["index.mjs"]);
+  });
+
+  it("passes a source whose __dirname reference is backed by a shim definition", () => {
+    const result = findUnshimmedSources([{ path: "index.mjs", content: SHIMMED }]);
+    expect(result).toEqual([]);
+  });
+
+  it("passes a source that never references __dirname", () => {
+    const result = findUnshimmedSources([{ path: "util.mjs", content: NO_DIRNAME }]);
+    expect(result).toEqual([]);
+  });
+
+  it("reports only the offending files among a mixed set", () => {
+    const result = findUnshimmedSources([
+      { path: "a.mjs", content: SHIMMED },
+      { path: "b.mjs", content: UNSHIMMED },
+      { path: "c.mjs", content: NO_DIRNAME },
+    ]);
+    expect(result).toEqual(["b.mjs"]);
+  });
+});
+```
+
+- [ ] **Step 3: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- esm-shim-guard
+```
+
+Expected: FAIL — `Cannot find module '../../scripts/esm-shim-guard.mjs'`
+
+- [ ] **Step 4: ガード本体を実装**
+
+`packages/renderer/scripts/esm-shim-guard.mjs` を新規作成:
+
+```javascript
+/**
+ * Regression guard for the ESM `__dirname` shim (renderer 0.13.1 fix).
+ *
+ * PreviewManager resolves bundled assets via `__dirname`, which only exists in
+ * the ESM output because tsdown injects a shim (`shims: true` in
+ * tsdown.config.mts). If that flag is ever dropped, the .mjs build throws
+ * `ReferenceError: __dirname is not defined` at import time under an ESM
+ * Electron main — exactly the 0.13.0 bug consumers had to patch around.
+ *
+ * Invariant checked here: every dist .mjs that references `__dirname` must
+ * also define it (`const __dirname = ...` — the shape of tsdown's shim).
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const findUnshimmedSources = (sources) =>
+  sources
+    .filter(({ content }) => /\b__dirname\b/.test(content) && !/const __dirname\s*=/.test(content))
+    .map(({ path }) => path);
+
+const invokedAsScript =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsScript) {
+  const distDir = new URL("../dist/", import.meta.url);
+  const entries = await readdir(distDir, { recursive: true });
+  const mjsPaths = entries.filter((entry) => entry.endsWith(".mjs"));
+  const sources = await Promise.all(
+    mjsPaths.map(async (entryPath) => ({
+      path: entryPath,
+      content: await readFile(new URL(entryPath, distDir), "utf8"),
+    })),
+  );
+  const offenders = findUnshimmedSources(sources);
+  if (offenders.length > 0) {
+    console.error(
+      `[esm-shim-guard] ESM output references __dirname without a shim: ${offenders.join(", ")}\n` +
+        `[esm-shim-guard] Check that tsdown.config.mts still sets \`shims: true\`.`,
+    );
+    process.exit(1);
+  }
+  console.log(`[esm-shim-guard] OK — ${mjsPaths.length} .mjs file(s) checked`);
+}
+```
+
+`packages/renderer/scripts/esm-shim-guard.d.mts` を新規作成:
+
+```typescript
+export declare const findUnshimmedSources: (
+  sources: readonly { readonly path: string; readonly content: string }[],
+) => string[];
+```
+
+- [ ] **Step 5: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- esm-shim-guard
+```
+
+Expected: PASS（4 件）
+
+- [ ] **Step 6: build スクリプトに配線**
+
+`packages/renderer/package.json` の `scripts.build` を変更:
+
+```diff
+-    "build": "tsdown && cp -r src/assets dist/assets",
++    "build": "tsdown && cp -r src/assets dist/assets && node scripts/esm-shim-guard.mjs",
+```
+
+- [ ] **Step 7: 実ビルドでガードが green になることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer build
+```
+
+Expected: ビルド成功、最後に `[esm-shim-guard] OK — N .mjs file(s) checked` が出力される
+
+- [ ] **Step 8: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+Expected: どちらも成功
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/renderer/scripts/esm-shim-guard.mjs packages/renderer/scripts/esm-shim-guard.d.mts packages/renderer/src/__tests__/esm-shim-guard.test.ts packages/renderer/package.json
+git commit -m "test(renderer): guard ESM __dirname shim in build output"
+```
+
+---
+
+### Task 2: core — `PaintDefect` union と `sendTextureFromPaintEvent` の返り値
+
+**Files:**
+- Modify: `packages/core/src/types.ts`（末尾に追加）
+- Modify: `packages/core/src/index.ts:42-67`
+- Test: `packages/core/src/__tests__/index.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type PaintDefect = { readonly reason: "no-texture" } | { readonly reason: "no-nt-handle" } | { readonly reason: "no-io-surface" } | { readonly reason: "unsupported-platform"; readonly platform: NodeJS.Platform }`（`packages/core/src/types.ts` から export、`packages/core/src/index.ts` で re-export）
+  - `sendTextureFromPaintEvent(sender, textureInfo): PaintDefect | undefined` — 送出成功時は `undefined`、drop 時は defect を返す。**throw の挙動（sender 停止後の native throw など）は従来どおり変更しない**
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/core/src/__tests__/index.test.ts` の `describe("sendTextureFromPaintEvent", ...)` 内に追加。既存の `it("does nothing when textureInfo is undefined", ...)` は返り値の assert を足して次の内容に**置き換える**:
+
+```typescript
+  it("returns a no-texture defect when textureInfo is undefined", async () => {
+    const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+    const sender = new TextureSender("Test", 1920, 1080);
+
+    const defect = sendTextureFromPaintEvent(sender, undefined);
+    expect(defect).toEqual({ reason: "no-texture" });
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockSendSurface).not.toHaveBeenCalled();
+  });
+```
+
+同じ describe 内に以下 4 件を追加（platform の差し替えは既存テストと同じ `Object.defineProperty` + `try/finally` パターン）:
+
+```typescript
+  it("returns undefined on successful darwin send", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toBeUndefined();
+      expect(mockSendSurface).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns a no-io-surface defect on darwin when the handle lacks ioSurface", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: {},
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toEqual({ reason: "no-io-surface" });
+      expect(mockSendSurface).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns a no-nt-handle defect on win32 when the handle lacks ntHandle", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: {},
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toEqual({ reason: "no-nt-handle" });
+      expect(mockSend).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns an unsupported-platform defect on linux", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
+
+      expect(sendTextureFromPaintEvent(sender, textureInfo)).toEqual({
+        reason: "unsupported-platform",
+        platform: "linux",
+      });
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockSendSurface).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-core test
+```
+
+Expected: FAIL — 新テスト 5 件が `expected undefined to deeply equal { reason: ... }` で落ちる（既存テストは green のまま）
+
+- [ ] **Step 3: `PaintDefect` を types.ts に追加**
+
+`packages/core/src/types.ts` の末尾に追加:
+
+```typescript
+/**
+ * Reason a paint event could not be forwarded to the sender.
+ *
+ * This is a modeled no-op, not an error: the paint pipeline continues, but the
+ * frame was dropped. Callers may surface it (e.g. the high-level bridge emits
+ * it as a `frameDropped` event) instead of the drop being silent.
+ */
+export type PaintDefect =
+  | { readonly reason: "no-texture" }
+  | { readonly reason: "no-nt-handle" }
+  | { readonly reason: "no-io-surface" }
+  | { readonly reason: "unsupported-platform"; readonly platform: NodeJS.Platform };
+```
+
+- [ ] **Step 4: `sendTextureFromPaintEvent` を変更**
+
+`packages/core/src/index.ts` — import type に `PaintDefect` を追加し、type re-export（39 行目）にも追加:
+
+```typescript
+import type {
+  TextureInfo,
+  PaintTexture,
+  Platform,
+  PixelFormat,
+  SenderInfo,
+  ReceivedFrame,
+  PaintDefect,
+} from "./types";
+```
+
+```typescript
+export type { TextureInfo, PaintTexture, Platform, PixelFormat, SenderInfo, ReceivedFrame, PaintDefect };
+```
+
+関数本体（42–67 行目）を次に置き換える。**既存の行はガードの return 値と JSDoc 以外変更しない**（`function` 宣言・`Number(...)` は据え置き — 未マージ PR #58/#64 との衝突最小化）:
+
+```typescript
+/**
+ * Send a texture from an Electron paint event to Syphon/Spout.
+ *
+ * Handles platform detection and buffer extraction automatically.
+ *
+ * @returns `undefined` when the texture was handed to the sender, or a
+ * {@link PaintDefect} describing why the frame was dropped. Drops are normal
+ * no-ops (e.g. Chromium delivered a paint without a shareable handle), not
+ * errors — but callers should surface them instead of letting output go
+ * silently black. Native send failures still throw as before.
+ */
+export function sendTextureFromPaintEvent(
+  sender: InstanceType<typeof TextureSender>,
+  textureInfo: TextureInfo | undefined,
+): PaintDefect | undefined {
+  if (!textureInfo) return { reason: "no-texture" };
+  const { handle, codedSize } = textureInfo;
+
+  if (process.platform === "win32") {
+    const ntHandle = handle.ntHandle;
+    if (!ntHandle || !Buffer.isBuffer(ntHandle)) return { reason: "no-nt-handle" };
+    const handleValue = Number(ntHandle.readBigInt64LE(0));
+    sender.send(handleValue, codedSize.width, codedSize.height);
+    return undefined;
+  }
+
+  if (process.platform === "darwin") {
+    const ioSurface = handle.ioSurface;
+    if (!ioSurface) return { reason: "no-io-surface" };
+    sender.sendSurface(ioSurface, codedSize.width, codedSize.height);
+    return undefined;
+  }
+
+  return { reason: "unsupported-platform", platform: process.platform };
+}
+```
+
+- [ ] **Step 5: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-core test
+```
+
+Expected: PASS（既存含め全件）
+
+- [ ] **Step 6: core を再ビルド + lint / typecheck**
+
+renderer は workspace の core を **dist の型**（`dist/index.d.cts` / `.d.mts`）で解決するため、ここで再ビルドしないと Task 3 の renderer 側 typecheck が旧シグネチャ（`void` 返り）のままになり型エラーになる:
+
+```bash
+pnpm --filter @napolab/texture-bridge-core build
+pnpm lint && pnpm typecheck
+```
+
+Expected: すべて成功
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/types.ts packages/core/src/index.ts packages/core/src/__tests__/index.test.ts
+git commit -m "feat(core): return PaintDefect from sendTextureFromPaintEvent instead of silent drop"
+```
+
+---
+
+### Task 3: renderer — `frameDropped` イベント + デデュープ
+
+**Files:**
+- Modify: `packages/renderer/src/types.ts`（`BridgeEvents`、75–82 行目付近）
+- Modify: `packages/renderer/src/bridge.ts`（`TextureBridgeImpl` の export、`handlePaint`、フィールド追加）
+- Test: `packages/renderer/src/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 の `PaintDefect`（`@napolab/texture-bridge-core` から import type）と `sendTextureFromPaintEvent(): PaintDefect | undefined`
+- Produces:
+  - `BridgeEvents` に `frameDropped: [defect: PaintDefect]` を追加
+  - `TextureBridgeImpl` を named export（テスト seam。パッケージ index からは非公開のまま）
+  - `handlePaint(event: { texture?: PaintTexture }): void` — 引数型を実際に使う shape に絞る（`PaintEvent` は非公開のままで dts エラーを回避）
+  - デデュープ規約: **同一 `reason` の連続 defect は 1 回だけ emit。送出成功で状態リセット**（60fps での持続 defect が毎フレーム emit されるスパムを防ぐ。reason が変われば即 emit）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/renderer/src/__tests__/bridge.test.ts` — import 部を次のように変更:
+
+```typescript
+import { buildBrowserWindowOptions, computeDipSize, TextureBridgeImpl } from "../bridge";
+import { BrowserWindow } from "electron";
+import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
+import type { PaintDefect } from "@napolab/texture-bridge-core";
+import type { TextureBridgeOptions } from "../types";
+```
+
+ファイル末尾に describe を追加:
+
+```typescript
+describe("TextureBridgeImpl.handlePaint — frameDropped", () => {
+  const sendMock = vi.mocked(sendTextureFromPaintEvent);
+
+  const makeBridge = () =>
+    new TextureBridgeImpl(new BrowserWindow(), new TextureSender("t", 16, 9), null, baseOpts);
+
+  const makeTexture = () => ({
+    textureInfo: {
+      pixelFormat: "bgra" as const,
+      codedSize: { width: 16, height: 9 },
+      visibleRect: { x: 0, y: 0, width: 16, height: 9 },
+      handle: {},
+    },
+    release: vi.fn(),
+  });
+
+  const collectDropped = (bridge: TextureBridgeImpl) => {
+    const dropped: PaintDefect[] = [];
+    bridge.on("frameDropped", (defect) => {
+      dropped.push(defect);
+    });
+    return dropped;
+  };
+
+  it("emits a no-texture defect when the paint event has no texture", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    bridge.handlePaint({ texture: undefined });
+
+    expect(dropped).toEqual([{ reason: "no-texture" }]);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("emits the defect returned by sendTextureFromPaintEvent and still releases the texture", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+    const texture = makeTexture();
+
+    bridge.handlePaint({ texture });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }]);
+    expect(texture.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes consecutive defects with the same reason", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }]);
+  });
+
+  it("re-emits after a successful send resets the dedupe state", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    sendMock.mockReturnValue(undefined);
+    bridge.handlePaint({ texture: makeTexture() });
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }, { reason: "no-nt-handle" }]);
+  });
+
+  it("emits immediately when the defect reason changes", () => {
+    sendMock.mockReset();
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+
+    sendMock.mockReturnValue({ reason: "no-nt-handle" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    sendMock.mockReturnValue({ reason: "no-io-surface" });
+    bridge.handlePaint({ texture: makeTexture() });
+
+    expect(dropped).toEqual([{ reason: "no-nt-handle" }, { reason: "no-io-surface" }]);
+  });
+
+  it("does not emit frameDropped on a successful send", () => {
+    sendMock.mockReset();
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    const dropped = collectDropped(bridge);
+    const texture = makeTexture();
+
+    bridge.handlePaint({ texture });
+
+    expect(dropped).toEqual([]);
+    expect(texture.release).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: FAIL — `TextureBridgeImpl` が bridge.ts から export されていない（import エラー）
+
+- [ ] **Step 3: `BridgeEvents` に `frameDropped` を追加**
+
+`packages/renderer/src/types.ts` — 先頭の import に追加:
+
+```typescript
+import type { PaintDefect } from "@napolab/texture-bridge-core";
+```
+
+`BridgeEvents`（75–82 行目）を変更:
+
+```typescript
+/** Events emitted by TextureBridge */
+export interface BridgeEvents {
+  fps: [fps: number];
+  ready: [];
+  error: [error: Error];
+  /**
+   * A paint frame was dropped before reaching the sender (missing texture /
+   * missing platform handle / unsupported platform). Not an error — but if
+   * this fires persistently the output is black on the receiving side.
+   * Consecutive drops with the same reason are deduped: the event fires on
+   * the first occurrence and again only after a successful send or a reason
+   * change.
+   */
+  frameDropped: [defect: PaintDefect];
+  disposed: [];
+  resize: [width: number, height: number];
+}
+```
+
+- [ ] **Step 4: `bridge.ts` を変更**
+
+(a) import に `PaintDefect` を追加（既存の core import 文に足す）:
+
+```typescript
+import {
+  TextureSender,
+  sendTextureFromPaintEvent,
+  type PaintTexture,
+  type PaintDefect,
+} from "@napolab/texture-bridge-core";
+```
+
+(b) クラス宣言（40 行目）を export に変更し、JSDoc を付ける:
+
+```typescript
+/** Exported for unit tests — not part of the package's public entry point. */
+export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
+```
+
+(c) フィールドを追加（`private _disposed = false;` の直後）:
+
+```typescript
+  private lastDropReason: PaintDefect["reason"] | null = null;
+```
+
+(d) private メソッドを追加（`handlePaint` の直前。class メソッドは shorthand — `.claude/rules/function-style.md`）:
+
+```typescript
+  /** Emit `frameDropped`, deduping consecutive drops with the same reason. */
+  private emitFrameDropped(defect: PaintDefect): void {
+    if (defect.reason === this.lastDropReason) return;
+    this.lastDropReason = defect.reason;
+    this.emit("frameDropped", defect);
+  }
+```
+
+(e) `handlePaint`（74–96 行目付近）を次に置き換える。引数型を実使用 shape に絞る（`PaintEvent` は非公開のまま）。`catch` 節と fps 部分は既存のまま:
+
+```typescript
+  /** Handle a paint event from the offscreen BrowserWindow. */
+  handlePaint(event: { texture?: PaintTexture }): void {
+    const texture = event.texture;
+    if (!texture?.textureInfo) {
+      texture?.release?.();
+      this.emitFrameDropped({ reason: "no-texture" });
+      return;
+    }
+
+    // If we've been disposed between the paint event and this callback, the
+    // underlying sender has been stopped and calling into it would throw
+    // "TextureSender has been stopped" for every in-flight paint. Drop the
+    // texture cleanly instead of emitting a stream of teardown errors.
+    if (this._disposed) {
+      texture.release?.();
+      return;
+    }
+
+    try {
+      const defect = sendTextureFromPaintEvent(this.sender, texture.textureInfo);
+      if (defect === undefined) {
+        this.lastDropReason = null;
+      } else {
+        this.emitFrameDropped(defect);
+      }
+      this.previewManager?.sendFrame(texture);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emit("error", error);
+    } finally {
+      texture.release?.();
+    }
+```
+
+（`handlePaint` 内のこれ以降 — `if (this._disposed) return;` と fps カウンタ — は既存のまま）
+
+注: `createTextureBridge` 内の `bridge.handlePaint(event)` 呼び出し（260 行目付近）は `PaintEvent` が構造的に `{ texture?: PaintTexture }` を満たすため変更不要。preview への `sendFrame` は defect 時も従来どおり呼ぶ（現行の挙動維持 — 従来も silent return 後に呼ばれていた）。
+
+- [ ] **Step 5: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: PASS（新 6 件 + 既存全件）
+
+- [ ] **Step 6: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+Expected: どちらも成功
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/renderer/src/types.ts packages/renderer/src/bridge.ts packages/renderer/src/__tests__/bridge.test.ts
+git commit -m "feat(renderer): emit frameDropped event for silently dropped paint frames"
+```
+
+---
+
+### Task 4: 公開面の仕上げ — re-export + README
+
+**Files:**
+- Modify: `packages/renderer/src/index.ts`
+- Modify: `README.md`（`TextureBridge` セクション 584 行目付近、`sendTextureFromPaintEvent` セクション 757 行目付近、Troubleshooting「Black texture output」986 行目付近）
+
+**Interfaces:**
+- Consumes: Task 2 の `PaintDefect`、Task 3 の `frameDropped`
+- Produces: `@napolab/texture-bridge-renderer` から `PaintDefect` 型が import 可能になる
+
+注: `docs/ja/INSTALLATION.md` のコードサンプルは返り値を無視する形のままで有効なので**変更しない**。CHANGELOG は release-please 管理のため手動編集しない。
+
+- [ ] **Step 1: renderer index から `PaintDefect` を re-export**
+
+`packages/renderer/src/index.ts` に追加:
+
+```typescript
+export type { PaintDefect } from "@napolab/texture-bridge-core";
+```
+
+- [ ] **Step 2: README — `TextureBridge` interface スニペットを更新**
+
+`README.md` の `#### TextureBridge` 内 interface スニペット（589 行目付近）の `on(event: "error", ...)` 行の直後に追加:
+
+```typescript
+  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
+```
+
+interface スニペットの直後に説明を追加:
+
+```markdown
+`frameDropped` fires when a paint frame is dropped before reaching the sender
+(`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`).
+It is not an error — but if it fires persistently, receivers see black output.
+Consecutive drops with the same reason are deduped: the event fires once, and
+again only after a successful send or a reason change.
+```
+
+- [ ] **Step 3: README — `sendTextureFromPaintEvent` セクションを更新**
+
+`#### sendTextureFromPaintEvent(sender, textureInfo)`（757 行目付近）の本文を次に置き換え:
+
+```markdown
+Low-level convenience function that handles platform-specific texture handle extraction and forwarding.
+
+- **macOS**: Reads `handle.ioSurface` buffer → calls `sender.sendSurface()`
+- **Windows**: Reads `handle.ntHandle` buffer as BigInt64LE → calls `sender.send()`
+
+Returns `undefined` when the frame was handed to the sender, or a `PaintDefect`
+(`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`)
+when the frame was dropped. Drops are normal no-ops, not errors — surface them
+in your own paint loop the same way `createTextureBridge` does with its
+`frameDropped` event. Native send failures still throw.
+```
+
+- [ ] **Step 4: README — Troubleshooting に診断手順を追記**
+
+`### Black texture output`（986 行目付近）のリストに 1 項目追加:
+
+```markdown
+- Subscribe to `bridge.on("frameDropped", ...)` (or check the return value of
+  `sendTextureFromPaintEvent`) — a persistent `no-nt-handle` / `no-io-surface`
+  reason means Chromium is not delivering a shareable GPU handle, which
+  otherwise manifests only as black output.
+```
+
+- [ ] **Step 5: lint / typecheck / 全テスト**
+
+```bash
+pnpm lint && pnpm typecheck && pnpm --filter @napolab/texture-bridge-core test && pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: すべて成功
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/index.ts README.md
+git commit -m "docs: document frameDropped event and PaintDefect return value"
+```
+
+---
+
+### Task 5: 最終検証 + レビュー依頼
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: フルビルドで shim ガードを含む全体を検証**
+
+```bash
+pnpm --filter @napolab/texture-bridge-core build
+pnpm --filter @napolab/texture-bridge-renderer build
+```
+
+Expected: 両方成功。renderer 側は `[esm-shim-guard] OK` を出力
+
+- [ ] **Step 2: 全テスト + lint + typecheck の最終確認**
+
+```bash
+pnpm lint && pnpm typecheck && pnpm --filter @napolab/texture-bridge-core test && pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: すべて成功
+
+- [ ] **Step 3: difit でレビュー依頼**
+
+```bash
+npx difit HEAD main
+```
+
+ユーザーにレビューを依頼し、指摘があれば対応する。**push / PR 作成はユーザーの指示を待つ。**
+
+---
+
+## 実装しないこと（スコープ外）
+
+- neverthrow の core への導入（PR #64 の領分。#64 が先にマージされた場合は、`safeDispatchSend` の `.match` の ok 側で `undefined`、ガード分岐で defect を返す形に本実装を rebase する）
+- `frameDropped` のカウンタ・集計 API（消費者側で数えられる）
+- `TextureInfo.handle` の公開型変更（Electron 互換のまま。内部分類は今回のガード分岐で十分）
+- Cannelloni 側の 0.13.1 アップグレード + patch 撤去（別リポジトリの作業）

--- a/docs/superpowers/plans/2026-08-11-osr-scale-policy.md
+++ b/docs/superpowers/plans/2026-08-11-osr-scale-policy.md
@@ -1,0 +1,617 @@
+# OSR Scale Policy（Electron 41+ deviceScaleFactor 固定）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Electron 42 の「OSR デフォルト device scale = 1.0」breaking change に対応し、Electron ≥ 41 では `offscreen.deviceScaleFactor: 1` を明示固定して `width/height` = pixels の契約を全環境で決定論化する（`pixelExact` は ≥41 で自明に満たされる no-op に）。
+
+**Architecture:** 判定は純関数 3 つ（`resolveElectronMajor` / `resolveOsrScalePolicy` / `resolveWindowDipSize`）に分離して単体テスト可能にする。`buildBrowserWindowOptions` が policy を受けて offscreen prefs と `enableLargerThanScreen` を出し分け、`createTextureBridge` / `resize()` は `resolveWindowDipSize` でウィンドウ寸法を決める。Electron 40（`deviceScaleFactor` 無視、実測済み）は現行ロジック完全維持。根拠は `reports/2026-08-11-pixelexact-osr-scale-investigation.md` の実測マトリクス。
+
+**Tech Stack:** pnpm / vitest / tsgo / oxlint+oxfmt。electron mock は既存 bridge.test.ts の `vi.mock("electron", ...)` を拡張。
+
+## Global Constraints
+
+- ベースは **main**（マージ済み #67 込み）。開始前に `git fetch origin main && git pull --ff-only origin main`
+- ブランチ名: `feat/osr-scale-policy`
+- 境界は **major ≥ 41 → "unit-scale"**（`deviceScaleFactor` オプションは 41 で追加・実測で動作確認済み。40 では無視されるため "device-scale" = 現行ロジック）
+- ユーザーが `webPreferences.offscreen` を明示指定した場合はそれが**全体として**勝つ（現行の spread 順 `offscreen: {...}, ...webPreferences` を維持）
+- Sender は常に pixel-space（`new TextureSender(name, width, height)`）— 変更しない
+- 各タスク完了時 `pnpm lint && pnpm typecheck`（tsc 直接実行禁止）
+- コミットは本計画のステップでのみ。CLAUDE.md / tasks.md を含めない。push は指示があるまでしない
+- semver 注意: Electron 41 ユーザーはデフォルト挙動が変わる（×2 → ×1 テクスチャ）。0.x の feat として README に移行節を書く
+- 実装完了後 difit でレビュー依頼（Task 5）
+
+## File Structure
+
+| ファイル | 役割 |
+|---|---|
+| `packages/renderer/src/bridge.ts` | policy 純関数 3 つの追加、`buildBrowserWindowOptions` に policy 引数、`createTextureBridge`/`resize` の配線 |
+| `packages/renderer/src/types.ts` | `pixelExact` JSDoc の版別注記 |
+| `packages/renderer/src/__tests__/bridge.test.ts` | policy 純関数・options 出し分け・resize のテスト追加、electron mock の `getPrimaryDisplay` を vi.fn 化 |
+| `packages/renderer/scripts/osr-scale-probe.cjs` | 調査で使った実測 probe を再検証用にコミット |
+| `README.md` / `lang/ja/README.md` | Retina/DPI 節の版別書き直し + Electron 42 移行節 |
+
+---
+
+### Task 1: policy 純関数（resolveElectronMajor / resolveOsrScalePolicy / resolveWindowDipSize）
+
+**Files:**
+- Modify: `packages/renderer/src/bridge.ts`（`computeDipSize` の直後に追加）
+- Test: `packages/renderer/src/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type OsrScalePolicy = "device-scale" | "unit-scale"`
+  - `resolveElectronMajor(versions: { electron?: string }): number` — parse 失敗時 0
+  - `resolveOsrScalePolicy(electronMajor: number): OsrScalePolicy` — `>= 41` で `"unit-scale"`
+  - `resolveWindowDipSize(options: Pick<TextureBridgeOptions, "width" | "height" | "pixelExact">, policy: OsrScalePolicy, scaleFactor: number): { width: number; height: number }`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/renderer/src/__tests__/bridge.test.ts` — import に追加:
+
+```typescript
+import {
+  buildBrowserWindowOptions,
+  computeDipSize,
+  resolveElectronMajor,
+  resolveOsrScalePolicy,
+  resolveWindowDipSize,
+  TextureBridgeImpl,
+} from "../bridge";
+```
+
+ファイル末尾に describe を追加:
+
+```typescript
+describe("resolveElectronMajor", () => {
+  it("parses the major version from a semver string", () => {
+    expect(resolveElectronMajor({ electron: "42.4.0" })).toBe(42);
+    expect(resolveElectronMajor({ electron: "40.2.1" })).toBe(40);
+  });
+
+  it("returns 0 when the electron version is missing or malformed", () => {
+    expect(resolveElectronMajor({})).toBe(0);
+    expect(resolveElectronMajor({ electron: "garbage" })).toBe(0);
+  });
+});
+
+describe("resolveOsrScalePolicy", () => {
+  it("selects device-scale for Electron 40 and below", () => {
+    expect(resolveOsrScalePolicy(40)).toBe("device-scale");
+    expect(resolveOsrScalePolicy(0)).toBe("device-scale");
+  });
+
+  it("selects unit-scale for Electron 41 and above", () => {
+    expect(resolveOsrScalePolicy(41)).toBe("unit-scale");
+    expect(resolveOsrScalePolicy(42)).toBe("unit-scale");
+  });
+});
+
+describe("resolveWindowDipSize", () => {
+  it("returns width/height untouched under unit-scale, even with pixelExact", () => {
+    const size = resolveWindowDipSize({ width: 1920, height: 1080, pixelExact: true }, "unit-scale", 2);
+    expect(size).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it("divides by scaleFactor under device-scale when pixelExact is set", () => {
+    const size = resolveWindowDipSize({ width: 1920, height: 1080, pixelExact: true }, "device-scale", 2);
+    expect(size).toEqual({ width: 960, height: 540 });
+  });
+
+  it("returns width/height untouched under device-scale without pixelExact", () => {
+    const size = resolveWindowDipSize({ width: 1920, height: 1080 }, "device-scale", 2);
+    expect(size).toEqual({ width: 1920, height: 1080 });
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: FAIL — `resolveElectronMajor` 等が export されていない（import エラー）
+
+- [ ] **Step 3: 実装**
+
+`packages/renderer/src/bridge.ts` — `computeDipSize` の直後に追加（top-level は arrow 関数 — `.claude/rules/function-style.md`。既存の `function` 宣言はリファクタ PR の領分なので触らない）:
+
+```typescript
+/**
+ * How the OSR compositor maps the window's DIP size to the shared-texture
+ * pixel size.
+ *
+ * - `"device-scale"` (Electron ≤ 40): the paint framebuffer is
+ *   `DIP × display.scaleFactor`, and `webPreferences.offscreen.deviceScaleFactor`
+ *   is ignored — `pixelExact` must pre-divide the window size to hit an exact
+ *   pixel count.
+ * - `"unit-scale"` (Electron ≥ 41): `offscreen.deviceScaleFactor` is honored
+ *   (and defaults to 1.0 from Electron 42), so we pin it to 1 and DIP == px
+ *   holds deterministically — no DIP division, `pixelExact` is trivially
+ *   satisfied.
+ *
+ * Empirical basis: reports/2026-08-11-pixelexact-osr-scale-investigation.md
+ * (measured on Electron 40.2.1 / 41.10.4 / 42.4.0, macOS Retina scaleFactor 2).
+ */
+export type OsrScalePolicy = "device-scale" | "unit-scale";
+
+/** Parse the Electron major version; 0 when missing or malformed. */
+export const resolveElectronMajor = (versions: { electron?: string }): number => {
+  const [major] = (versions.electron ?? "").split(".");
+  const parsed = parseInt(major ?? "", 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/** `offscreen.deviceScaleFactor` exists (and is honored) from Electron 41. */
+export const resolveOsrScalePolicy = (electronMajor: number): OsrScalePolicy =>
+  electronMajor >= 41 ? "unit-scale" : "device-scale";
+
+/**
+ * Window DIP size for the requested pixel size under the given policy.
+ * Under unit-scale DIP == px, so the size passes through; under device-scale
+ * only `pixelExact` pre-divides by the display scaleFactor (legacy behavior).
+ */
+export const resolveWindowDipSize = (
+  options: Pick<TextureBridgeOptions, "width" | "height" | "pixelExact">,
+  policy: OsrScalePolicy,
+  scaleFactor: number,
+): { width: number; height: number } => {
+  if (policy === "unit-scale") return { width: options.width, height: options.height };
+  if (options.pixelExact === true) return computeDipSize(options.width, options.height, scaleFactor);
+  return { width: options.width, height: options.height };
+};
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: PASS（新 7 件 + 既存全件）
+
+- [ ] **Step 5: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/bridge.ts packages/renderer/src/__tests__/bridge.test.ts
+git commit -m "feat(renderer): add OSR scale policy resolvers for Electron 41+ deviceScaleFactor"
+```
+
+---
+
+### Task 2: buildBrowserWindowOptions の policy 対応
+
+**Files:**
+- Modify: `packages/renderer/src/bridge.ts:217-243`（`buildBrowserWindowOptions`）
+- Test: `packages/renderer/src/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 の `OsrScalePolicy`
+- Produces: `buildBrowserWindowOptions(options: TextureBridgeOptions, policy: OsrScalePolicy): Electron.BrowserWindowConstructorOptions`
+  - unit-scale: `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` + **常に** `enableLargerThanScreen: true`（要求 px がディスプレイ DIP を超えても work-area クランプで縮まないように）
+  - device-scale: 現行どおり（`offscreen: { useSharedTexture: true }`、`pixelExact` 時のみ `enableLargerThanScreen`）
+  - ユーザー `webPreferences` の spread 位置は現行のまま（`offscreen` ごと上書き可能）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+既存の `describe("buildBrowserWindowOptions", ...)` は**全呼び出しに第 2 引数 `"device-scale"` を追加**して現行アサーションを維持する（現行挙動の回帰テストになる）。その上で新 describe を追加:
+
+```typescript
+describe("buildBrowserWindowOptions — OSR scale policy", () => {
+  it("pins offscreen.deviceScaleFactor to 1 under unit-scale", () => {
+    const out = buildBrowserWindowOptions(baseOpts, "unit-scale");
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true, deviceScaleFactor: 1 });
+  });
+
+  it("does not set deviceScaleFactor under device-scale", () => {
+    const out = buildBrowserWindowOptions(baseOpts, "device-scale");
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
+  });
+
+  it("always enables enableLargerThanScreen under unit-scale", () => {
+    const out = buildBrowserWindowOptions(baseOpts, "unit-scale");
+    expect(out.enableLargerThanScreen).toBe(true);
+  });
+
+  it("keeps enableLargerThanScreen gated on pixelExact under device-scale", () => {
+    expect(buildBrowserWindowOptions(baseOpts, "device-scale").enableLargerThanScreen).toBeUndefined();
+    expect(
+      buildBrowserWindowOptions({ ...baseOpts, pixelExact: true }, "device-scale").enableLargerThanScreen,
+    ).toBe(true);
+  });
+
+  it("lets a user-supplied webPreferences.offscreen win entirely", () => {
+    const out = buildBrowserWindowOptions(
+      { ...baseOpts, webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: 2 } } },
+      "unit-scale",
+    );
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true, deviceScaleFactor: 2 });
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: FAIL — 第 2 引数が未実装（型エラー or deviceScaleFactor 不在）
+
+- [ ] **Step 3: 実装**
+
+`buildBrowserWindowOptions` を次に置き換える（JSDoc は既存文の末尾に policy の段落を 1 つ追加）:
+
+```typescript
+export function buildBrowserWindowOptions(
+  options: TextureBridgeOptions,
+  policy: OsrScalePolicy,
+): Electron.BrowserWindowConstructorOptions {
+  const { width, height, webPreferences, includeAlpha, pixelExact } = options;
+
+  const offscreen =
+    policy === "unit-scale"
+      ? { useSharedTexture: true, deviceScaleFactor: 1 }
+      : { useSharedTexture: true };
+  const largerThanScreen = policy === "unit-scale" || pixelExact === true;
+
+  return {
+    width,
+    height,
+    show: false,
+    // `enableLargerThanScreen` is documented as macOS-only but is harmless on
+    // other platforms. Under unit-scale the DIP size equals the requested pixel
+    // size — which may exceed the display work area — so it is always set;
+    // under device-scale it is set only when `pixelExact` requests it.
+    ...(largerThanScreen ? { enableLargerThanScreen: true } : {}),
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      offscreen,
+      ...webPreferences,
+    },
+    // Hex `#RRGGBBAA` with alpha=0x00 is the explicit "fully transparent
+    // backdrop" signal Chromium honors on offscreen render surfaces. The
+    // `transparent: true` flag alone leaves the compositor painting opaque,
+    // so both keys must be applied together.
+    ...(includeAlpha ? { transparent: true, backgroundColor: "#00000000" } : {}),
+  };
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: PASS
+
+- [ ] **Step 5: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/bridge.ts packages/renderer/src/__tests__/bridge.test.ts
+git commit -m "feat(renderer): pin offscreen.deviceScaleFactor=1 under unit-scale policy"
+```
+
+---
+
+### Task 3: createTextureBridge / resize の配線
+
+**Files:**
+- Modify: `packages/renderer/src/bridge.ts`（`TextureBridgeImpl` constructor、`resize`、`createTextureBridge`）
+- Test: `packages/renderer/src/__tests__/bridge.test.ts`（electron mock の `getPrimaryDisplay` を vi.fn 化 + resize テスト）
+
+**Interfaces:**
+- Consumes: Task 1 の `resolveWindowDipSize` / `resolveOsrScalePolicy` / `resolveElectronMajor`、Task 2 の `buildBrowserWindowOptions(options, policy)`
+- Produces:
+  - `TextureBridgeImpl` constructor 第 5 引数 `policy: OsrScalePolicy = resolveOsrScalePolicy(resolveElectronMajor(process.versions))`（デフォルト付きなので既存テストの 4 引数呼び出しはそのまま通る）
+  - `resize()` / rollback が `resolveWindowDipSize(opts, this.policy, screen.getPrimaryDisplay().scaleFactor)` を使う
+  - `createTextureBridge` が policy を一度解決し、window 構築（`resolveWindowDipSize` で寸法決定 + `buildBrowserWindowOptions(…, policy)`）と `TextureBridgeImpl` に渡す
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+(a) electron mock の `screen` を可変化（ファイル先頭の `vi.mock("electron", ...)` を変更）:
+
+```typescript
+const getPrimaryDisplayMock = vi.fn(() => ({ scaleFactor: 1 }));
+
+vi.mock("electron", () => ({
+  app: { isReady: () => true },
+  BrowserWindow: class MockBrowserWindow {
+    setSize = vi.fn();
+    isDestroyed(): boolean {
+      return false;
+    }
+    close(): void {}
+  },
+  screen: {
+    getPrimaryDisplay: () => getPrimaryDisplayMock(),
+  },
+}));
+```
+
+（既存テストで `MockBrowserWindow` に追加済みのメソッドがあれば残す。`setSize` は resize テスト用に `vi.fn()` プロパティとして持たせ、インスタンスから参照する。**`MockTextureSender` にも `stop(): void {}` を追加すること** — `resize()` は `this.sender.stop()` と `new TextureSender(...)` を呼ぶため、無いと resize テストが throw する）
+
+(b) ファイル末尾に resize の describe を追加:
+
+```typescript
+describe("TextureBridgeImpl.resize — OSR scale policy", () => {
+  const makeBridgeWithPolicy = (policy: "device-scale" | "unit-scale", opts: TextureBridgeOptions) =>
+    new TextureBridgeImpl(new BrowserWindow(), new TextureSender("t", 16, 9), null, opts, policy);
+
+  it("sets the window to the raw pixel size under unit-scale even with pixelExact", () => {
+    getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+    const bridge = makeBridgeWithPolicy("unit-scale", { ...baseOpts, pixelExact: true });
+
+    bridge.resize(1280, 720);
+
+    expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(1280, 720);
+  });
+
+  it("divides the window size by scaleFactor under device-scale with pixelExact", () => {
+    getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+    const bridge = makeBridgeWithPolicy("device-scale", { ...baseOpts, pixelExact: true });
+
+    bridge.resize(1280, 720);
+
+    expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(640, 360);
+  });
+});
+```
+
+注: `bridge.renderWindow.setSize` の参照は mock クラスのインスタンスプロパティ（`setSize = vi.fn()`）。`TextureBridge` 型には `setSize` が無いので、テスト内では `new BrowserWindow()` を変数に取り、その `setSize` を assert する形にしてよい（`const win = new BrowserWindow(); const bridge = new TextureBridgeImpl(win, ...); expect(win.setSize).toHaveBeenCalledWith(...)`）。実装時にコンパイルが通る形を選ぶこと。
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: FAIL — constructor 第 5 引数が未実装 / resize が pixelExact 分岐のまま
+
+- [ ] **Step 3: 実装**
+
+(a) `TextureBridgeImpl` にフィールドと constructor 引数を追加:
+
+```typescript
+  private readonly policy: OsrScalePolicy;
+
+  constructor(
+    renderWindow: BrowserWindow,
+    sender: InstanceType<typeof TextureSender>,
+    previewManager: PreviewManager | null,
+    options: TextureBridgeOptions,
+    policy: OsrScalePolicy = resolveOsrScalePolicy(resolveElectronMajor(process.versions)),
+  ) {
+    super();
+    this._renderWindow = renderWindow;
+    this.sender = sender;
+    this.previewManager = previewManager;
+    this.options = options;
+    this.policy = policy;
+  }
+```
+
+(b) `resize()` 内の 2 箇所の DIP 計算を置き換え:
+
+```typescript
+    const dip = resolveWindowDipSize(this.options, this.policy, screen.getPrimaryDisplay().scaleFactor);
+    this._renderWindow.setSize(dip.width, dip.height);
+```
+
+rollback 側も同様:
+
+```typescript
+      const prevDip = resolveWindowDipSize(prevOpts, this.policy, screen.getPrimaryDisplay().scaleFactor);
+      this._renderWindow.setSize(prevDip.width, prevDip.height);
+```
+
+（`this.options = { ...this.options, width, height }` の更新タイミングは現行実装のまま — `resolveWindowDipSize` へは resize 後の新しい width/height が入っている options を渡す。現行コードが `computeDipSize(width, height, ...)` と引数直渡しなら、`resolveWindowDipSize({ ...this.options, width, height }, ...)` の形で等価にする）
+
+(c) `createTextureBridge` の window 構築部を置き換え:
+
+```typescript
+  const policy = resolveOsrScalePolicy(resolveElectronMajor(process.versions));
+
+  // ---- Offscreen BrowserWindow ----
+  // Window DIP size per the OSR scale policy: under unit-scale DIP == px so the
+  // requested size passes through; under device-scale (Electron ≤ 40) pixelExact
+  // pre-divides by the primary display's scaleFactor. The sender below always
+  // uses pixel-space dimensions.
+  const dip = resolveWindowDipSize(options, policy, screen.getPrimaryDisplay().scaleFactor);
+  const renderWindow = new BrowserWindow(buildBrowserWindowOptions({ ...options, ...dip }, policy));
+```
+
+`TextureBridgeImpl` 構築に policy を渡す:
+
+```typescript
+  const bridge = new TextureBridgeImpl(renderWindow, sender, previewManager, options, policy);
+```
+
+**注:** `createTextureBridge` 冒頭の destructure `const { name, width, height, frameRate = 60, rendererUrl, preview, pixelExact } = options;` から **`pixelExact` を削除する**こと（`resolveWindowDipSize` に移ったため未使用になり lint エラーになる）。`width`/`height` は sender 構築で引き続き使用する。
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: PASS（全件。既存 frameDropped テスト群は constructor デフォルト引数のため無変更で通る）
+
+- [ ] **Step 5: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/bridge.ts packages/renderer/src/__tests__/bridge.test.ts
+git commit -m "feat(renderer): apply OSR scale policy to window sizing and resize"
+```
+
+---
+
+### Task 4: ドキュメント（pixelExact JSDoc / README EN+JA / probe スクリプト）
+
+**Files:**
+- Modify: `packages/renderer/src/types.ts`（`pixelExact` JSDoc）
+- Modify: `README.md`（「macOS Retina and Windows DPI scaling」節 361–366 行付近、`TextureBridgeOptions` API ref、Migration 節の追加）
+- Modify: `lang/ja/README.md`（対応箇所のミラー）
+- Create: `packages/renderer/scripts/osr-scale-probe.cjs`（調査で使った probe をコピーしてコミット。冒頭コメントに `reports/2026-08-11-pixelexact-osr-scale-investigation.md` への参照を追記）
+
+**Interfaces:**
+- Consumes: Task 1–3 の実装済み挙動
+
+- [ ] **Step 1: `pixelExact` JSDoc に版別注記を追加**
+
+`packages/renderer/src/types.ts` の `pixelExact` JSDoc 冒頭（`Pin the offscreen framebuffer...` の段落の直後）に追加:
+
+```
+   * Electron ≥ 41: this option is trivially satisfied and effectively a no-op —
+   * the bridge pins `webPreferences.offscreen.deviceScaleFactor` to 1, so the
+   * framebuffer always lands at exactly `width × height` pixels regardless of
+   * display scaling (Electron 42 changed the OSR default device scale factor
+   * to 1.0; the bridge makes it explicit from 41 where the option first
+   * exists). The DIP-division described below applies only to Electron 40.
+```
+
+- [ ] **Step 2: README EN の Retina/DPI 節を版別に書き直し**
+
+`README.md` の `> ### macOS Retina and Windows DPI scaling` ブロックを次で置き換え:
+
+```markdown
+> ### macOS Retina and Windows DPI scaling
+>
+> ⚠️ **This is the #1 cause of a black or garbled output on Electron ≤ 40.** How the offscreen framebuffer relates to your requested `width × height` depends on the Electron version:
+>
+> - **Electron ≥ 41:** `createTextureBridge` pins `webPreferences.offscreen.deviceScaleFactor` to `1`, so the framebuffer is always exactly `width × height` pixels — display scaling does not affect the texture. (`Electron 42` changed the OSR default device scale factor to `1.0`; the bridge sets it explicitly from 41, where the option first appeared.) `pixelExact` is trivially satisfied and effectively a no-op.
+> - **Electron 40:** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer delivered to the shared texture is `width × height × display.scaleFactor`. On a macOS Retina display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture. Use `createTextureBridge({ pixelExact: true })` to absorb this, or handle DPR yourself on the low-level core path.
+>
+> **Low-level core** (manual `BrowserWindow` + `paint`) has no absorption on any version — on Electron ≥ 41 pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself; on Electron 40 keep the sender's declared size and the actual framebuffer size in agreement manually.
+```
+
+- [ ] **Step 3: README EN に移行節を追加**
+
+`## Migration: Explicit Disposal (v0.6+)` の直前に追加:
+
+```markdown
+## Migration: Electron 42 / OSR device scale
+
+Electron 42 changed offscreen rendering's default device scale factor to `1.0`
+([breaking change](https://www.electronjs.org/docs/latest/breaking-changes)).
+From the release containing this change, `createTextureBridge` pins
+`offscreen.deviceScaleFactor: 1` on Electron ≥ 41, making `width`/`height`
+mean exact pixels on every display.
+
+- **If you used `pixelExact: true`** (e.g. on Electron 40): keep it — it is a
+  no-op on Electron ≥ 41 and still required on 40.
+- **If you worked around scaling yourself** (`force-device-scale-factor=1`,
+  manual DIP math, removing `pixelExact` after a quarter-resolution output on
+  Electron 42): those workarounds are no longer needed once you upgrade.
+- **If you intentionally want a scaled framebuffer**, pass your own
+  `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` —
+  a user-supplied `offscreen` block always wins.
+
+Empirical background: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`.
+```
+
+- [ ] **Step 4: lang/ja/README.md に対応 3 箇所をミラー**
+
+EN の Retina/DPI 節・移行節・`pixelExact` 関連記述を対応位置に自然な日本語で反映（EN の挿入文を先に読み、忠実に翻訳）。
+
+- [ ] **Step 5: probe スクリプトをコミット対象として配置**
+
+調査で使った probe（`/private/tmp/.../scratchpad/osr-scale-probe.cjs` と同内容）を `packages/renderer/scripts/osr-scale-probe.cjs` として作成。冒頭コメントに追記:
+
+```javascript
+/**
+ * ...（既存ヘッダーコメント）...
+ *
+ * Findings recorded in reports/2026-08-11-pixelexact-osr-scale-investigation.md
+ * (Electron 40: paints at display scale, deviceScaleFactor ignored;
+ *  Electron 41: deviceScaleFactor honored, default = display scale;
+ *  Electron 42: default flipped to 1.0).
+ *
+ * Re-run: <electron binary> packages/renderer/scripts/osr-scale-probe.cjs <plain|dip> [--dsf-1] [--force-scale-1]
+ */
+```
+
+- [ ] **Step 6: 検証**
+
+```bash
+pnpm lint && pnpm typecheck && pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/renderer/src/types.ts README.md lang/ja/README.md packages/renderer/scripts/osr-scale-probe.cjs
+git commit -m "docs: version-specific OSR scaling behavior and Electron 42 migration guide"
+```
+
+---
+
+### Task 5: 実機検証 + 最終レビュー + difit
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: ビルド + 全テスト**
+
+```bash
+pnpm --filter @napolab/texture-bridge-core build && pnpm --filter @napolab/texture-bridge-renderer build
+pnpm lint && pnpm typecheck && pnpm --filter @napolab/texture-bridge-core test && pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: すべて成功（renderer build は `[esm-shim-guard] OK` を含む）
+
+- [ ] **Step 2: 実機スモーク（Electron 40 = example）**
+
+example（Electron 40）を起動し、fps が出ること・`frameDropped` が出ないことを確認して必ず kill する。40 は device-scale policy なので従来と同一挙動のはず。
+
+```bash
+pnpm --filter @napolab/texture-bridge-example dev   # バックグラウンド起動 → ログ確認 → 必ず process kill
+```
+
+- [ ] **Step 3: probe による policy 実証（Electron 42）**
+
+renderer をビルドした状態で、42 の Electron バイナリから `createTextureBridge` 相当の window options を検証する。最低限、コミットした probe を 42 で実行して `deviceScaleFactor: 1` の codedSize が要求 px と一致することを確認:
+
+```bash
+# scratchpad に electron@42 がある場合はそれを利用
+<electron42> packages/renderer/scripts/osr-scale-probe.cjs plain --dsf-1
+```
+
+Expected: `codedSize == 1920×1080`（scaleFactor 2 のディスプレイでも）
+
+- [ ] **Step 4: difit でレビュー依頼**
+
+```bash
+npx difit HEAD main
+```
+
+ユーザーにレビューを依頼。**push / PR 作成は指示を待つ。**
+
+---
+
+## 実装しないこと（スコープ外）
+
+- Electron 40 サポートの削除（peerDependencies は `>=40.0.0` のまま）
+- `pixelExact` オプションの削除（deprecated 扱いの文書化のみ。削除は次 major）
+- Windows 実機での display scaling 検証（レポートの残課題。CI では不可能）
+- core（低レベル）API への policy 自動適用（core は「吸収しない」契約 — README に手動指定方法を記載するのみ）

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -261,10 +261,12 @@ win.webContents.on("paint", (details) => {
 
 > ### macOS Retina と Windows DPI スケーリング
 >
-> ⚠️ **黒画面・崩れた出力の最大の原因です。** Chromium はオフスクリーン面を **DIP（デバイス非依存ピクセル）** でサイズ指定するため、共有テクスチャに実際に渡されるフレームバッファは `width × height × display.scaleFactor` になります。**macOS Retina**（scaleFactor 2）では `new TextureSender("X", 1280, 720)` と宣言したつもりが **2560×1440** のテクスチャを生成してしまい、センダーの宣言サイズと実フレームバッファが食い違って、レシーバー側が黒や崩れた表示になります。Windows のディスプレイスケーリング（150% / 175%）でも同じ不一致が起きます。
+> ⚠️ **Electron 40 以下では黒画面・崩れた出力の最大の原因です。** オフスクリーンフレームバッファが要求した `width × height` とどう対応するかは Electron のバージョンによって変わります:
 >
-> - **高レベル `createTextureBridge`** は **`pixelExact: true`** オプション（[`TextureBridgeOptions`](#createtexturebridgeoptions-promisetexturebridge) 参照）でこれを吸収します。BrowserWindow を DIP でサイズ指定してフレームバッファをちょうど `width × height` に着地させ、センダーを要求ピクセルサイズで登録します。
-> - **低レベル core**（手動 `BrowserWindow` + `paint`）には**吸収機構がありません** — センダーの宣言サイズと実フレームバッファサイズの整合は*自分で*取る必要があります。センダーを実フレームバッファサイズ（`宣言 = 論理 × scaleFactor`）で宣言するか、`webContents.setZoomFactor` / 固定スケールのディスプレイで DPR を打ち消すか、`createTextureBridge({ pixelExact: true })` に移行してください。
+> - **Electron ≥ 41:** `createTextureBridge` が `webPreferences.offscreen.deviceScaleFactor` を `1` に固定するため、フレームバッファは常に厳密に `width × height` ピクセルになります — ディスプレイのスケーリングはテクスチャに影響しません。（`Electron 42` は OSR のデフォルトデバイススケールファクターを `1.0` に変更しました。このオプションが初めて存在する 41 から、ブリッジが明示的に設定しています。）`pixelExact` は自明に満たされ、実質的に no-op になります。
+> - **Electron 40:** Chromium はオフスクリーン面を **DIP（デバイス非依存ピクセル）** でサイズ指定するため、共有テクスチャに渡されるフレームバッファは `width × height × display.scaleFactor` になります。macOS Retina ディスプレイ（scaleFactor 2）では `new TextureSender("X", 1280, 720)` と宣言したつもりが **2560×1440** のテクスチャを生成してしまいます。これを吸収するには `createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路で自分で DPR を処理してください。
+>
+> **低レベル core**（手動 `BrowserWindow` + `paint`）はどのバージョンでも吸収機構がありません — Electron ≥ 41 では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡し、Electron 40 ではセンダーの宣言サイズと実フレームバッファサイズの整合を自分で取ってください。
 
 ### Electron 無しの最小サニティチェック
 
@@ -345,7 +347,7 @@ interface PreviewOptions {
 }
 ```
 
-**`pixelExact`** — `true` のとき、ホストディスプレイの DPR に関係なくオフスクリーンフレームバッファを正確に `width × height` ピクセルに固定します。指定しないと Retina（scaleFactor 2）や Windows スケーリング（150% / 175%）のディスプレイでは宣言したセンダーサイズより大きいフレームバッファが生成され、多くの場合レシーバーで黒画面/崩れになります（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。センダーは常に要求ピクセルサイズで登録されるため、レシーバーは指定どおりの寸法を受け取ります。注意: 割り切れないスケール比（例: `1920 / 1.75`）では 1 ピクセルの誤差が残ることがあり、構築時のプライマリディスプレイの scaleFactor のみが反映されます — DPI 変更後は `resize()` で再適用してください。
+**`pixelExact`** — `true` のとき、ホストディスプレイの DPR に関係なくオフスクリーンフレームバッファを正確に `width × height` ピクセルに固定します。**Electron ≥ 41:** 自明に満たされ実質的に no-op です — `createTextureBridge` がすでに `offscreen.deviceScaleFactor: 1` を固定しているため、このオプションの有無に関わらずフレームバッファは常に正確です。**Electron 40:** 指定しないと Retina（scaleFactor 2）や Windows スケーリング（150% / 175%）のディスプレイでは宣言したセンダーサイズより大きいフレームバッファが生成され、多くの場合レシーバーで黒画面/崩れになります（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。センダーは常に要求ピクセルサイズで登録されるため、レシーバーは指定どおりの寸法を受け取ります。注意: 割り切れないスケール比（例: `1920 / 1.75`）では 1 ピクセルの誤差が残ることがあり、構築時のプライマリディスプレイの scaleFactor のみが反映されます — DPI 変更後は `resize()` で再適用してください。
 
 #### `TextureBridge`
 
@@ -608,6 +610,16 @@ win.webContents.on("paint", (event) => {
   }
 });
 ```
+
+## 移行ガイド: Electron 42 / OSR デバイススケール
+
+Electron 42 でオフスクリーンレンダリングのデフォルトデバイススケールファクターが `1.0` に変更されました（[breaking change](https://www.electronjs.org/docs/latest/breaking-changes)）。この変更を取り込んだリリース以降、`createTextureBridge` は Electron ≥ 41 で `offscreen.deviceScaleFactor: 1` を固定するため、`width`/`height` はどのディスプレイでも正確なピクセル数を意味するようになります。
+
+- **`pixelExact: true` を使っていた場合**（Electron 40 など）: そのままで問題ありません — Electron ≥ 41 では no-op であり、40 では引き続き必要です。
+- **自分でスケーリングを回避していた場合**（`force-device-scale-factor=1`、手動の DIP 計算、Electron 42 で 1/4 解像度になった後に `pixelExact` を外す、など）: アップグレード後はこれらの回避策は不要になります。
+- **意図的にスケーリングされたフレームバッファが欲しい場合**は、自分で `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` を渡してください — ユーザー指定の `offscreen` ブロックは常に優先されます。
+
+実測データの背景: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`。
 
 ## CI/CD
 

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -263,7 +263,7 @@ win.webContents.on("paint", (details) => {
 >
 > ⚠️ **Electron 40 以下では黒画面・崩れた出力の最大の原因です。** オフスクリーンフレームバッファが要求した `width × height` とどう対応するかは Electron のバージョンによって変わります:
 >
-> - **Electron ≥ 41:** `createTextureBridge` が `webPreferences.offscreen.deviceScaleFactor` を `1` に固定するため、フレームバッファは常に厳密に `width × height` ピクセルになります — ディスプレイのスケーリングはテクスチャに影響しません。（`Electron 42` は OSR のデフォルトデバイススケールファクターを `1.0` に変更しました。このオプションが初めて存在する 41 から、ブリッジが明示的に設定しています。）`pixelExact` は自明に満たされ、実質的に no-op になります。
+> - **Electron ≥ 41:** `createTextureBridge` が `webPreferences.offscreen.deviceScaleFactor` を `1` に固定するため、フレームバッファは常に厳密に `width × height` ピクセルになります — ディスプレイのスケーリングはテクスチャに影響しません。（`Electron 42` は OSR のデフォルトデバイススケールファクターを `1.0` に変更しました。このオプションが初めて存在する 41 から、ブリッジが明示的に設定しています。）`pixelExact` は自明に満たされ、実質的に no-op になります。macOS では検証済みですが、Windows のディスプレイスケーリングでの検証は未実施です（調査レポートに未解決項目として記載）— Windows でクランプが発生した場合はサイズを小さくするか、[プローブスクリプト](../../packages/renderer/scripts/osr-scale-probe.cjs)で検証してください。
 > - **Electron 40:** Chromium はオフスクリーン面を **DIP（デバイス非依存ピクセル）** でサイズ指定するため、共有テクスチャに渡されるフレームバッファは `width × height × display.scaleFactor` になります。macOS Retina ディスプレイ（scaleFactor 2）では `new TextureSender("X", 1280, 720)` と宣言したつもりが **2560×1440** のテクスチャを生成してしまいます。これを吸収するには `createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路で自分で DPR を処理してください。
 >
 > **低レベル core**（手動 `BrowserWindow` + `paint`）はどのバージョンでも吸収機構がありません — Electron ≥ 41 では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡し、Electron 40 ではセンダーの宣言サイズと実フレームバッファサイズの整合を自分で取ってください。
@@ -572,7 +572,7 @@ electron-texture-bridge/
 
 ### テクスチャが真っ黒
 
-- **DPR / Retina のサイズ不一致（最も多い）。** Retina ディスプレイや Windows のディスプレイスケーリング下では実フレームバッファが `width × height × scaleFactor` になり、論理サイズで宣言したセンダーと食い違ってレシーバーが黒/崩れになります。`createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路ではセンダーを実フレームバッファサイズで宣言するか自分で DPR を打ち消してください（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。
+- **DPR / Retina のサイズ不一致（最も多い）。** **Electron ≤ 40:** Retina ディスプレイや Windows のディスプレイスケーリング下では実フレームバッファが `width × height × scaleFactor` になり、論理サイズで宣言したセンダーと食い違ってレシーバーが黒/崩れになります。`createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路ではセンダーを実フレームバッファサイズで宣言するか自分で DPR を打ち消してください。**Electron ≥ 41:** `createTextureBridge` が OSR のデバイススケールファクターを `1` に固定するため、この不一致は発生しません — [移行ガイド: Electron 42 / OSR デバイススケール](#移行ガイド-electron-42--osr-デバイススケール)を参照してください。低レベル core 経路では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡してください。（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。
 - **Electron とブリッジの切り分け**には[Electron 無しの最小サニティチェック](#electron-無しの最小サニティチェック)を使ってください — `sendRgbaBuffer` が VJ アプリに映ればネイティブ側は健全で、問題は Electron OSR 経路にあります。
 - `preserveDrawingBuffer` は不要（Chromium のコンポジターが直接読み取る）
 - ピクセルフォーマットの不一致を確認：Chromium は BGRA を出力するので、レシーバー側も BGRA を期待しているか確認
@@ -613,7 +613,7 @@ win.webContents.on("paint", (event) => {
 
 ## 移行ガイド: Electron 42 / OSR デバイススケール
 
-Electron 42 でオフスクリーンレンダリングのデフォルトデバイススケールファクターが `1.0` に変更されました（[breaking change](https://www.electronjs.org/docs/latest/breaking-changes)）。この変更を取り込んだリリース以降、`createTextureBridge` は Electron ≥ 41 で `offscreen.deviceScaleFactor: 1` を固定するため、`width`/`height` はどのディスプレイでも正確なピクセル数を意味するようになります。
+Electron 42 でオフスクリーンレンダリングのデフォルトデバイススケールファクターが `1.0` に変更されました（[breaking change](https://www.electronjs.org/docs/latest/breaking-changes)）。この変更を含む texture-bridge のリリース以降（CHANGELOG 参照）、`createTextureBridge` は Electron ≥ 41 で `offscreen.deviceScaleFactor: 1` を固定するため、`width`/`height` はどのディスプレイでも正確なピクセル数を意味するようになります。
 
 - **`pixelExact: true` を使っていた場合**（Electron 40 など）: そのままで問題ありません — Electron ≥ 41 では no-op であり、40 では引き続き必要です。
 - **自分でスケーリングを回避していた場合**（`force-device-scale-factor=1`、手動の DIP 計算、Electron 42 で 1/4 解像度になった後に `pixelExact` を外す、など）: アップグレード後はこれらの回避策は不要になります。

--- a/packages/renderer/scripts/osr-scale-probe.cjs
+++ b/packages/renderer/scripts/osr-scale-probe.cjs
@@ -3,7 +3,7 @@
  * actually deliver, as a function of window DIP size, display scaleFactor,
  * and force-device-scale-factor?
  *
- * Usage: electron osr-scale-probe.cjs <plain|dip> [--force-scale-1]
+ * Usage: electron osr-scale-probe.cjs <plain|dip> [--dsf-1] [--force-scale-1]
  *   plain = BrowserWindow sized 1920x1080 DIP
  *   dip   = BrowserWindow sized computeDipSize(1920,1080,scaleFactor) (pixelExact math)
  *

--- a/packages/renderer/scripts/osr-scale-probe.cjs
+++ b/packages/renderer/scripts/osr-scale-probe.cjs
@@ -1,0 +1,66 @@
+/**
+ * Empirical probe: what pixel size does the OSR useSharedTexture paint event
+ * actually deliver, as a function of window DIP size, display scaleFactor,
+ * and force-device-scale-factor?
+ *
+ * Usage: electron osr-scale-probe.cjs <plain|dip> [--force-scale-1]
+ *   plain = BrowserWindow sized 1920x1080 DIP
+ *   dip   = BrowserWindow sized computeDipSize(1920,1080,scaleFactor) (pixelExact math)
+ *
+ * Findings recorded in reports/2026-08-11-pixelexact-osr-scale-investigation.md
+ * (Electron 40: paints at display scale, deviceScaleFactor ignored;
+ *  Electron 41: deviceScaleFactor honored, default = display scale;
+ *  Electron 42: default flipped to 1.0).
+ *
+ * Re-run: <electron binary> packages/renderer/scripts/osr-scale-probe.cjs <plain|dip> [--dsf-1] [--force-scale-1]
+ */
+const { app, BrowserWindow, screen } = require("electron");
+
+const mode = process.argv[2] ?? "plain";
+const forceScale = process.argv.includes("--force-scale-1");
+if (forceScale) app.commandLine.appendSwitch("force-device-scale-factor", "1");
+
+const WIDTH = 1920;
+const HEIGHT = 1080;
+
+const computeDipSize = (w, h, scaleFactor) => ({
+  width: Math.max(1, Math.round(w / scaleFactor)),
+  height: Math.max(1, Math.round(h / scaleFactor)),
+});
+
+app.whenReady().then(() => {
+  const scaleFactor = screen.getPrimaryDisplay().scaleFactor;
+  const dip = mode === "dip" ? computeDipSize(WIDTH, HEIGHT, scaleFactor) : { width: WIDTH, height: HEIGHT };
+
+  const dsf1 = process.argv.includes("--dsf-1");
+  const offscreen = dsf1 ? { useSharedTexture: true, deviceScaleFactor: 1 } : { useSharedTexture: true };
+  const win = new BrowserWindow({
+    width: dip.width,
+    height: dip.height,
+    show: false,
+    webPreferences: { offscreen },
+  });
+
+  let count = 0;
+  win.webContents.on("paint", (event) => {
+    const texture = event.texture;
+    if (!texture) return;
+    count += 1;
+    const { codedSize, visibleRect, pixelFormat } = texture.textureInfo;
+    console.log(
+      JSON.stringify({ mode, forceScale, scaleFactor, windowDip: dip, codedSize, visibleRect, pixelFormat }),
+    );
+    texture.release();
+    if (count >= 2) {
+      win.destroy();
+      app.quit();
+    }
+  });
+  win.webContents.setFrameRate(10);
+  win.loadURL("data:text/html,<body style='background:%23ff00ff'><h1>probe</h1></body>");
+  setTimeout(() => {
+    console.log(JSON.stringify({ mode, forceScale, error: "timeout without paint" }));
+    win.destroy();
+    app.quit();
+  }, 10000);
+});

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -4,16 +4,19 @@ import { describe, expect, it, vi } from "vitest";
 // `buildBrowserWindowOptions` is a pure function, but the module-level
 // `import { app, BrowserWindow } from "electron"` would otherwise pull the
 // real native module.
+const getPrimaryDisplayMock = vi.fn(() => ({ scaleFactor: 1 }));
+
 vi.mock("electron", () => ({
   app: { isReady: () => true },
   BrowserWindow: class MockBrowserWindow {
+    setSize = vi.fn();
     isDestroyed(): boolean {
       return false;
     }
     close(): void {}
   },
   screen: {
-    getPrimaryDisplay: () => ({ scaleFactor: 1 }),
+    getPrimaryDisplay: () => getPrimaryDisplayMock(),
   },
 }));
 
@@ -443,5 +446,31 @@ describe("resolveWindowDipSize", () => {
   it("returns width/height untouched under device-scale without pixelExact", () => {
     const size = resolveWindowDipSize({ width: 1920, height: 1080 }, "device-scale", 2);
     expect(size).toEqual({ width: 1920, height: 1080 });
+  });
+});
+
+describe("TextureBridgeImpl.resize — OSR scale policy", () => {
+  const makeBridgeWithPolicy = (
+    policy: "device-scale" | "unit-scale",
+    opts: TextureBridgeOptions,
+  ) =>
+    new TextureBridgeImpl(new BrowserWindow(), new TextureSender("t", 16, 9), null, opts, policy);
+
+  it("sets the window to the raw pixel size under unit-scale even with pixelExact", () => {
+    getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+    const bridge = makeBridgeWithPolicy("unit-scale", { ...baseOpts, pixelExact: true });
+
+    bridge.resize(1280, 720);
+
+    expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(1280, 720);
+  });
+
+  it("divides the window size by scaleFactor under device-scale with pixelExact", () => {
+    getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+    const bridge = makeBridgeWithPolicy("device-scale", { ...baseOpts, pixelExact: true });
+
+    bridge.resize(1280, 720);
+
+    expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(640, 360);
   });
 });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -32,14 +32,20 @@ vi.mock("electron", () => ({
   },
 }));
 
-// Lets resize-rollback tests force the sender constructor to throw without
-// a `let` rebinding — a plain mutable holder object instead.
-const senderCtorBehavior = { shouldThrow: false };
+// Lets resize-rollback tests force the sender constructor to throw exactly N
+// times without a `let` rebinding — a plain mutable holder object instead.
+// Counting (rather than a boolean) lets the *forward* construction throw
+// while the *rollback* reconstruction succeeds, so the rollback path is
+// genuinely exercised rather than short-circuited by a second throw.
+const senderCtorBehavior = { throwsRemaining: 0 };
 
 vi.mock("@napolab/texture-bridge-core", () => ({
   TextureSender: class MockTextureSender {
     constructor() {
-      if (senderCtorBehavior.shouldThrow) throw new Error("sender ctor failed");
+      if (senderCtorBehavior.throwsRemaining > 0) {
+        senderCtorBehavior.throwsRemaining -= 1;
+        throw new Error("sender ctor failed");
+      }
     }
     stop(): void {}
   },
@@ -63,7 +69,7 @@ import type { PreviewManager } from "../preview-manager";
 
 afterEach(() => {
   getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 1 });
-  senderCtorBehavior.shouldThrow = false;
+  senderCtorBehavior.throwsRemaining = 0;
 });
 
 const baseOpts: TextureBridgeOptions = {
@@ -510,13 +516,21 @@ describe("TextureBridgeImpl.resize — OSR scale policy", () => {
       "device-scale",
     );
 
-    senderCtorBehavior.shouldThrow = true;
+    // Exactly one throw: the *forward* `new TextureSender(...)` fails, the
+    // *rollback* reconstruction inside the catch block must succeed — so the
+    // final `throw err` genuinely rethrows the original forward error rather
+    // than short-circuiting on a second throw from the rollback itself.
+    senderCtorBehavior.throwsRemaining = 1;
     expect(() => bridge.resize(1280, 720)).toThrow("sender ctor failed");
+    expect(senderCtorBehavior.throwsRemaining).toBe(0);
 
     expect(vi.mocked(win.setSize).mock.calls).toEqual([
       [640, 360], // forward: 1280x720 / scaleFactor 2
       [960, 540], // rollback: baseOpts 1920x1080 / scaleFactor 2
     ]);
+
+    // The rolled-back sender is functional: a subsequent resize succeeds.
+    expect(() => bridge.resize(1024, 512)).not.toThrow();
   });
 });
 

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -47,13 +47,16 @@ const baseOpts: TextureBridgeOptions = {
 
 describe("buildBrowserWindowOptions", () => {
   it("forwards width and height to the BrowserWindow constructor args", () => {
-    const out = buildBrowserWindowOptions({ ...baseOpts, width: 1280, height: 720 });
+    const out = buildBrowserWindowOptions(
+      { ...baseOpts, width: 1280, height: 720 },
+      "device-scale",
+    );
     expect(out.width).toBe(1280);
     expect(out.height).toBe(720);
   });
 
   it("creates a hidden offscreen window with sharedTexture by default", () => {
-    const out = buildBrowserWindowOptions(baseOpts);
+    const out = buildBrowserWindowOptions(baseOpts, "device-scale");
     expect(out.show).toBe(false);
     expect(out.webPreferences?.contextIsolation).toBe(true);
     expect(out.webPreferences?.nodeIntegration).toBe(false);
@@ -63,7 +66,7 @@ describe("buildBrowserWindowOptions", () => {
   });
 
   it("does not enable transparent by default", () => {
-    const out = buildBrowserWindowOptions(baseOpts);
+    const out = buildBrowserWindowOptions(baseOpts, "device-scale");
     expect(out.transparent).toBeUndefined();
     expect(out.backgroundColor).toBeUndefined();
   });
@@ -73,22 +76,25 @@ describe("buildBrowserWindowOptions", () => {
     // when both flags are set on the BrowserWindow. transparent:true alone
     // leaves Chromium painting an opaque backdrop; backgroundColor with the
     // alpha byte zero is what flips the initial fill to fully-transparent.
-    const out = buildBrowserWindowOptions({ ...baseOpts, includeAlpha: true });
+    const out = buildBrowserWindowOptions({ ...baseOpts, includeAlpha: true }, "device-scale");
     expect(out.transparent).toBe(true);
     expect(out.backgroundColor).toBe("#00000000");
   });
 
   it("treats includeAlpha: false the same as omitted", () => {
-    const out = buildBrowserWindowOptions({ ...baseOpts, includeAlpha: false });
+    const out = buildBrowserWindowOptions({ ...baseOpts, includeAlpha: false }, "device-scale");
     expect(out.transparent).toBeUndefined();
     expect(out.backgroundColor).toBeUndefined();
   });
 
   it("preserves caller-supplied webPreferences (merge over the offscreen base)", () => {
-    const out = buildBrowserWindowOptions({
-      ...baseOpts,
-      webPreferences: { backgroundThrottling: false },
-    });
+    const out = buildBrowserWindowOptions(
+      {
+        ...baseOpts,
+        webPreferences: { backgroundThrottling: false },
+      },
+      "device-scale",
+    );
     expect(out.webPreferences?.backgroundThrottling).toBe(false);
     expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
   });
@@ -96,15 +102,18 @@ describe("buildBrowserWindowOptions", () => {
   it("lets caller-supplied webPreferences override the base defaults", () => {
     // Documents the existing override behavior in createTextureBridge so we
     // do not silently regress when refactoring the helper.
-    const out = buildBrowserWindowOptions({
-      ...baseOpts,
-      webPreferences: { contextIsolation: false },
-    });
+    const out = buildBrowserWindowOptions(
+      {
+        ...baseOpts,
+        webPreferences: { contextIsolation: false },
+      },
+      "device-scale",
+    );
     expect(out.webPreferences?.contextIsolation).toBe(false);
   });
 
   it("does not set enableLargerThanScreen by default", () => {
-    const out = buildBrowserWindowOptions(baseOpts);
+    const out = buildBrowserWindowOptions(baseOpts, "device-scale");
     expect(out.enableLargerThanScreen).toBeUndefined();
   });
 
@@ -115,13 +124,58 @@ describe("buildBrowserWindowOptions", () => {
     // pre-translated a large pixel target into DIP via `computeDipSize`
     // and the resulting DIP is still larger than the display's available
     // area (rare, but possible on small / low-DPR monitors).
-    const out = buildBrowserWindowOptions({ ...baseOpts, pixelExact: true });
+    const out = buildBrowserWindowOptions({ ...baseOpts, pixelExact: true }, "device-scale");
     expect(out.enableLargerThanScreen).toBe(true);
   });
 
   it("treats pixelExact: false the same as omitted", () => {
-    const out = buildBrowserWindowOptions({ ...baseOpts, pixelExact: false });
+    const out = buildBrowserWindowOptions({ ...baseOpts, pixelExact: false }, "device-scale");
     expect(out.enableLargerThanScreen).toBeUndefined();
+  });
+});
+
+describe("buildBrowserWindowOptions — OSR scale policy", () => {
+  it("pins offscreen.deviceScaleFactor to 1 under unit-scale", () => {
+    const out = buildBrowserWindowOptions(baseOpts, "unit-scale");
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true, deviceScaleFactor: 1 });
+  });
+
+  it("does not set deviceScaleFactor under device-scale", () => {
+    const out = buildBrowserWindowOptions(baseOpts, "device-scale");
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
+  });
+
+  it("always enables enableLargerThanScreen under unit-scale", () => {
+    const out = buildBrowserWindowOptions(baseOpts, "unit-scale");
+    expect(out.enableLargerThanScreen).toBe(true);
+  });
+
+  it("keeps enableLargerThanScreen gated on pixelExact under device-scale", () => {
+    expect(
+      buildBrowserWindowOptions(baseOpts, "device-scale").enableLargerThanScreen,
+    ).toBeUndefined();
+    expect(
+      buildBrowserWindowOptions({ ...baseOpts, pixelExact: true }, "device-scale")
+        .enableLargerThanScreen,
+    ).toBe(true);
+  });
+
+  it("lets a user-supplied webPreferences.offscreen win entirely", () => {
+    // `deviceScaleFactor` was added to Electron's `Offscreen` type in 41; the
+    // workspace's installed Electron types are 40.x, so a fresh object
+    // literal directly in the `offscreen` position would fail the excess
+    // property check (TS2353) even though it is a valid runtime value on
+    // Electron >= 41. Binding it to a named const first sidesteps the
+    // literal-only excess property check without weakening the assertion.
+    const userOffscreen = { useSharedTexture: true, deviceScaleFactor: 2 };
+    const out = buildBrowserWindowOptions(
+      {
+        ...baseOpts,
+        webPreferences: { offscreen: userOffscreen },
+      },
+      "unit-scale",
+    );
+    expect(out.webPreferences?.offscreen).toEqual({ useSharedTexture: true, deviceScaleFactor: 2 });
   });
 });
 

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -24,7 +24,14 @@ vi.mock("@napolab/texture-bridge-core", () => ({
   sendTextureFromPaintEvent: vi.fn(),
 }));
 
-import { buildBrowserWindowOptions, computeDipSize, TextureBridgeImpl } from "../bridge";
+import {
+  buildBrowserWindowOptions,
+  computeDipSize,
+  resolveElectronMajor,
+  resolveOsrScalePolicy,
+  resolveWindowDipSize,
+  TextureBridgeImpl,
+} from "../bridge";
 import { BrowserWindow } from "electron";
 import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
 import type { PaintDefect, PaintTexture } from "@napolab/texture-bridge-core";
@@ -333,5 +340,54 @@ describe("TextureBridgeImpl.handlePaint — frameDropped", () => {
 
     expect(sendFrame).toHaveBeenCalledTimes(1);
     expect(sendFrame).toHaveBeenCalledWith(texture);
+  });
+});
+
+describe("resolveElectronMajor", () => {
+  it("parses the major version from a semver string", () => {
+    expect(resolveElectronMajor({ electron: "42.4.0" })).toBe(42);
+    expect(resolveElectronMajor({ electron: "40.2.1" })).toBe(40);
+  });
+
+  it("returns 0 when the electron version is missing or malformed", () => {
+    expect(resolveElectronMajor({})).toBe(0);
+    expect(resolveElectronMajor({ electron: "garbage" })).toBe(0);
+  });
+});
+
+describe("resolveOsrScalePolicy", () => {
+  it("selects device-scale for Electron 40 and below", () => {
+    expect(resolveOsrScalePolicy(40)).toBe("device-scale");
+    expect(resolveOsrScalePolicy(0)).toBe("device-scale");
+  });
+
+  it("selects unit-scale for Electron 41 and above", () => {
+    expect(resolveOsrScalePolicy(41)).toBe("unit-scale");
+    expect(resolveOsrScalePolicy(42)).toBe("unit-scale");
+  });
+});
+
+describe("resolveWindowDipSize", () => {
+  it("returns width/height untouched under unit-scale, even with pixelExact", () => {
+    const size = resolveWindowDipSize(
+      { width: 1920, height: 1080, pixelExact: true },
+      "unit-scale",
+      2,
+    );
+    expect(size).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it("divides by scaleFactor under device-scale when pixelExact is set", () => {
+    const size = resolveWindowDipSize(
+      { width: 1920, height: 1080, pixelExact: true },
+      "device-scale",
+      2,
+    );
+    expect(size).toEqual({ width: 960, height: 540 });
+  });
+
+  it("returns width/height untouched under device-scale without pixelExact", () => {
+    const size = resolveWindowDipSize({ width: 1920, height: 1080 }, "device-scale", 2);
+    expect(size).toEqual({ width: 1920, height: 1080 });
   });
 });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -39,13 +39,20 @@ vi.mock("electron", () => ({
 // genuinely exercised rather than short-circuited by a second throw.
 const senderCtorBehavior = { throwsRemaining: 0 };
 
+// Records every `new TextureSender(name, width, height)` call so tests can
+// assert the sender is always constructed in pixel space, under both OSR
+// scale policies — a regression passing DIP sizes here would otherwise be
+// invisible since MockTextureSender previously ignored its ctor args.
+const senderCtorArgs: Array<readonly [string, number, number]> = [];
+
 vi.mock("@napolab/texture-bridge-core", () => ({
   TextureSender: class MockTextureSender {
-    constructor() {
+    constructor(name?: string, width?: number, height?: number) {
       if (senderCtorBehavior.throwsRemaining > 0) {
         senderCtorBehavior.throwsRemaining -= 1;
         throw new Error("sender ctor failed");
       }
+      if (name !== undefined) senderCtorArgs.push([name, width ?? 0, height ?? 0]);
     }
     stop(): void {}
   },
@@ -70,6 +77,7 @@ import type { PreviewManager } from "../preview-manager";
 afterEach(() => {
   getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 1 });
   senderCtorBehavior.throwsRemaining = 0;
+  senderCtorArgs.length = 0;
 });
 
 const baseOpts: TextureBridgeOptions = {
@@ -494,6 +502,7 @@ describe("TextureBridgeImpl.resize — OSR scale policy", () => {
     bridge.resize(1280, 720);
 
     expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(1280, 720);
+    expect(senderCtorArgs.at(-1)).toEqual(["test", 1280, 720]);
   });
 
   it("divides the window size by scaleFactor under device-scale with pixelExact", () => {
@@ -503,6 +512,7 @@ describe("TextureBridgeImpl.resize — OSR scale policy", () => {
     bridge.resize(1280, 720);
 
     expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(640, 360);
+    expect(senderCtorArgs.at(-1)).toEqual(["test", 1280, 720]);
   });
 
   it("rolls the window size back when the new sender cannot be constructed", () => {
@@ -561,6 +571,7 @@ describe("createTextureBridge — OSR scale policy wiring", () => {
         useSharedTexture: true,
         deviceScaleFactor: 1,
       });
+      expect(senderCtorArgs).toContainEqual(["test", 1920, 1080]);
 
       // policy handoff to the impl: resize under unit-scale ignores pixelExact
       bridge.resize(1280, 720);
@@ -579,6 +590,7 @@ describe("createTextureBridge — OSR scale policy wiring", () => {
       expect(windowOptions?.width).toBe(960);
       expect(windowOptions?.height).toBe(540);
       expect(windowOptions?.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
+      expect(senderCtorArgs).toContainEqual(["test", 1920, 1080]);
     });
   });
 });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock Electron and the native core so we can import bridge.ts in node tests.
 // `buildBrowserWindowOptions` is a pure function, but the module-level
@@ -6,10 +6,22 @@ import { describe, expect, it, vi } from "vitest";
 // real native module.
 const getPrimaryDisplayMock = vi.fn(() => ({ scaleFactor: 1 }));
 
+// Captures every `new BrowserWindow(options)` call made by `createTextureBridge`
+// so tests can assert on the constructed window options without a real
+// native module. Existing tests construct `new BrowserWindow()` with no
+// args, so the `options !== undefined` guard keeps those unaffected.
+const constructedWindowOptions: Electron.BrowserWindowConstructorOptions[] = [];
+
 vi.mock("electron", () => ({
   app: { isReady: () => true },
   BrowserWindow: class MockBrowserWindow {
     setSize = vi.fn();
+    webContents = { on: vi.fn(), setFrameRate: vi.fn() };
+    loadURL = vi.fn(async () => undefined);
+    loadFile = vi.fn(async () => undefined);
+    constructor(options?: Electron.BrowserWindowConstructorOptions) {
+      if (options !== undefined) constructedWindowOptions.push(options);
+    }
     isDestroyed(): boolean {
       return false;
     }
@@ -20,8 +32,15 @@ vi.mock("electron", () => ({
   },
 }));
 
+// Lets resize-rollback tests force the sender constructor to throw without
+// a `let` rebinding — a plain mutable holder object instead.
+const senderCtorBehavior = { shouldThrow: false };
+
 vi.mock("@napolab/texture-bridge-core", () => ({
   TextureSender: class MockTextureSender {
+    constructor() {
+      if (senderCtorBehavior.shouldThrow) throw new Error("sender ctor failed");
+    }
     stop(): void {}
   },
   sendTextureFromPaintEvent: vi.fn(),
@@ -30,6 +49,7 @@ vi.mock("@napolab/texture-bridge-core", () => ({
 import {
   buildBrowserWindowOptions,
   computeDipSize,
+  createTextureBridge,
   resolveElectronMajor,
   resolveOsrScalePolicy,
   resolveWindowDipSize,
@@ -40,6 +60,11 @@ import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridg
 import type { PaintDefect, PaintTexture } from "@napolab/texture-bridge-core";
 import type { TextureBridgeOptions } from "../types";
 import type { PreviewManager } from "../preview-manager";
+
+afterEach(() => {
+  getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 1 });
+  senderCtorBehavior.shouldThrow = false;
+});
 
 const baseOpts: TextureBridgeOptions = {
   name: "test",
@@ -472,5 +497,74 @@ describe("TextureBridgeImpl.resize — OSR scale policy", () => {
     bridge.resize(1280, 720);
 
     expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(640, 360);
+  });
+
+  it("rolls the window size back when the new sender cannot be constructed", () => {
+    getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+    const win = new BrowserWindow();
+    const bridge = new TextureBridgeImpl(
+      win,
+      new TextureSender("t", 16, 9),
+      null,
+      { ...baseOpts, pixelExact: true },
+      "device-scale",
+    );
+
+    senderCtorBehavior.shouldThrow = true;
+    expect(() => bridge.resize(1280, 720)).toThrow("sender ctor failed");
+
+    expect(vi.mocked(win.setSize).mock.calls).toEqual([
+      [640, 360], // forward: 1280x720 / scaleFactor 2
+      [960, 540], // rollback: baseOpts 1920x1080 / scaleFactor 2
+    ]);
+  });
+});
+
+describe("createTextureBridge — OSR scale policy wiring", () => {
+  const withElectronMajor = async (version: string, run: () => Promise<void>): Promise<void> => {
+    const original = Object.getOwnPropertyDescriptor(process.versions, "electron");
+    Object.defineProperty(process.versions, "electron", { value: version, configurable: true });
+    try {
+      await run();
+    } finally {
+      if (original) Object.defineProperty(process.versions, "electron", original);
+      else Reflect.deleteProperty(process.versions, "electron");
+    }
+  };
+
+  it("builds the window at raw pixel size with deviceScaleFactor pinned on Electron >= 41", async () => {
+    await withElectronMajor("42.0.0", async () => {
+      getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+      constructedWindowOptions.length = 0;
+
+      const bridge = await createTextureBridge({ ...baseOpts, pixelExact: true });
+
+      const [windowOptions] = constructedWindowOptions;
+      expect(windowOptions?.width).toBe(1920);
+      expect(windowOptions?.height).toBe(1080);
+      expect(windowOptions?.enableLargerThanScreen).toBe(true);
+      expect(windowOptions?.webPreferences?.offscreen).toEqual({
+        useSharedTexture: true,
+        deviceScaleFactor: 1,
+      });
+
+      // policy handoff to the impl: resize under unit-scale ignores pixelExact
+      bridge.resize(1280, 720);
+      expect(bridge.renderWindow.setSize).toHaveBeenCalledWith(1280, 720);
+    });
+  });
+
+  it("keeps legacy DIP division on Electron 40", async () => {
+    await withElectronMajor("40.2.1", async () => {
+      getPrimaryDisplayMock.mockReturnValue({ scaleFactor: 2 });
+      constructedWindowOptions.length = 0;
+
+      await createTextureBridge({ ...baseOpts, pixelExact: true });
+
+      const [windowOptions] = constructedWindowOptions;
+      expect(windowOptions?.width).toBe(960);
+      expect(windowOptions?.height).toBe(540);
+      expect(windowOptions?.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
+    });
   });
 });

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -258,25 +258,38 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
  * is the documented recipe for Chromium to emit per-pixel alpha into the
  * shared texture. The page itself must use a transparent background
  * (`html, body { background: transparent }`) for the alpha to mean anything.
+ *
+ * `policy` selects the `offscreen` prefs and `enableLargerThanScreen` gating:
+ * under `"unit-scale"` `deviceScaleFactor` is pinned to 1 and
+ * `enableLargerThanScreen` is always set (the DIP size equals the requested
+ * pixel size, which may exceed the display's work area); under
+ * `"device-scale"` behavior is unchanged from before this option existed.
  */
 export function buildBrowserWindowOptions(
   options: TextureBridgeOptions,
+  policy: OsrScalePolicy,
 ): Electron.BrowserWindowConstructorOptions {
   const { width, height, webPreferences, includeAlpha, pixelExact } = options;
+
+  const offscreen =
+    policy === "unit-scale"
+      ? { useSharedTexture: true, deviceScaleFactor: 1 }
+      : { useSharedTexture: true };
+  const largerThanScreen = policy === "unit-scale" || pixelExact === true;
 
   return {
     width,
     height,
     show: false,
     // `enableLargerThanScreen` is documented as macOS-only but is harmless on
-    // other platforms. We set it whenever `pixelExact` is requested so the
-    // offscreen window's DIP size — which may be larger than the display when
-    // the system DPI is < 100% — is not clamped to the work area.
-    ...(pixelExact === true ? { enableLargerThanScreen: true } : {}),
+    // other platforms. Under unit-scale the DIP size equals the requested pixel
+    // size — which may exceed the display work area — so it is always set;
+    // under device-scale it is set only when `pixelExact` requests it.
+    ...(largerThanScreen ? { enableLargerThanScreen: true } : {}),
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      offscreen: { useSharedTexture: true },
+      offscreen,
       ...webPreferences,
     },
     // Hex `#RRGGBBAA` with alpha=0x00 is the explicit "fully transparent
@@ -309,7 +322,9 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
     pixelExact === true
       ? { ...options, ...computeDipSize(width, height, screen.getPrimaryDisplay().scaleFactor) }
       : options;
-  const renderWindow = new BrowserWindow(buildBrowserWindowOptions(windowOptions));
+  // TODO(Task 3): resolve via resolveOsrScalePolicy(resolveElectronMajor(process.versions))
+  // once TextureBridgeImpl / resize() are wired to consume the policy too.
+  const renderWindow = new BrowserWindow(buildBrowserWindowOptions(windowOptions, "device-scale"));
 
   // ---- Native sender ----
   const sender = new TextureSender(name, width, height);

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -34,6 +34,51 @@ export function computeDipSize(
   };
 }
 
+/**
+ * How the OSR compositor maps the window's DIP size to the shared-texture
+ * pixel size.
+ *
+ * - `"device-scale"` (Electron ≤ 40): the paint framebuffer is
+ *   `DIP × display.scaleFactor`, and `webPreferences.offscreen.deviceScaleFactor`
+ *   is ignored — `pixelExact` must pre-divide the window size to hit an exact
+ *   pixel count.
+ * - `"unit-scale"` (Electron ≥ 41): `offscreen.deviceScaleFactor` is honored
+ *   (and defaults to 1.0 from Electron 42), so we pin it to 1 and DIP == px
+ *   holds deterministically — no DIP division, `pixelExact` is trivially
+ *   satisfied.
+ *
+ * Empirical basis: reports/2026-08-11-pixelexact-osr-scale-investigation.md
+ * (measured on Electron 40.2.1 / 41.10.4 / 42.4.0, macOS Retina scaleFactor 2).
+ */
+export type OsrScalePolicy = "device-scale" | "unit-scale";
+
+/** Parse the Electron major version; 0 when missing or malformed. */
+export const resolveElectronMajor = (versions: { electron?: string }): number => {
+  const [major] = (versions.electron ?? "").split(".");
+  const parsed = parseInt(major ?? "", 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/** `offscreen.deviceScaleFactor` exists (and is honored) from Electron 41. */
+export const resolveOsrScalePolicy = (electronMajor: number): OsrScalePolicy =>
+  electronMajor >= 41 ? "unit-scale" : "device-scale";
+
+/**
+ * Window DIP size for the requested pixel size under the given policy.
+ * Under unit-scale DIP == px, so the size passes through; under device-scale
+ * only `pixelExact` pre-divides by the display scaleFactor (legacy behavior).
+ */
+export const resolveWindowDipSize = (
+  options: Pick<TextureBridgeOptions, "width" | "height" | "pixelExact">,
+  policy: OsrScalePolicy,
+  scaleFactor: number,
+): { width: number; height: number } => {
+  if (policy === "unit-scale") return { width: options.width, height: options.height };
+  if (options.pixelExact === true)
+    return computeDipSize(options.width, options.height, scaleFactor);
+  return { width: options.width, height: options.height };
+};
+
 interface PaintEvent extends Event {
   texture?: PaintTexture;
 }

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -92,18 +92,21 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
   private _disposed = false;
   private lastDropReason: PaintDefect["reason"] | null = null;
   private options: TextureBridgeOptions;
+  private readonly policy: OsrScalePolicy;
 
   constructor(
     renderWindow: BrowserWindow,
     sender: InstanceType<typeof TextureSender>,
     previewManager: PreviewManager | null,
     options: TextureBridgeOptions,
+    policy: OsrScalePolicy = resolveOsrScalePolicy(resolveElectronMajor(process.versions)),
   ) {
     super();
     this._renderWindow = renderWindow;
     this.sender = sender;
     this.previewManager = previewManager;
     this.options = options;
+    this.policy = policy;
   }
 
   get renderWindow(): BrowserWindow {
@@ -191,13 +194,14 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     const prevOpts = this.options;
     this.options = { ...this.options, width, height };
 
-    // 1. Resize offscreen BrowserWindow. When `pixelExact` is set the caller's
-    //    width/height are pixel-space, so translate to DIP via the primary
-    //    display's scaleFactor before passing to setSize.
-    const dip =
-      this.options.pixelExact === true
-        ? computeDipSize(width, height, screen.getPrimaryDisplay().scaleFactor)
-        : { width, height };
+    // 1. Resize offscreen BrowserWindow. Under `"unit-scale"` DIP == px, so the
+    //    requested size passes through; under `"device-scale"` `pixelExact`
+    //    pre-divides by the primary display's scaleFactor.
+    const dip = resolveWindowDipSize(
+      this.options,
+      this.policy,
+      screen.getPrimaryDisplay().scaleFactor,
+    );
     this._renderWindow.setSize(dip.width, dip.height);
 
     // 2. Recreate native sender with new dimensions.
@@ -209,10 +213,11 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
       this.sender = new TextureSender(this.options.name, width, height);
     } catch (err) {
       this.options = prevOpts;
-      const prevDip =
-        prevOpts.pixelExact === true
-          ? computeDipSize(prevOpts.width, prevOpts.height, screen.getPrimaryDisplay().scaleFactor)
-          : { width: prevOpts.width, height: prevOpts.height };
+      const prevDip = resolveWindowDipSize(
+        prevOpts,
+        this.policy,
+        screen.getPrimaryDisplay().scaleFactor,
+      );
       this._renderWindow.setSize(prevDip.width, prevDip.height);
       this.sender = new TextureSender(prevOpts.name, prevOpts.width, prevOpts.height);
       throw err;
@@ -311,20 +316,17 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
     throw new Error("createTextureBridge() must be called after app.whenReady()");
   }
 
-  const { name, width, height, frameRate = 60, rendererUrl, preview, pixelExact } = options;
+  const { name, width, height, frameRate = 60, rendererUrl, preview } = options;
+
+  const policy = resolveOsrScalePolicy(resolveElectronMajor(process.versions));
 
   // ---- Offscreen BrowserWindow ----
-  // When pixelExact is set, the caller's width/height are pixel-space — translate
-  // to DIP via the primary display's scaleFactor before constructing the window
-  // so the resulting framebuffer lands at the requested pixel count. The sender
-  // below always uses pixel-space dimensions.
-  const windowOptions: TextureBridgeOptions =
-    pixelExact === true
-      ? { ...options, ...computeDipSize(width, height, screen.getPrimaryDisplay().scaleFactor) }
-      : options;
-  // TODO(Task 3): resolve via resolveOsrScalePolicy(resolveElectronMajor(process.versions))
-  // once TextureBridgeImpl / resize() are wired to consume the policy too.
-  const renderWindow = new BrowserWindow(buildBrowserWindowOptions(windowOptions, "device-scale"));
+  // Window DIP size per the OSR scale policy: under unit-scale DIP == px so the
+  // requested size passes through; under device-scale (Electron ≤ 40) pixelExact
+  // pre-divides by the primary display's scaleFactor. The sender below always
+  // uses pixel-space dimensions.
+  const dip = resolveWindowDipSize(options, policy, screen.getPrimaryDisplay().scaleFactor);
+  const renderWindow = new BrowserWindow(buildBrowserWindowOptions({ ...options, ...dip }, policy));
 
   // ---- Native sender ----
   const sender = new TextureSender(name, width, height);
@@ -337,7 +339,7 @@ export async function createTextureBridge(options: TextureBridgeOptions): Promis
   }
 
   // ---- Bridge instance ----
-  const bridge = new TextureBridgeImpl(renderWindow, sender, previewManager, options);
+  const bridge = new TextureBridgeImpl(renderWindow, sender, previewManager, options, policy);
 
   // ---- Paint handler (delegates to instance method, no private field access) ----
   renderWindow.webContents.on("paint", (event: PaintEvent) => {

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -42,6 +42,13 @@ export interface TextureBridgeOptions {
    * Pin the offscreen framebuffer to exactly `width × height` pixels regardless
    * of the host display's device pixel ratio (default: false).
    *
+   * Electron ≥ 41: this option is trivially satisfied and effectively a no-op —
+   * the bridge pins `webPreferences.offscreen.deviceScaleFactor` to 1, so the
+   * framebuffer always lands at exactly `width × height` pixels regardless of
+   * display scaling (Electron 42 changed the OSR default device scale factor
+   * to 1.0; the bridge makes it explicit from 41 where the option first
+   * exists). The DIP-division described below applies only to Electron 40.
+   *
    * Chromium's offscreen render surface is normally sized as `width × height`
    * in DIP (device-independent pixels), so the framebuffer actually delivered
    * to the GPU shared-texture path is `DIP × display.scaleFactor`. On a

--- a/reports/2026-08-11-pixelexact-osr-scale-investigation.md
+++ b/reports/2026-08-11-pixelexact-osr-scale-investigation.md
@@ -1,0 +1,66 @@
+# pixelExact / OSR device scale 調査 — Electron 40→42 の挙動変更が矛盾の正体
+
+- 日付: 2026-08-11
+- 対象: backlog #3（`pixelExact` の再検証、width/height の DIP/pixel 契約不一致）
+- 方法: 同一マシン（macOS, Built-in Retina, `scaleFactor = 2`）で Electron **40.2.1 / 41.10.4 / 42.4.0** を並べ、OSR `useSharedTexture` ウィンドウの paint `codedSize` を実測（probe: `osr-scale-probe.cjs`、window 1920×1080 DIP と `computeDipSize` 適用の 960×540 DIP の 2 モード × スイッチ/オプション組合せ）
+
+## 結論
+
+**Genovese（Electron 40, `pixelExact: true` で正常）と Cannelloni（Electron 42, `pixelExact: true` で 1/4 解像度）の矛盾は、両方正しい。** Electron 42 の公式 breaking change「OSR のデフォルト device scale factor を 1.0 に変更」が原因で、`pixelExact` の前提（DIP × scaleFactor = framebuffer px）が 42 以降では成立しない。
+
+## 実測マトリクス
+
+| | Electron 40.2.1 | Electron 41.10.4 | Electron 42.4.0 |
+|---|---|---|---|
+| OSR paint のデフォルトスケール | **display scale（×2）** | **display scale（×2）** | **1.0** |
+| window 1920×1080 DIP → codedSize | 3840×2160 | 3840×2160 | **1920×1080** |
+| `pixelExact` 計算（960×540 DIP）→ codedSize | **1920×1080 = 申告一致 ✓** | 1920×1080 ✓ | **960×540 = 1/4 解像度 ✗** |
+| `webPreferences.offscreen.deviceScaleFactor: 1` | **無視される**（×2 のまま） | **効く**（×1） | 効く（デフォルトと同じ） |
+| `force-device-scale-factor=1` スイッチ | OSR には無効（×2 のまま） | 未測定 | no-op（元から 1.0） |
+
+## 根本原因（Electron 側の変更）
+
+Electron の breaking changes に明記されている:
+
+> Offscreen rendering will use `1.0` as default device scale factor.（従来は primary display の scale factor を使っており、ユーザー環境によって出力サイズが変わっていた。42 から定数 1.0 に変更。）
+
+移行パスとして `webPreferences.offscreen.deviceScaleFactor` が **41 で追加**（未指定時は旧挙動 = display scale を維持）され、**42 でデフォルトが 1.0 に反転**した。実測もこれと完全に一致する（41 ではオプション指定時のみ 1.0、42 では無指定でも 1.0）。
+
+Cannelloni が併用した `force-device-scale-factor=1` は、40 では OSR に対して無効であることを実測確認。42 で彼らの症状が直ったのは **`pixelExact` を外したことが本質**で、スイッチは（OSR に関しては）お守りだった。
+
+## 各消費者への影響の整理
+
+| 消費者 | Electron | 現状 | 将来リスク |
+|---|---|---|---|
+| Genovese | ^40.0.0 | `pixelExact: true` が設計通り機能 | **42 へ上げた瞬間に 1/4 解像度になる**（texture-bridge 未対応のまま上げた場合） |
+| Cannelloni | ^42.4.0 | `pixelExact` 削除 + スイッチで運用（実質: 42 のデフォルト 1.0 に依存） | texture-bridge が 42 対応すれば workaround 一式を撤去できる |
+| README の Retina 警告 | — | 「DIP × scaleFactor で膨らむ」記述は **41 まで**の挙動。42 では黒画面の主因ではなくなった | 版別の記述が必要 |
+
+## texture-bridge の修正方針（提案）
+
+鍵は「**推測せず、Electron 41 で追加された `offscreen.deviceScaleFactor` で明示的に固定する**」こと。
+
+- **Electron ≥ 41**: `createTextureBridge` は常に `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を設定する（ユーザーが `webPreferences` で明示指定した場合はそちらを尊重）。
+  - これで **DIP = px が全環境で決定論的**になり、`TextureBridgeOptions.width/height` の「pixels」という文書上の契約（Genovese AGENTS.md が指摘した不一致）が**そのまま真になる**
+  - `pixelExact` は「framebuffer を width×height px に固定する」という約束が自明に満たされるため **no-op（実質 deprecated）**。DIP 割り算は行わない（行うと 42 系で 1/4 化する）
+- **Electron 40**: `deviceScaleFactor` が無視されるため現行ロジック維持（`pixelExact: true` で DIP 割り算、false なら DIP×scale + README 警告）。
+- 判定は `process.versions.electron` の major で分岐（41 を境界に）。
+- ドキュメント: README の Retina/DPI 節を版別に書き直し。Cannelloni へは「0.14.x 以降 + Electron 42 で `pixelExact` 削除・スイッチ撤去可能」、Genovese へは「Electron 42 に上げる前に texture-bridge を上げること」という移行ガイドを追記。
+
+### この設計が Cannelloni の症状を再現條件ごと解消する理由
+
+1/4 解像度は「`pixelExact` の DIP 割り算」×「42 の scale 1.0」の掛け算で起きた。≥41 で DIP 割り算を廃止し scale を 1 に固定すれば、割り算も掛け算も存在しなくなる。
+
+## 残課題 / 未測定
+
+- Windows での同挙動の確認（display scaling 150%/175% 環境。CI の windows-native-smoke ではヘッドレスのため scale 検証は不可 — 実機確認が必要）
+- Electron 41 の `force-device-scale-factor` の OSR への影響（本筋に影響しないため未測定）
+- マルチディスプレイ（scale の異なる外部ディスプレイ）で 40/41 のデフォルトがどちらの scale を拾うか
+
+## Sources
+
+- [Electron Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes) — "Offscreen rendering will use `1.0` as default device scale factor"
+- [Electron Offscreen Rendering tutorial](https://www.electronjs.org/docs/latest/tutorial/offscreen-rendering/)
+- [electron/electron#45428 — Documentation / tests for 'useSharedTexture' offscreen mode on macOS](https://github.com/electron/electron/issues/45428)
+- Cannelloni `reports/2026-06-17-syphon-quarter-resolution-pixelexact.md`（1/4 解像度の一次報告）
+- Genovese `src/main/bootstrap/texture-bridge-setup.ts:32-38`（pixelExact 使用箇所）/ `AGENTS.md:47`（width/height 契約不一致の指摘）


### PR DESCRIPTION
## Summary

backlog #3（`pixelExact` 再検証）の実装。調査レポート `reports/2026-08-11-pixelexact-osr-scale-investigation.md`（本 PR でコミット）が根拠。

### 背景 — 消費者間の矛盾の正体
Electron 42 の breaking change で OSR のデフォルト device scale factor が display scale → **1.0** に変更された。`pixelExact` の DIP 割り算はこの前提変化により **Electron 42 で 1/4 解像度**を引き起こす（Electron 40 では設計通り動作）。同一マシンで Electron 40.2.1 / 41.10.4 / 42.4.0 を並べた実測マトリクスで確定。

### 変更
- **`OsrScalePolicy`**（純関数 3 つで判定、非公開・単体テスト済み）
  - **Electron ≥ 41（unit-scale）**: `webPreferences.offscreen.deviceScaleFactor: 1` を明示固定 + `enableLargerThanScreen` 常時 ON → `width`/`height` = 実ピクセルが全ディスプレイで決定論的に成立。`pixelExact` は自明に満たされ実質 no-op
  - **Electron 40（device-scale）**: レガシー経路を維持（`deviceScaleFactor` は 40 では無視されることを実測確認）
  - ユーザー指定の `webPreferences.offscreen` は全体が優先
- resize / rollback も同じ policy で配線。sender は常に pixel-space（テストで不変条件を assert）
- README EN+JA: 版別の Retina/DPI 節・Electron 42 移行ガイド・Troubleshooting の整合
- 実測用 probe スクリプト（`packages/renderer/scripts/osr-scale-probe.cjs`）と調査レポートをコミット

### 消費者への効果
- Cannelloni（Electron 42）: `pixelExact` 削除・`force-device-scale-factor` 等の workaround が不要になる
- Genovese（Electron 40, `pixelExact: true`）: 挙動不変のまま、将来の 42 アップグレードで自動的に安全側へ

## Test plan
- renderer 157/157 pass（policy 純関数 / options 出し分け / createTextureBridge 配線（41+/40 両系統）/ resize / rollback-then-rethrow / sender pixel-space 不変条件）、core 14/14
- 実機: example（Electron 40）~55fps・frameDropped 0（レガシー挙動不変）/ Electron 42 + scaleFactor 2 ディスプレイで probe が codedSize 1920×1080 を返すことを確認
- `pnpm lint`（0 errors）/ `pnpm typecheck` / 両 build（`[esm-shim-guard] OK`）

## 残課題
- Windows の display scaling 実機検証（`enableLargerThanScreen` が macOS-only のため、README に未検証の旨を明記済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)