### PR TITLE
refactor(renderer): shared toError helper + arrow-style cleanup

### DIFF
--- a/packages/renderer/src/__tests__/to-error.test.ts
+++ b/packages/renderer/src/__tests__/to-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { toError } from "../to-error";
+
+describe("toError", () => {
+  it("returns Error instances unchanged", () => {
+    const error = new Error("boom");
+    expect(toError(error)).toBe(error);
+  });
+
+  it("returns Error subclasses unchanged", () => {
+    const error = new TypeError("bad type");
+    expect(toError(error)).toBe(error);
+  });
+
+  it("wraps a string into an Error with the string as message", () => {
+    expect(toError("boom").message).toBe("boom");
+  });
+
+  it("wraps non-string primitives via stringification", () => {
+    expect(toError(42).message).toBe("42");
+    expect(toError(undefined).message).toBe("undefined");
+    expect(toError(null).message).toBe("null");
+  });
+
+  it("preserves the original non-Error value on `cause`", () => {
+    const wrapped = toError("boom");
+    expect(wrapped.cause).toBe("boom");
+
+    const wrappedNumber = toError(42);
+    expect(wrappedNumber.cause).toBe(42);
+  });
+
+  it("does not set `cause` when the value is already an Error", () => {
+    const error = new Error("boom");
+    expect(toError(error).cause).toBeUndefined();
+  });
+});

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -9,6 +9,7 @@ import {
 import { PreviewManager } from "./preview-manager";
 import { FpsCounter } from "./fps-counter";
 import type { TextureBridgeOptions, TextureBridge } from "./types";
+import { toError } from "./to-error";
 
 /**
  * Convert a pixel-space size to a device-independent (DIP) size for a given
@@ -20,11 +21,11 @@ import type { TextureBridgeOptions, TextureBridge } from "./types";
  * 1097.14 → 1097 → 1097 × 1.75 = 1919.75, which Chromium typically rounds
  * back to 1920).
  */
-export function computeDipSize(
+export const computeDipSize = (
   pixelWidth: number,
   pixelHeight: number,
   scaleFactor: number,
-): { width: number; height: number } {
+): { width: number; height: number } => {
   if (scaleFactor <= 0) {
     return { width: Math.max(1, pixelWidth), height: Math.max(1, pixelHeight) };
   }
@@ -32,7 +33,7 @@ export function computeDipSize(
     width: Math.max(1, Math.round(pixelWidth / scaleFactor)),
     height: Math.max(1, Math.round(pixelHeight / scaleFactor)),
   };
-}
+};
 
 /**
  * How the OSR compositor maps the window's DIP size to the shared-texture
@@ -179,8 +180,7 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
       }
       this.previewManager?.sendFrame(texture);
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     } finally {
       texture.release?.();
     }
@@ -295,10 +295,10 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
  * pixel size, which may exceed the display's work area); under
  * `"device-scale"` behavior is unchanged from before this option existed.
  */
-export function buildBrowserWindowOptions(
+export const buildBrowserWindowOptions = (
   options: TextureBridgeOptions,
   policy: OsrScalePolicy,
-): Electron.BrowserWindowConstructorOptions {
+): Electron.BrowserWindowConstructorOptions => {
   const { width, height, webPreferences, includeAlpha, pixelExact } = options;
 
   const offscreen =
@@ -328,7 +328,7 @@ export function buildBrowserWindowOptions(
     // so both keys must be applied together.
     ...(includeAlpha ? { transparent: true, backgroundColor: "#00000000" } : {}),
   };
-}
+};
 
 /**
  * Create a fully-wired texture bridge: offscreen window, native sender,
@@ -363,11 +363,9 @@ export const createTextureBridgeWith =
     const sender = deps.createSender(name, width, height);
 
     // ---- Preview ----
-    let previewManager: PreviewManager | null = null;
-    if (preview?.enabled !== false && preview) {
-      previewManager = new PreviewManager(width, height, preview);
-      previewManager.open();
-    }
+    const previewManager =
+      preview && preview.enabled !== false ? new PreviewManager(width, height, preview) : null;
+    previewManager?.open();
 
     // ---- Bridge instance ----
     const bridge = new TextureBridgeImpl(
@@ -387,9 +385,11 @@ export const createTextureBridgeWith =
     renderWindow.webContents.setFrameRate(frameRate);
 
     // ---- Load renderer URL ----
-    if (rendererUrl.startsWith("http://") || rendererUrl.startsWith("https://")) {
-      await renderWindow.loadURL(rendererUrl);
-    } else if (rendererUrl.startsWith("file://")) {
+    const isUrlScheme =
+      rendererUrl.startsWith("http://") ||
+      rendererUrl.startsWith("https://") ||
+      rendererUrl.startsWith("file://");
+    if (isUrlScheme) {
       await renderWindow.loadURL(rendererUrl);
     } else {
       await renderWindow.loadFile(rendererUrl);

--- a/packages/renderer/src/client/index.ts
+++ b/packages/renderer/src/client/index.ts
@@ -46,7 +46,7 @@ export interface WorkerRendererHandle {
  *
  * This runs in the renderer process (browser context) only.
  */
-export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRendererHandle {
+export const createWorkerRenderer = (options: WorkerRendererOptions): WorkerRendererHandle => {
   const { worker, width, height } = options;
 
   const canvas = options.canvas ?? document.createElement("canvas");
@@ -87,4 +87,4 @@ export function createWorkerRenderer(options: WorkerRendererOptions): WorkerRend
       observer.disconnect();
     },
   };
-}
+};

