### PR TITLE
feat: DI seam (createTextureBridgeWith) + synchronous dispose + package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,6 +1132,23 @@ making `width`/`height` mean exact pixels on every display.
 
 Empirical background: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`.
 
+## Migration: Synchronous dispose (v0.14+)
+
+Starting from v0.14, `dispose()` also `destroy()`s the offscreen
+`renderWindow` synchronously instead of `close()`-ing it — see the
+`dispose()` notes under [`TextureBridge`](#texturebridge) above for the two
+consumer-visible changes this brings (disposed-time window access, missing
+close/beforeunload events).
+
+If you previously worked around the old async `close()` by calling
+`bridge.dispose()` and then your own `bridge.renderWindow.destroy()`,
+**remove that external `destroy()` call** — calling it after `dispose()` now
+targets an already-destroyed window, and Electron does not guarantee a second
+`destroy()` is safe. Guard it or move it before `dispose()` if you can't
+remove it right away
+(`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`, or
+call it **before** `dispose()`, not after).
+
 ## Migration: Explicit Disposal (v0.6+)
 
 Starting from v0.6, `stop()` and `dispose()` are **terminal operations** that immediately release native GPU/IPC resources. Previously, resource cleanup depended on JavaScript garbage collection timing.
@@ -1177,17 +1194,6 @@ const bridge = await createTextureBridge({ ... });
 // ... use bridge ...
 bridge.dispose(); // now deterministic
 ```
