### PR TITLE
refactor(core): rules compliance + TextureSendError via fromThrowable

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,11 @@ Returns `undefined` when the frame was handed to the sender, or a `PaintDefect`
 the `unsupported-platform` variant also carries the offending `platform`)
 when the frame was dropped. Drops are normal no-ops, not errors — surface them
 in your own paint loop the same way `createTextureBridge` does with its
-`frameDropped` event. Native send failures still throw.
+`frameDropped` event. Native send failures throw a `TextureSendError`
+(exported from both packages) — the message is preserved and the original
+thrown value is available on `error.cause`. With `createTextureBridge`,
+these surface on the bridge's `error` event, so you can discriminate with
+`instanceof TextureSendError`.
 
 #### `TextureSender`
 

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -490,7 +490,10 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
 `unsupported-platform` バリアントには該当する `platform` も含まれます）を返します。
 ドロップは通常のノーオペレーションであり、エラーではありません — `createTextureBridge` が
 `frameDropped` イベントで行っているのと同様に、自前の paint ループでも表面化させてください。
-ネイティブの送信失敗は引き続き throw されます。
+ネイティブの送信失敗は `TextureSendError`（両パッケージからエクスポートされます）として
+throw されます — メッセージはそのまま保持され、元の throw 値は `error.cause` から参照できます。
+`createTextureBridge` を使っている場合、これらはブリッジの `error` イベントとして表面化するため、
+`instanceof TextureSendError` で判別できます。
 
 #### `TextureSender`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@napolab/texture-bridge": "workspace:*"