--- a/packages/renderer/src/client/shared-texture-consumer.ts
+++ b/packages/renderer/src/client/shared-texture-consumer.ts
@@ -20,6 +20,7 @@
  */
 
 import { sharedTexture } from "electron";
+import { toError } from "../to-error";
 import { createMultiDispatcher } from "./multi-dispatcher";
 
 export interface SharedTextureConsumerFrame {
@@ -151,7 +152,7 @@ export const consumeSharedTexture = (
       // A consumer whose `onError` itself throws must not crash the outer
       // try/finally (which would leak VideoFrame.close()).
       try {
-        handlers.onError?.(err instanceof Error ? err : new Error(String(err)));
+        handlers.onError?.(toError(err));
       } catch (handlerErr) {
         console.error("[consumeSharedTexture] onError handler threw:", handlerErr);
       }

--- a/packages/renderer/src/discovery.ts
+++ b/packages/renderer/src/discovery.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { listSenders } from "@napolab/texture-bridge-core";
 import type { SenderInfo } from "@napolab/texture-bridge-core";
+import { toError } from "./to-error";
 
 export interface SenderDiscoveryEvents {
   updated: [senders: SenderInfo[]];
@@ -68,8 +69,7 @@ export class SenderDiscovery extends EventEmitter {
         this.emit("updated", current);
       }
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     }
   }
 

--- a/packages/renderer/src/receiver.ts
+++ b/packages/renderer/src/receiver.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { TextureReceiver } from "@napolab/texture-bridge-core";
 import type { ReceivedFrame } from "@napolab/texture-bridge-core";
 import { FpsCounter } from "./fps-counter";
+import { toError } from "./to-error";
 
 export interface TextureReceiverBridgeOptions {
   senderName: string;
@@ -96,8 +97,7 @@ class TextureReceiverBridgeImpl extends EventEmitter implements TextureReceiverB
         this.emit("fps", fps);
       }
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     }
   }
 
@@ -109,16 +109,15 @@ class TextureReceiverBridgeImpl extends EventEmitter implements TextureReceiverB
       if (!frame) return;
       this._onFrame(frame);
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
     }
   }
 }
 
-export function createTextureReceiver(
+export const createTextureReceiver = (
   options: TextureReceiverBridgeOptions,
-): TextureReceiverBridge {
+): TextureReceiverBridge => {
   const { senderName, appName, serverUuid, pollIntervalMs = 16 } = options;
   const receiver = new TextureReceiver(senderName, appName, serverUuid);
   return new TextureReceiverBridgeImpl(receiver, pollIntervalMs);
-}
+};

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -14,6 +14,7 @@ import type { WebContents } from "electron";
 import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge-core";
 import type { SharedTextureFrame } from "@napolab/texture-bridge-core";
 import { FpsCounter } from "./fps-counter";