-
-`dispose()` also `destroy()`s the offscreen `renderWindow` synchronously
-instead of `close()`-ing it — see the `dispose()` notes under
-[`TextureBridge`](#texturebridge) above for the two consumer-visible changes
-this brings (disposed-time window access, missing close/beforeunload events).
-If you previously worked around the old async `close()` by calling
-`bridge.dispose()` and then your own `bridge.renderWindow.destroy()`,
-**remove that external `destroy()` call** — calling it after `dispose()` now
-targets an already-destroyed window, and Electron does not guarantee a second
-`destroy()` is safe. Guard it or move it before `dispose()` if you can't
-remove it right away (see above).
 
 **`using` declarations** (Node.js 22+, `"lib": ["ESNext.Disposable"]`):
 

--- a/README.md
+++ b/README.md
@@ -667,10 +667,17 @@ Electron's `before-quit` and pop a crash dialog. Two things follow from that:
   `closed` event still fires.
 
 The preview window is unaffected: it's a real, visible window and still
-closes via `close()` with normal close semantics. If you previously called
-`renderWindow.destroy()` yourself as a workaround, it's now redundant — the
-call is idempotent (guarded against double-destroy), so leaving it in place
-is harmless too.
+closes via `close()` with normal close semantics. If you previously worked
+around the old async `close()` by calling `bridge.dispose()` followed by your
+own `bridge.renderWindow.destroy()`, **remove that external `destroy()` call**
+— `dispose()` now does it for you, and Electron does not guarantee a second
+`destroy()` on an already-destroyed window is safe (it can throw "Object has
+been destroyed"). The library's own guard only covers its *internal*
+`destroy()` call inside `dispose()`; it does not protect an external call made
+*after* `dispose()` returns. If you must keep the workaround temporarily,
+either guard it yourself
+(`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`) or
+call it **before** `dispose()`, not after.
 
 #### `createWorkerRenderer(options)` (from `renderer/client`)
 
@@ -1175,8 +1182,12 @@ bridge.dispose(); // now deterministic
 instead of `close()`-ing it — see the `dispose()` notes under
 [`TextureBridge`](#texturebridge) above for the two consumer-visible changes
 this brings (disposed-time window access, missing close/beforeunload events).
-If you previously called `renderWindow.destroy()` yourself as a workaround,
-it's now redundant but harmless to leave in place.
+If you previously worked around the old async `close()` by calling
+`bridge.dispose()` and then your own `bridge.renderWindow.destroy()`,
+**remove that external `destroy()` call** — calling it after `dispose()` now
+targets an already-destroyed window, and Electron does not guarantee a second
+`destroy()` is safe. Guard it or move it before `dispose()` if you can't
+remove it right away (see above).
 
 **`using` declarations** (Node.js 22+, `"lib": ["ESNext.Disposable"]`):
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ Do you want to push raw RGBA without Electron at all (test / CI / sanity check)?
         See "Minimal sanity check (no Electron)" below.
 ```
 
+### Package roles and dependency direction
+
+```
+@napolab/texture-bridge-renderer   High-level factory API (recommended): createTextureBridge,
+        │                          receivers, discovery, preview
+        ▼
+@napolab/texture-bridge-core       Low-level primitives: TextureSender / TextureReceiver,
+        │                          sendTextureFromPaintEvent — Electron optional
+        ▼
+@napolab/texture-bridge            Native addon (napi-rs binding)
+        │
+        ▼
+@napolab/texture-bridge-darwin-arm64 / -darwin-x64 / -win32-x64-msvc
+                                   Prebuilt platform binaries (installed automatically)
+```
+
 ## Architecture
 
 ### Sending (Electron → VJ Software)
@@ -583,6 +599,29 @@ interface PreviewOptions {
 
 **`pixelExact`** — when `true`, the offscreen framebuffer is pinned to exactly `width × height` pixels regardless of the host display's device pixel ratio. **Electron ≥ 41:** trivially satisfied and effectively a no-op — `createTextureBridge` already pins `offscreen.deviceScaleFactor: 1`, so the framebuffer is always exact whether or not this option is set. **Electron 40:** without it, a Retina (scaleFactor 2) or Windows-scaled (150% / 175%) display produces a framebuffer larger than the declared sender size, which typically shows up as black/garbled output in the receiver (see the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling)). The sender is always registered at the requested pixel size, so receivers see the dimensions you asked for. Note: non-divisible scale ratios (e.g. `1920 / 1.75`) can leave a 1-pixel discrepancy, and only the primary display's scaleFactor at construction time is honored — call `resize()` to re-apply after a DPI change.
 
+#### `createTextureBridgeWith(deps)` (advanced)
+
+```typescript
+interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => TextureSender;
+}
+
+function createTextureBridgeWith(
+  deps: TextureBridgeDeps,
+): (options: TextureBridgeOptions) => Promise<TextureBridge>;
+```
+
+Returns `createTextureBridge` bound to injected constructors — lets tests and
+embedders swap the `BrowserWindow` construction or the native `TextureSender`
+construction with test doubles. `createTextureBridge` itself is just
+`createTextureBridgeWith` bound to the real `BrowserWindow` and `TextureSender`.
+The factory still calls Electron's `app` / `screen` globals directly and
+constructs the preview window itself (`PreviewManager`) — this seam does not
+make the factory Electron-free, only its window/sender construction is
+injectable. A fully Electron-free test environment needs `app` / `screen`
+mocked separately.
+
 #### `TextureBridge`
 
 The returned handle provides:
@@ -616,6 +655,22 @@ again only after a successful send or a reason change. If a drop latches
 before your listener is attached (e.g. while the renderer page is still
 loading), read `bridge.droppedReason` — it holds the latest drop reason, or
 `null` after a successful send.
+
+`dispose()` destroys the offscreen `renderWindow` synchronously via
+`destroy()` (not `close()`), so teardown cannot lose the race against
+Electron's `before-quit` and pop a crash dialog. Two things follow from that:
+
+- **`disposed` listeners must not touch `bridge.renderWindow.webContents`** —
+  the offscreen window is already destroyed by the time `disposed` fires.
+- **The render window's `close` event and the page's `beforeunload`/`unload`
+  handlers no longer fire** — that's `destroy()`'s documented behavior. Its
+  `closed` event still fires.
+
+The preview window is unaffected: it's a real, visible window and still
+closes via `close()` with normal close semantics. If you previously called
+`renderWindow.destroy()` yourself as a workaround, it's now redundant — the
+call is idempotent (guarded against double-destroy), so leaving it in place
+is harmless too.
 
 #### `createWorkerRenderer(options)` (from `renderer/client`)
 
@@ -1115,6 +1170,13 @@ const bridge = await createTextureBridge({ ... });
 // ... use bridge ...
 bridge.dispose(); // now deterministic
 ```
+
+`dispose()` also `destroy()`s the offscreen `renderWindow` synchronously
+instead of `close()`-ing it — see the `dispose()` notes under
+[`TextureBridge`](#texturebridge) above for the two consumer-visible changes
+this brings (disposed-time window access, missing close/beforeunload events).
+If you previously called `renderWindow.destroy()` yourself as a workaround,
+it's now redundant but harmless to leave in place.
 
 **`using` declarations** (Node.js 22+, `"lib": ["ESNext.Disposable"]`):
 

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -42,6 +42,22 @@ Electron 無しで生 RGBA を流したい（テスト / CI / サニティチェ
         後述の「Electron 無しの最小サニティチェック」を参照。
 ```
 
+### パッケージの役割と依存方向
+
+```
+@napolab/texture-bridge-renderer   高レベルファクトリ API（推奨）: createTextureBridge、
+        │                          レシーバー、ディスカバリ、プレビュー
+        ▼
+@napolab/texture-bridge-core       低レベルプリミティブ: TextureSender / TextureReceiver、
+        │                          sendTextureFromPaintEvent — Electron はオプション
+        ▼
+@napolab/texture-bridge            ネイティブアドオン（napi-rs バインディング）
+        │
+        ▼
+@napolab/texture-bridge-darwin-arm64 / -darwin-x64 / -win32-x64-msvc
+                                   プリビルド済みプラットフォームバイナリ（自動インストール）
+```
+
 ## アーキテクチャ
 
 ```
@@ -349,6 +365,29 @@ interface PreviewOptions {
 
 **`pixelExact`** — `true` のとき、ホストディスプレイの DPR に関係なくオフスクリーンフレームバッファを正確に `width × height` ピクセルに固定します。**Electron ≥ 41:** 自明に満たされ実質的に no-op です — `createTextureBridge` がすでに `offscreen.deviceScaleFactor: 1` を固定しているため、このオプションの有無に関わらずフレームバッファは常に正確です。**Electron 40:** 指定しないと Retina（scaleFactor 2）や Windows スケーリング（150% / 175%）のディスプレイでは宣言したセンダーサイズより大きいフレームバッファが生成され、多くの場合レシーバーで黒画面/崩れになります（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。センダーは常に要求ピクセルサイズで登録されるため、レシーバーは指定どおりの寸法を受け取ります。注意: 割り切れないスケール比（例: `1920 / 1.75`）では 1 ピクセルの誤差が残ることがあり、構築時のプライマリディスプレイの scaleFactor のみが反映されます — DPI 変更後は `resize()` で再適用してください。
 
+#### `createTextureBridgeWith(deps)`（上級者向け）
+
+```typescript
+interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => TextureSender;
+}
+
+function createTextureBridgeWith(
+  deps: TextureBridgeDeps,
+): (options: TextureBridgeOptions) => Promise<TextureBridge>;
+```
+
+注入されたコンストラクタに束縛された `createTextureBridge` を返します —
+テストや組み込み側が `BrowserWindow` の構築や、ネイティブ `TextureSender` の
+構築をテストダブルに差し替えられるようにするためのものです。
+`createTextureBridge` 自体も、実際の `BrowserWindow` / `TextureSender` に束縛した
+`createTextureBridgeWith` にすぎません。ファクトリは Electron の `app` / `screen`
+グローバルを引き続き直接参照し、プレビューウィンドウも自前で構築します
+（`PreviewManager`）— このシームはウィンドウ / センダーの構築のみを注入可能にし、
+ファクトリ全体を Electron 非依存にするものではありません。完全に Electron 無しの
+テスト環境が必要な場合は、`app` / `screen` を別途モックしてください。
+
 #### `TextureBridge`
 
 返されるハンドル：
@@ -382,6 +421,23 @@ interface TextureBridge {
 ドロップが確定していた場合（例: レンダラーページがまだロード中の場合）は、
 `bridge.droppedReason` を読んでください — 最新のドロップ理由、または成功した送信の後は
 `null` を保持します。
+
+`dispose()` は、オフスクリーンの `renderWindow` を `close()` ではなく
+`destroy()` で同期的に破棄します。これにより、Electron の `before-quit` との
+競合でクラッシュダイアログが出るリスクがなくなります。ここから 2 点が
+帰結します:
+
+- **`disposed` リスナーで `bridge.renderWindow.webContents` に触れてはいけません** —
+  `disposed` が発火する時点で、オフスクリーンウィンドウはすでに破棄済みです。
+- **レンダーウィンドウの `close` イベントと、ページの `beforeunload`/`unload`
+  ハンドラはもう発火しません** — これは `destroy()` の仕様どおりの挙動です。
+  `closed` イベントは引き続き発火します。
+
+プレビューウィンドウは影響を受けません: 実在する可視ウィンドウであり、
+引き続き `close()` により通常のクローズセマンティクスで閉じます。以前
+ワークアラウンドとして自前で `renderWindow.destroy()` を呼んでいた場合、
+今は不要になっていますが（呼び出しは二重破棄に対してガードされ冪等なため）
+残しておいても害はありません。
 
 #### `createWorkerRenderer(options)`（`renderer/client` から）
 

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -434,10 +434,18 @@ interface TextureBridge {
   `closed` イベントは引き続き発火します。
 
 プレビューウィンドウは影響を受けません: 実在する可視ウィンドウであり、
-引き続き `close()` により通常のクローズセマンティクスで閉じます。以前
-ワークアラウンドとして自前で `renderWindow.destroy()` を呼んでいた場合、
-今は不要になっていますが（呼び出しは二重破棄に対してガードされ冪等なため）
-残しておいても害はありません。
+引き続き `close()` により通常のクローズセマンティクスで閉じます。以前、
+旧来の非同期な `close()` を避けるため `bridge.dispose()` の後に自前で
+`bridge.renderWindow.destroy()` を呼ぶワークアラウンドをしていた場合は、
+**その外部からの `destroy()` 呼び出しを削除してください** — `dispose()` が
+今はそれを内部で行うため、`dispose()` の後に呼ぶとすでに破棄済みのウィンドウ
+に対して呼び出すことになり、Electron は二重の `destroy()` が安全であることを
+保証していません（"Object has been destroyed" で例外になり得ます）。ライブラリ
+側のガードは `dispose()` 内部の呼び出しのみを保護するものであり、`dispose()`
+呼び出し後に外部から呼ばれる `destroy()` までは保護しません。すぐに削除できない
+場合は、自分でガードする
+（`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`）か、
+`dispose()` より前に呼び出すようにしてください。
 
 #### `createWorkerRenderer(options)`（`renderer/client` から）
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@napolab/texture-bridge-core",
   "version": "0.13.1",
-  "description": "High-level GPU texture sharing for Electron (Spout + Syphon Metal)",
+  "description": "Low-level GPU texture sharing primitives for Electron (Spout + Syphon Metal): TextureSender/TextureReceiver + paint-event helpers",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",

--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -9,10 +9,16 @@ import { app, BrowserWindow, globalShortcut, ipcMain } from "electron";
 import path from "path";
 import { createTextureBridge, createSharedTextureReceiver } from "@napolab/texture-bridge-renderer";
 import { listSenders } from "@napolab/texture-bridge";
+import type { TextureBridge } from "@napolab/texture-bridge-renderer";
 
 // GPU acceleration flags
 app.commandLine.appendSwitch("enable-features", "SharedArrayBuffer");
 app.commandLine.appendSwitch("force-device-scale-factor", "1");
+
+// Hoisted so the `before-quit` handler below (registered outside the
+// `app.whenReady()` closure) can tear the bridge down deterministically —
+// mirrors the `activeReceiver` null-guard pattern used for the receiver.
+let activeBridge: TextureBridge | null = null;
 
 function getRendererUrl(): string {
   if (process.env.ELECTRON_RENDERER_URL) {
@@ -43,6 +49,7 @@ app.whenReady().then(async () => {
     // raymarching shader emits alpha=0 for background pixels.
     includeAlpha: true,
   });
+  activeBridge = bridge;
 
   bridge.on("fps", (fps) => {
     console.log(`[example] FPS: ${fps.toFixed(1)}`);
@@ -163,4 +170,8 @@ app.on("window-all-closed", () => {
 
 app.on("before-quit", () => {
   globalShortcut.unregisterAll();
+  if (activeBridge) {
+    activeBridge.dispose();
+    activeBridge = null;
+  }
 });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -64,6 +64,7 @@ import {
   buildBrowserWindowOptions,
   computeDipSize,
   createTextureBridge,
+  createTextureBridgeWith,
   resolveElectronMajor,
   resolveOsrScalePolicy,
   resolveWindowDipSize,
@@ -593,6 +594,26 @@ describe("createTextureBridge — OSR scale policy wiring", () => {
       expect(windowOptions?.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
       expect(senderCtorArgs).toContainEqual(["test", 1920, 1080]);
     });
+  });
+});
+
+describe("createTextureBridgeWith — dependency injection seam", () => {
+  it("routes window and sender construction through the injected deps", async () => {
+    const createWindow = vi.fn(
+      (options: Electron.BrowserWindowConstructorOptions) => new BrowserWindow(options),
+    );
+    const createSender = vi.fn(
+      (name: string, width: number, height: number) => new TextureSender(name, width, height),
+    );
+
+    const bridge = await createTextureBridgeWith({ createWindow, createSender })(baseOpts);
+
+    expect(createWindow).toHaveBeenCalledTimes(1);
+    expect(createWindow.mock.calls[0]?.[0]?.webPreferences?.offscreen).toBeDefined();
+    expect(createSender).toHaveBeenCalledWith("test", 1920, 1080);
+
+    bridge.resize(1280, 720);
+    expect(createSender).toHaveBeenCalledWith("test", 1280, 720);
   });
 });
 

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -55,7 +55,7 @@ vi.mock("@napolab/texture-bridge-core", () => ({
       }
       if (name !== undefined) senderCtorArgs.push([name, width ?? 0, height ?? 0]);
     }
-    stop(): void {}
+    stop = vi.fn();
   },
   sendTextureFromPaintEvent: vi.fn(),
 }));
@@ -615,6 +615,24 @@ describe("createTextureBridgeWith — dependency injection seam", () => {
     bridge.resize(1280, 720);
     expect(createSender).toHaveBeenCalledWith("test", 1280, 720);
   });
+
+  it("routes the resize rollback reconstruction through the injected createSender", async () => {
+    const createWindow = vi.fn(
+      (options: Electron.BrowserWindowConstructorOptions) => new BrowserWindow(options),
+    );
+    const createSender = vi.fn(
+      (name: string, width: number, height: number) => new TextureSender(name, width, height),
+    );
+    const bridge = await createTextureBridgeWith({ createWindow, createSender })(baseOpts);
+    createSender.mockClear();
+
+    senderCtorBehavior.throwsRemaining = 1;
+    expect(() => bridge.resize(1280, 720)).toThrow("sender ctor failed");
+
+    expect(createSender).toHaveBeenCalledTimes(2);
+    expect(createSender).toHaveBeenNthCalledWith(1, "test", 1280, 720);
+    expect(createSender).toHaveBeenNthCalledWith(2, "test", 1920, 1080);
+  });
 });
 
 describe("TextureBridgeImpl.dispose — synchronous teardown", () => {
@@ -637,5 +655,29 @@ describe("TextureBridgeImpl.dispose — synchronous teardown", () => {
     bridge.dispose();
 
     expect(win.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the teardown order: destroy window → stop sender → dispose preview → emit disposed", () => {
+    const win = new BrowserWindow();
+    const sender = new TextureSender("t", 16, 9);
+    const previewDispose = vi.fn();
+    const previewStub: unknown = { dispose: previewDispose };
+    const bridge = new TextureBridgeImpl(win, sender, previewStub as PreviewManager, baseOpts);
+    const disposedListener = vi.fn();
+    bridge.on("disposed", disposedListener);
+
+    bridge.dispose();
+
+    expect(win.destroy).toHaveBeenCalledTimes(1);
+    expect(sender.stop).toHaveBeenCalledTimes(1);
+    expect(previewDispose).toHaveBeenCalledTimes(1);
+    expect(disposedListener).toHaveBeenCalledTimes(1);
+    const order = [
+      vi.mocked(win.destroy).mock.invocationCallOrder[0],
+      vi.mocked(sender.stop).mock.invocationCallOrder[0],
+      previewDispose.mock.invocationCallOrder[0],
+      disposedListener.mock.invocationCallOrder[0],
+    ];
+    expect([...order].sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual(order);
   });
 });

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -25,7 +25,8 @@ vi.mock("electron", () => ({
     isDestroyed(): boolean {
       return false;
     }
-    close(): void {}
+    close = vi.fn();
+    destroy = vi.fn();
   },
   screen: {
     getPrimaryDisplay: () => getPrimaryDisplayMock(),
@@ -592,5 +593,28 @@ describe("createTextureBridge — OSR scale policy wiring", () => {
       expect(windowOptions?.webPreferences?.offscreen).toEqual({ useSharedTexture: true });
       expect(senderCtorArgs).toContainEqual(["test", 1920, 1080]);
     });
+  });
+});
+
+describe("TextureBridgeImpl.dispose — synchronous teardown", () => {
+  it("destroys the render window synchronously instead of close()", () => {
+    const win = new BrowserWindow();
+    const bridge = new TextureBridgeImpl(win, new TextureSender("t", 16, 9), null, baseOpts);
+
+    bridge.dispose();
+
+    expect(win.destroy).toHaveBeenCalledTimes(1);
+    expect(win.close).not.toHaveBeenCalled();
+    expect(bridge.isDisposed).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    const win = new BrowserWindow();
+    const bridge = new TextureBridgeImpl(win, new TextureSender("t", 16, 9), null, baseOpts);
+
+    bridge.dispose();
+    bridge.dispose();
+
+    expect(win.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -233,9 +233,13 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     if (this._disposed) return;
     this._disposed = true;
 
-    // Remove paint listener by destroying the window
+    // Destroy the offscreen window synchronously. `close()` is async and
+    // cancellable — it loses the race against `before-quit`, letting Chromium
+    // SIGKILL the OSR renderer and pop a crash dialog. Both known consumers
+    // independently worked around this by forcing `destroy()`; a hidden
+    // offscreen window has no user-facing close semantics to honor.
     if (!this._renderWindow.isDestroyed()) {
-      this._renderWindow.close();
+      this._renderWindow.destroy();
     }
 
     this.sender.stop();

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -91,6 +91,8 @@ interface PaintEvent extends Event {
  * Note: the factory still consults Electron's `app` / `screen` globals and
  * constructs the preview window directly, so a fully Electron-free test
  * environment additionally needs those mocked.
+ * Future dependencies will be added as optional fields, so object literals
+ * passing only these two members keep compiling.
  */
 export interface TextureBridgeDeps {
   createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
@@ -277,8 +279,9 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
  * Build the BrowserWindow constructor options for the offscreen renderer.
  *
  * Extracted as a pure function so it can be unit tested without touching
- * Electron's native module — the actual `new BrowserWindow(...)` call lives
- * in `createTextureBridge`.
+ * Electron's native module — the actual construction happens through
+ * `TextureBridgeDeps.createWindow` — `createTextureBridge` binds it to
+ * `new BrowserWindow(...)`.
  *
  * `options.includeAlpha` flips the OSR pipeline into alpha-preserving mode:
  * `transparent: true` plus `backgroundColor: "#00000000"` on the BrowserWindow
@@ -337,7 +340,9 @@ export const createTextureBridgeWith =
   (deps: TextureBridgeDeps) =>
   async (options: TextureBridgeOptions): Promise<TextureBridge> => {
     if (!app.isReady()) {
-      throw new Error("createTextureBridge() must be called after app.whenReady()");
+      throw new Error(
+        "createTextureBridge()/createTextureBridgeWith() must be called after app.whenReady()",
+      );
     }
 
     const { name, width, height, frameRate = 60, rendererUrl, preview } = options;
@@ -395,7 +400,10 @@ export const createTextureBridgeWith =
     return bridge;
   };
 
-/** {@link createTextureBridgeWith} bound to the real BrowserWindow / TextureSender. */
+/**
+ * {@link createTextureBridgeWith} bound to the real BrowserWindow / TextureSender.
+ * Must be called after `app.whenReady()`.
+ */
 export const createTextureBridge = createTextureBridgeWith({
   createWindow: (options) => new BrowserWindow(options),
   createSender: (name, width, height) => new TextureSender(name, width, height),

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -83,6 +83,17 @@ interface PaintEvent extends Event {
   texture?: PaintTexture;
 }
 
+/**
+ * Injectable constructors for {@link createTextureBridgeWith}. Lets tests and
+ * embedders swap the BrowserWindow / native sender without faking Electron
+ * globals (the pattern consumers previously built themselves as
+ * `createDeckWith(createBridge)`).
+ */
+export interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => InstanceType<typeof TextureSender>;
+}
+
 /** Exported for unit tests — not part of the package's public entry point. */
 export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
   private _renderWindow: BrowserWindow;
@@ -93,6 +104,7 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
   private lastDropReason: PaintDefect["reason"] | null = null;
   private options: TextureBridgeOptions;
   private readonly policy: OsrScalePolicy;
+  private readonly createSender: TextureBridgeDeps["createSender"];
 
   constructor(
     renderWindow: BrowserWindow,
@@ -100,6 +112,8 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     previewManager: PreviewManager | null,
     options: TextureBridgeOptions,
     policy: OsrScalePolicy = resolveOsrScalePolicy(resolveElectronMajor(process.versions)),
+    createSender: TextureBridgeDeps["createSender"] = (name, width, height) =>
+      new TextureSender(name, width, height),
   ) {
     super();
     this._renderWindow = renderWindow;
@@ -107,6 +121,7 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     this.previewManager = previewManager;
     this.options = options;
     this.policy = policy;
+    this.createSender = createSender;
   }
 
   get renderWindow(): BrowserWindow {
@@ -210,7 +225,7 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     //    If the new sender fails, restore one with the original dimensions.
     this.sender.stop();
     try {
-      this.sender = new TextureSender(this.options.name, width, height);
+      this.sender = this.createSender(this.options.name, width, height);
     } catch (err) {
       this.options = prevOpts;
       const prevDip = resolveWindowDipSize(
@@ -219,7 +234,7 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
         screen.getPrimaryDisplay().scaleFactor,
       );
       this._renderWindow.setSize(prevDip.width, prevDip.height);
-      this.sender = new TextureSender(prevOpts.name, prevOpts.width, prevOpts.height);
+      this.sender = this.createSender(prevOpts.name, prevOpts.width, prevOpts.height);
       throw err;
     }
 
@@ -315,53 +330,70 @@ export function buildBrowserWindowOptions(
  *
  * Must be called after `app.whenReady()`.
  */
-export async function createTextureBridge(options: TextureBridgeOptions): Promise<TextureBridge> {
-  if (!app.isReady()) {
-    throw new Error("createTextureBridge() must be called after app.whenReady()");
-  }
+export const createTextureBridgeWith =
+  (deps: TextureBridgeDeps) =>
+  async (options: TextureBridgeOptions): Promise<TextureBridge> => {
+    if (!app.isReady()) {
+      throw new Error("createTextureBridge() must be called after app.whenReady()");
+    }
 
-  const { name, width, height, frameRate = 60, rendererUrl, preview } = options;
+    const { name, width, height, frameRate = 60, rendererUrl, preview } = options;
 
-  const policy = resolveOsrScalePolicy(resolveElectronMajor(process.versions));
+    const policy = resolveOsrScalePolicy(resolveElectronMajor(process.versions));
 
-  // ---- Offscreen BrowserWindow ----
-  // Window DIP size per the OSR scale policy: under unit-scale DIP == px so the
-  // requested size passes through; under device-scale (Electron ≤ 40) pixelExact
-  // pre-divides by the primary display's scaleFactor. The sender below always
-  // uses pixel-space dimensions.
-  const dip = resolveWindowDipSize(options, policy, screen.getPrimaryDisplay().scaleFactor);
-  const renderWindow = new BrowserWindow(buildBrowserWindowOptions({ ...options, ...dip }, policy));
+    // ---- Offscreen BrowserWindow ----
+    // Window DIP size per the OSR scale policy: under unit-scale DIP == px so the
+    // requested size passes through; under device-scale (Electron ≤ 40) pixelExact
+    // pre-divides by the primary display's scaleFactor. The sender below always
+    // uses pixel-space dimensions.
+    const dip = resolveWindowDipSize(options, policy, screen.getPrimaryDisplay().scaleFactor);
+    const renderWindow = deps.createWindow(
+      buildBrowserWindowOptions({ ...options, ...dip }, policy),
+    );
 
-  // ---- Native sender ----
-  const sender = new TextureSender(name, width, height);
+    // ---- Native sender ----
+    const sender = deps.createSender(name, width, height);
 
-  // ---- Preview ----
-  let previewManager: PreviewManager | null = null;
-  if (preview?.enabled !== false && preview) {
-    previewManager = new PreviewManager(width, height, preview);
-    previewManager.open();
-  }
+    // ---- Preview ----
+    let previewManager: PreviewManager | null = null;
+    if (preview?.enabled !== false && preview) {
+      previewManager = new PreviewManager(width, height, preview);
+      previewManager.open();
+    }
 
-  // ---- Bridge instance ----
-  const bridge = new TextureBridgeImpl(renderWindow, sender, previewManager, options, policy);
+    // ---- Bridge instance ----
+    const bridge = new TextureBridgeImpl(
+      renderWindow,
+      sender,
+      previewManager,
+      options,
+      policy,
+      deps.createSender,
+    );
 
-  // ---- Paint handler (delegates to instance method, no private field access) ----
-  renderWindow.webContents.on("paint", (event: PaintEvent) => {
-    bridge.handlePaint(event);
-  });
+    // ---- Paint handler (delegates to instance method, no private field access) ----
+    renderWindow.webContents.on("paint", (event: PaintEvent) => {
+      bridge.handlePaint(event);
+    });
 
-  renderWindow.webContents.setFrameRate(frameRate);
+    renderWindow.webContents.setFrameRate(frameRate);
 
-  // ---- Load renderer URL ----
-  if (rendererUrl.startsWith("http://") || rendererUrl.startsWith("https://")) {
-    await renderWindow.loadURL(rendererUrl);
-  } else if (rendererUrl.startsWith("file://")) {
-    await renderWindow.loadURL(rendererUrl);
-  } else {
-    await renderWindow.loadFile(rendererUrl);
-  }
+    // ---- Load renderer URL ----
+    if (rendererUrl.startsWith("http://") || rendererUrl.startsWith("https://")) {
+      await renderWindow.loadURL(rendererUrl);
+    } else if (rendererUrl.startsWith("file://")) {
+      await renderWindow.loadURL(rendererUrl);
+    } else {
+      await renderWindow.loadFile(rendererUrl);
+    }
 
-  bridge.emit("ready");
+    bridge.emit("ready");
 
-  return bridge;
-}
+    return bridge;
+  };
+
+/** {@link createTextureBridgeWith} bound to the real BrowserWindow / TextureSender. */
+export const createTextureBridge = createTextureBridgeWith({
+  createWindow: (options) => new BrowserWindow(options),
+  createSender: (name, width, height) => new TextureSender(name, width, height),
+});

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -85,9 +85,12 @@ interface PaintEvent extends Event {
 
 /**
  * Injectable constructors for {@link createTextureBridgeWith}. Lets tests and
- * embedders swap the BrowserWindow / native sender without faking Electron
- * globals (the pattern consumers previously built themselves as
- * `createDeckWith(createBridge)`).
+ * embedders substitute the two heavyweight resources — the offscreen
+ * BrowserWindow and the native TextureSender — with doubles (the pattern
+ * consumers previously built themselves as `createDeckWith(createBridge)`).
+ * Note: the factory still consults Electron's `app` / `screen` globals and
+ * constructs the preview window directly, so a fully Electron-free test
+ * environment additionally needs those mocked.
  */
 export interface TextureBridgeDeps {
   createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1,4 +1,5 @@
-export { createTextureBridge } from "./bridge";
+export { createTextureBridge, createTextureBridgeWith } from "./bridge";
+export type { TextureBridgeDeps } from "./bridge";
 export { createTextureReceiver } from "./receiver";
 export { createSharedTextureReceiver } from "./shared-texture-receiver";
 export { SenderDiscovery } from "./discovery";

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -130,7 +130,12 @@ export interface TextureBridge {
    */
   readonly droppedReason: PaintDefect["reason"] | null;
 
-  /** Tear down all resources. Terminal operation — the bridge cannot be reused afterward. */
+  /**
+   * Tear down all resources synchronously. The offscreen window is
+   * `destroy()`ed (not `close()`d) so teardown cannot lose the race against
+   * `before-quit` — no separate `renderWindow.destroy()` workaround is needed.
+   * Terminal operation — the bridge cannot be reused afterward.
+   */
   dispose(): void;
 
   /** Alias for dispose(), enabling `using bridge = await createTextureBridge(...)` */

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -131,10 +131,12 @@ export interface TextureBridge {
   readonly droppedReason: PaintDefect["reason"] | null;
 
   /**
-   * Tear down all resources synchronously. The offscreen window is
-   * `destroy()`ed (not `close()`d) so teardown cannot lose the race against
-   * `before-quit` — no separate `renderWindow.destroy()` workaround is needed.
-   * Terminal operation — the bridge cannot be reused afterward.
+   * Tear down all resources. The offscreen window is `destroy()`ed
+   * synchronously (not `close()`d) so teardown cannot lose the race against
+   * `before-quit` — no separate `renderWindow.destroy()` workaround is
+   * needed. The preview window (a visible window with real close semantics)
+   * still closes normally via `close()`. Terminal operation — the bridge
+   * cannot be reused afterward.
    */
   dispose(): void;
 


### PR DESCRIPTION
## Summary

調査レポート backlog #5 / #6 / #7 の実装（計画: `docs/superpowers/plans/2026-08-12-di-seam-sync-dispose-docs.md`）。

### #6 — `dispose()` の同期 teardown 化（`fix(renderer)!`）
- offscreen window を `close()`（async・cancellable）ではなく **`destroy()`（sync）** で破棄。`before-quit` との競合で Chromium が OSR renderer を SIGKILL しクラッシュダイアログが出る問題を根治
- Genovese / Cannelloni が**独立に実装していた** `renderWindow.destroy()` workaround が不要になる（残す場合の安全な順序も README に明記）
- teardown 順序は不変（destroy → sender.stop → preview.dispose → `disposed` emit）で、順序をロックするテストを追加
- **BREAKING CHANGE footer** で consumer 可視の影響を CHANGELOG に明示: `close`/`beforeunload`/`unload` は発火しない（`closed` は発火）、`disposed` リスナーから `renderWindow.webContents` に触れない
- README に「Migration: Synchronous dispose (v0.14+)」節を新設

### #5 — `createTextureBridgeWith(deps)` の公開（feat）
- `TextureBridgeDeps = { createWindow, createSender }` を注入できる curried factory。Cannelloni が自作していた `createDeckWith(createBridge)` パターンのライブラリ版
- `resize()` の sender 再構築（forward / rollback とも）が注入経路を通ることをスパイでテスト
- JSDoc は seam の実際の範囲（app/screen globals・PreviewManager は直接使用）と進化契約（将来の deps は optional 追加）を明記

### #7 — パッケージドキュメント（docs）
- core package.json の description を「High-level」→ 低レベル primitives の正しい説明へ修正（Cannelloni doc-feedback §1）
- README EN+JA に依存方向図 + 役割テーブル（renderer → core → native → platform binaries）
- example が `before-quit` で `bridge.dispose()` を実行（推奨パターンの模範）

## Test plan
- renderer 162/162 pass（dispose destroy/idempotent/teardown 順序、DI seam forward+rollback、既存全系統）、core 14/14
- 実機: example 起動 ~40fps・drop/error 0・クリーン終了
- `pnpm lint`（0 errors）/ `pnpm typecheck` / 両 build（`[esm-shim-guard] OK`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)