+    "@napolab/texture-bridge": "workspace:*",
+    "neverthrow": "^8.2.0"
   },
   "peerDependencies": {
     "electron": ">=40.0.0"

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -215,12 +215,14 @@ describe("sendTextureFromPaintEvent", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
 
     try {
-      const { sendTextureFromPaintEvent, TextureSender } = await import("../index");
+      const { sendTextureFromPaintEvent, TextureSendError, TextureSender } =
+        await import("../index");
       const sender = new TextureSender("Test", 1920, 1080);
 
       // After stop(), sendSurface should throw
+      const nativeError = new Error("TextureSender has been stopped");
       mockSendSurface.mockImplementation(() => {
-        throw new Error("TextureSender has been stopped");
+        throw nativeError;
       });
       sender.stop();
 
@@ -231,9 +233,47 @@ describe("sendTextureFromPaintEvent", () => {
         handle: { ioSurface: Buffer.alloc(8) },
       };
 
-      expect(() => sendTextureFromPaintEvent(sender, textureInfo)).toThrow(
-        "TextureSender has been stopped",
-      );
+      try {
+        sendTextureFromPaintEvent(sender, textureInfo);
+        expect.unreachable("sendTextureFromPaintEvent should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TextureSendError);
+        expect((err as Error).message).toBe("TextureSender has been stopped");
+        expect((err as Error).cause).toBe(nativeError);
+      }
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("wraps non-Error thrown values with stringified message and cause", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    try {
+      const { sendTextureFromPaintEvent, TextureSendError, TextureSender } =
+        await import("../index");
+      const sender = new TextureSender("Test", 1920, 1080);
+
+      mockSendSurface.mockImplementation(() => {
+        throw "native boom";
+      });
+
+      const textureInfo = {
+        pixelFormat: "bgra" as const,
+        codedSize: { width: 1920, height: 1080 },
+        visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+        handle: { ioSurface: Buffer.alloc(8) },
+      };
+
+      try {
+        sendTextureFromPaintEvent(sender, textureInfo);
+        expect.unreachable("sendTextureFromPaintEvent should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TextureSendError);
+        expect((err as Error).message).toBe("native boom");
+        expect((err as Error).cause).toBe("native boom");
+      }
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Error classes for the core package's error channel (see
+ * .claude/skills/modeling-errors-as-classes). `name` is a stable wire/log
+ * discriminator; in-process discrimination uses `instanceof`.
+ */
+
+/** The native sender's `send()` / `sendSurface()` threw. */
+export class TextureSendError extends Error {
+  override name = "TextureSendError";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,11 +17,14 @@ import type {
 
 // Attach Symbol.dispose to native classes so `using` declarations work.
 // napi-rs cannot expose symbol-named methods, so we patch the prototypes here.
+// `function` expressions (not arrows) are required for the `this` binding.
 if (typeof Symbol.dispose === "symbol") {
-  (TextureSender.prototype as any)[Symbol.dispose] = function () {
+  TextureSender.prototype[Symbol.dispose] = function (this: InstanceType<typeof TextureSender>) {
     this.stop();
   };
-  (TextureReceiver.prototype as any)[Symbol.dispose] = function () {
+  TextureReceiver.prototype[Symbol.dispose] = function (
+    this: InstanceType<typeof TextureReceiver>,
+  ) {
     this.stop();
   };
 }
@@ -59,27 +62,28 @@ export type { SharedTextureFrame } from "@napolab/texture-bridge";
  * errors — but callers should surface them instead of letting output go
  * silently black. Native send failures still throw as before.
  */
-export function sendTextureFromPaintEvent(
+export const sendTextureFromPaintEvent = (
   sender: InstanceType<typeof TextureSender>,
   textureInfo: TextureInfo | undefined,
-): PaintDefect | undefined {
+): PaintDefect | undefined => {
   if (!textureInfo) return { reason: "no-texture" };
   const { handle, codedSize } = textureInfo;
 
-  if (process.platform === "win32") {
-    const ntHandle = handle.ntHandle;
-    if (!ntHandle || !Buffer.isBuffer(ntHandle)) return { reason: "no-nt-handle" };
-    const handleValue = Number(ntHandle.readBigInt64LE(0));
-    sender.send(handleValue, codedSize.width, codedSize.height);
-    return undefined;
+  switch (process.platform) {
+    case "win32": {
+      const ntHandle = handle.ntHandle;
+      if (!ntHandle || !Buffer.isBuffer(ntHandle)) return { reason: "no-nt-handle" };
+      const handleValue = Number(ntHandle.readBigInt64LE(0));
+      sender.send(handleValue, codedSize.width, codedSize.height);
+      return undefined;
+    }
+    case "darwin": {
+      const ioSurface = handle.ioSurface;
+      if (!ioSurface) return { reason: "no-io-surface" };
+      sender.sendSurface(ioSurface, codedSize.width, codedSize.height);
+      return undefined;
+    }
+    default:
+      return { reason: "unsupported-platform", platform: process.platform };
   }
-
-  if (process.platform === "darwin") {
-    const ioSurface = handle.ioSurface;
-    if (!ioSurface) return { reason: "no-io-surface" };
-    sender.sendSurface(ioSurface, codedSize.width, codedSize.height);
-    return undefined;
-  }
-
-  return { reason: "unsupported-platform", platform: process.platform };
-}
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+import { Result } from "neverthrow";
 import {
   TextureSender,
   TextureReceiver,
@@ -5,6 +6,7 @@ import {
   getPlatform,
   listSenders,
 } from "@napolab/texture-bridge";
+import { TextureSendError } from "./errors";
 import type {
   TextureInfo,
   PaintTexture,
@@ -40,6 +42,7 @@ declare module "@napolab/texture-bridge" {
 }
 
 export { TextureSender, TextureReceiver, closeNativeHandle, getPlatform, listSenders };
+export { TextureSendError } from "./errors";
 export type {
   TextureInfo,
   PaintTexture,
@@ -52,21 +55,16 @@ export type {
 export type { SharedTextureFrame } from "@napolab/texture-bridge";
 
 /**
- * Send a texture from an Electron paint event to Syphon/Spout.
- *
- * Handles platform detection and buffer extraction automatically.
- *
- * @returns `undefined` when the texture was handed to the sender, or a
- * {@link PaintDefect} describing why the frame was dropped. Drops are normal
- * no-ops (e.g. Chromium delivered a paint without a shareable handle), not
- * errors — but callers should surface them instead of letting output go
- * silently black. Native send failures still throw as before.
+ * Platform dispatch onto the native sender. Returns a {@link PaintDefect}
+ * when the frame was dropped (no shareable handle / unsupported platform).
+ * `send()` / `sendSurface()` can still throw (e.g. "TextureSender has been
+ * stopped") — the public entry point below folds that throw through
+ * `Result.fromThrowable`.
  */
-export const sendTextureFromPaintEvent = (
+const dispatchSend = (
   sender: InstanceType<typeof TextureSender>,
-  textureInfo: TextureInfo | undefined,
+  textureInfo: TextureInfo,
 ): PaintDefect | undefined => {
-  if (!textureInfo) return { reason: "no-texture" };
   const { handle, codedSize } = textureInfo;
 
   switch (process.platform) {
@@ -86,4 +84,43 @@ export const sendTextureFromPaintEvent = (
     default:
       return { reason: "unsupported-platform", platform: process.platform };
   }
+};
+
+/**
+ * `dispatchSend` with its throw folded into
+ * `Result<PaintDefect | undefined, TextureSendError>`. Bound once at module
+ * scope — `Result.fromThrowable` forwards the arguments.
+ */
+const safeDispatchSend = Result.fromThrowable(
+  dispatchSend,
+  (cause) => new TextureSendError(cause instanceof Error ? cause.message : `${cause}`, { cause }),
+);
+
+/**
+ * Send a texture from an Electron paint event to Syphon/Spout.
+ *
+ * Handles platform detection and buffer extraction automatically.
+ *
+ * @returns `undefined` when the texture was handed to the sender, or a
+ * {@link PaintDefect} describing why the frame was dropped. Drops are normal
+ * no-ops (e.g. Chromium delivered a paint without a shareable handle), not
+ * errors — but callers should surface them instead of letting output go
+ * silently black. The native `send()` / `sendSurface()` throw is wrapped with
+ * `Result.fromThrowable` and consumed here with a single `.match` — the
+ * `Result` never crosses the public API. On native failure a
+ * {@link TextureSendError} is thrown with the original message preserved and
+ * the thrown value on `Error.cause`.
+ */
+export const sendTextureFromPaintEvent = (
+  sender: InstanceType<typeof TextureSender>,
+  textureInfo: TextureInfo | undefined,
+): PaintDefect | undefined => {
+  if (!textureInfo) return { reason: "no-texture" };
+
+  return safeDispatchSend(sender, textureInfo).match(
+    (defect) => defect,
+    (error) => {
+      throw error;
+    },
+  );
 };

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["ES2020", "ESNext.Disposable"]
+    "lib": ["ES2020", "ES2022.Error", "ESNext.Disposable"]
   },
   "include": ["src"]
 }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -16,3 +16,4 @@ export type {
 } from "./shared-texture-receiver";
 export type { SenderDiscoveryEvents } from "./discovery";
 export type { PaintDefect } from "@napolab/texture-bridge-core";
+export { TextureSendError } from "@napolab/texture-bridge-core";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       electron:
         specifier: '>=40.0.0'
         version: 40.2.1
+      neverthrow:
+        specifier: ^8.2.0
+        version: 8.2.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -2018,6 +2021,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neverthrow@8.2.0:
+    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
+    engines: {node: '>=18'}
 
   node-abi@4.26.0:
     resolution: {integrity: sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==}
@@ -4567,6 +4574,10 @@ snapshots:
   nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
+
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
 
   node-abi@4.26.0:
     dependencies:


### PR DESCRIPTION
## Summary

旧 stacked PR **#58 + #64** の統合再実装（計画: `docs/superpowers/plans/2026-08-12-refactor-stack-revival.md` Task 1/5）。close 済み PR の diff を一次ソースに、#67 以降の新シグネチャ（`PaintDefect | undefined` 返却）へ適応して移植。

### rules compliance（旧 #58）
- `(TextureSender.prototype as any)` ×2 → 型付き `function(this: InstanceType<...>)`（`this` バインドのため arrow 不可 — sanctioned exception コメント付き）
- platform dispatch を if-chain → `switch (process.platform)`（default = `unsupported-platform` defect）
- `sendTextureFromPaintEvent` を arrow const 化。`Number(BigInt)` 行は type-coercion ルール対象外（文字列変換ではない）のため維持

### `TextureSendError`（旧 #64）
- `packages/core/src/errors.ts` 新規。native throw 点（`sender.send` / `sendSurface`）を **module-scope named `Result.fromThrowable`** + edge の `.match` で包み、message 保持 + 元の値を `cause` に載せて `TextureSendError` を throw
- **Result は公開 API に出さない**（neverthrow-api-boundary / consuming-results-at-api-boundaries スキル準拠 — スキルの canonical 例と同型）
- renderer からも **value re-export** — `createTextureBridge` の `error` イベントで `instanceof TextureSendError` 判別が可能に
- README EN/JA の throw 契約を更新

## Test plan
- core 15/15（TextureSendError ラップ・非 Error throw の cause 保持・全 defect 分岐）、renderer 162/162（dist 型再解決含む）
- `pnpm lint`（0 errors）/ `pnpm typecheck` / core build

旧 #58/#64 は close のまま（本 PR が後継）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)