+import { toError } from "./to-error";
 
 /**
  * Safely release a native shared-texture handle that was minted by the native
@@ -225,8 +226,7 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
     try {
       frame = this.receiver.receiveSharedTexture();
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this._recordTickError(error);
+      this._recordTickError(toError(err));
       return;
     }
     if (!frame) return;
@@ -296,8 +296,7 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
     try {
       imported = sharedTexture.importSharedTexture({ textureInfo });
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
       // importSharedTexture threw before taking ownership — release the handle
       // ourselves so we don't leak a per-frame NT HANDLE / IOSurface.
       releaseUnconsumedHandle(frame.handle);
@@ -318,8 +317,7 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       return "delivered";
     } catch (err) {
       if (this._disposed) return "skipped";
-      const error = err instanceof Error ? err : new Error(String(err));
-      this.emit("error", error);
+      this.emit("error", toError(err));
       return "failed";
     } finally {
       imported.release();
@@ -350,9 +348,9 @@ type SendResult = "delivered" | "failed" | "skipped";
  *
  * @experimental Requires Electron 40+ `sharedTexture` module.
  */
-export function createSharedTextureReceiver(
+export const createSharedTextureReceiver = (
   options: SharedTextureReceiverOptions,
-): SharedTextureReceiverBridge {
+): SharedTextureReceiverBridge => {
   const {
     senderName,
     appName,
@@ -374,4 +372,4 @@ export function createSharedTextureReceiver(
     receiver.setFlipY(flipY);
   }
   return new SharedTextureReceiverBridgeImpl(receiver, target, extraArgs, pollIntervalMs);
-}
+};

--- a/packages/renderer/src/to-error.ts
+++ b/packages/renderer/src/to-error.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalize an unknown `catch` value into an `Error` instance. `Error`
+ * instances pass through unchanged; anything else is stringified into the
+ * message and the original value is preserved on `cause` for debugging.
+ * Shared by every bridge that emits `"error"` events from a `catch` block.
+ */
+export const toError = (value: unknown): Error => {
+  if (value instanceof Error) return value;
+  return new Error(`${value}`, { cause: value });
+};

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["ES2020", "DOM", "ESNext.Disposable"]
+    "lib": ["ES2020", "DOM", "ESNext.Disposable", "ES2022.Error"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

旧 stacked PR **#59 + #61（有効分）** の再実装（計画: `docs/superpowers/plans/2026-08-12-refactor-stack-revival.md` Task 2/5）。

- **`to-error.ts` 新規**: `catch` 値の正規化ヘルパー。Error は同一参照素通し、非 Error は template literal message + **`cause` に元の値を保持**
- 生パターン `err instanceof Error ? err : new Error(String(err))` を **8 箇所すべて** `toError()` に置換（`packages/renderer/src` に残存 0）
- **arrow const 化**（シグネチャ不変）: `computeDipSize` / `buildBrowserWindowOptions` / `createTextureReceiver` / `createSharedTextureReceiver` / `createWorkerRenderer`
- `createTextureBridgeWith` 内の URL 分岐収束（http/https/file → 単一 `loadURL` 分岐）と `let previewManager` → const ternary
- `lastW/lastH`（client/index.ts）は **plain `let` を維持** — 旧 #61 の slot-object 化は既決事項（let-ban-pragmatism）により不採用
- tsconfig lib に `ES2022.Error` 追加（`ErrorOptions.cause` の型付け。core が #71 で行った変更と同種の additive）

## Test plan
- renderer **168/168**（+6 toError ユニットテスト。既存 162 は無変更 green = 挙動保存の回帰証明）
- `pnpm lint`（0 errors）/ `pnpm typecheck` clean

旧 #59/#61 は close のまま（本 PR が後継）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)