### PR TITLE
refactor(renderer): internal neverthrow adoption with typed error classes

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -30,7 +30,8 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@napolab/texture-bridge-core": "workspace:*"
+    "@napolab/texture-bridge-core": "workspace:*",
+    "neverthrow": "^8.2.0"
   },
   "peerDependencies": {
     "electron": ">=40.0.0"

--- a/packages/renderer/src/__tests__/errors.test.ts
+++ b/packages/renderer/src/__tests__/errors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  FrameReceiveError,
+  ReceiverStoppedError,
+  TextureDeliveryError,
+  TextureImportError,
+  UnsupportedPixelFormatError,
+} from "../errors";
+
+describe("renderer error classes", () => {
+  it("carry stable name discriminators", () => {
+    expect(new FrameReceiveError("x").name).toBe("FrameReceiveError");
+    expect(new TextureImportError("x").name).toBe("TextureImportError");
+    expect(new TextureDeliveryError("x").name).toBe("TextureDeliveryError");
+    expect(new UnsupportedPixelFormatError("nv12", ["bgra"]).name).toBe(
+      "UnsupportedPixelFormatError",
+    );
+    expect(new ReceiverStoppedError(10).name).toBe("ReceiverStoppedError");
+  });
+
+  it("are Error instances discriminable via instanceof", () => {
+    const error: Error = new TextureImportError("boom");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(TextureImportError);
+    expect(error instanceof TextureDeliveryError).toBe(false);
+  });
+
+  it("preserve the wrapped message and cause", () => {
+    const cause = new Error("import failed badly");
+    const wrapped = new TextureImportError(cause.message, { cause });
+    expect(wrapped.message).toBe("import failed badly");
+    expect(wrapped.cause).toBe(cause);
+  });
+
+  it("UnsupportedPixelFormatError formats the public message shape", () => {
+    const error = new UnsupportedPixelFormatError("nv12", ["bgra", "rgba", "rgbaf16"]);
+    expect(error.message).toBe(
+      'shared texture frame has unsupported pixelFormat "nv12" (expected one of bgra, rgba, rgbaf16)',
+    );
+  });
+
+  it("ReceiverStoppedError formats the circuit-breaker message shape", () => {
+    expect(new ReceiverStoppedError(10).message).toBe(
+      "shared texture receiver stopped after 10 consecutive errors",
+    );
+  });
+});

--- a/packages/renderer/src/__tests__/preview-manager.test.ts
+++ b/packages/renderer/src/__tests__/preview-manager.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TextureInfo } from "@napolab/texture-bridge-core";
+
+// -- electron mock ----------------------------------------------------------
+//
+// PreviewManager talks to `BrowserWindow`, `ipcMain`, and `sharedTexture`.
+// We stub all three so the module can be imported under vitest's node
+// environment (no real Electron runtime) — same approach as bridge.test.ts.
+
+const mockImportSharedTexture = vi.fn();
+const mockSendSharedTexture = vi.fn();
+const mockIpcMainOn = vi.fn();
+const mockIpcMainRemoveListener = vi.fn();
+
+vi.mock("electron", () => {
+  let nextWebContentsId = 1;
+
+  class MockBrowserWindow {
+    webContents: { id: number; mainFrame: unknown };
+    loadFile = vi.fn();
+    close = vi.fn(() => {
+      this._destroyed = true;
+    });
+    private _destroyed = false;
+    private closedListeners: Array<() => void> = [];
+
+    constructor() {
+      this.webContents = { id: nextWebContentsId++, mainFrame: { marker: "main-frame" } };
+    }
+
+    isDestroyed(): boolean {
+      return this._destroyed;
+    }
+
+    on(event: string, listener: () => void): void {
+      if (event === "closed") this.closedListeners.push(listener);
+    }
+  }
+
+  return {
+    BrowserWindow: MockBrowserWindow,
+    ipcMain: {
+      on: (event: string, listener: (event: { sender: { id: number } }) => void) =>
+        mockIpcMainOn(event, listener),
+      removeListener: (event: string, listener: unknown) =>
+        mockIpcMainRemoveListener(event, listener),
+    },
+    sharedTexture: {
+      importSharedTexture: (opts: unknown) => mockImportSharedTexture(opts),
+      sendSharedTexture: (opts: unknown) => mockSendSharedTexture(opts),
+    },
+  };
+});
+
+import { PreviewManager } from "../preview-manager";
+
+const flushPromises = async () => {
+  for (const _ of Array.from({ length: 10 })) {
+    await Promise.resolve();
+  }
+};
+
+const makeTextureInfo = (): TextureInfo => ({
+  pixelFormat: "bgra",
+  codedSize: { width: 1920, height: 1080 },
+  visibleRect: { x: 0, y: 0, width: 1920, height: 1080 },
+  handle: {},
+});
+
+/** Open the manager and simulate the renderer's `preview-ready` IPC ack. */
+const openReadyManager = (): PreviewManager => {
+  const manager = new PreviewManager(1920, 1080);
+  manager.open();
+
+  const win = manager.window;
+  if (!win) throw new Error("expected window to be open");
+
+  const call = mockIpcMainOn.mock.calls.at(-1) as
+    | [string, (event: { sender: { id: number } }) => void]
+    | undefined;
+  if (!call) throw new Error("expected a preview-ready listener to be registered");
+  call[1]({ sender: { id: win.webContents.id } });
+
+  return manager;
+};
+
+describe("PreviewManager.sendFrame", () => {
+  const mockImported = { release: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockImportSharedTexture.mockReturnValue(mockImported);
+    mockSendSharedTexture.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("swallows a synchronous throw from importSharedTexture", () => {
+    mockImportSharedTexture.mockImplementation(() => {
+      throw new Error("import boom");
+    });
+
+    const manager = openReadyManager();
+
+    expect(() => manager.sendFrame({ textureInfo: makeTextureInfo() })).not.toThrow();
+    expect(mockSendSharedTexture).not.toHaveBeenCalled();
+
+    manager.dispose();
+  });
+
+  it("swallows a synchronous throw from sendSharedTexture after a successful import", async () => {
+    mockImportSharedTexture.mockReturnValue(mockImported);
+    mockSendSharedTexture.mockImplementation(() => {
+      throw new Error("send boom");
+    });
+
+    const manager = openReadyManager();
+
+    expect(() => manager.sendFrame({ textureInfo: makeTextureInfo() })).not.toThrow();
+    await flushPromises();
+
+    manager.dispose();
+  });
+
+  it("silently skips when importSharedTexture returns a falsy value", async () => {
+    mockImportSharedTexture.mockReturnValue(undefined);
+
+    const manager = openReadyManager();
+
+    expect(() => manager.sendFrame({ textureInfo: makeTextureInfo() })).not.toThrow();
+    await flushPromises();
+    expect(mockSendSharedTexture).not.toHaveBeenCalled();
+
+    manager.dispose();
+  });
+
+  it("happy path: imports, sends to the preview window, then releases the texture", async () => {
+    mockImportSharedTexture.mockReturnValue(mockImported);
+    mockSendSharedTexture.mockResolvedValue(undefined);
+
+    const manager = openReadyManager();
+    const win = manager.window;
+    if (!win) throw new Error("expected window to be open");
+
+    manager.sendFrame({ textureInfo: makeTextureInfo() });
+    await flushPromises();
+
+    expect(mockSendSharedTexture).toHaveBeenCalledTimes(1);
+    const sendArg = mockSendSharedTexture.mock.calls[0][0] as {
+      frame: unknown;
+      importedSharedTexture: unknown;
+    };
+    expect(sendArg.frame).toBe(win.webContents.mainFrame);
+    expect(sendArg.importedSharedTexture).toBe(mockImported);
+    expect(mockImported.release).toHaveBeenCalledTimes(1);
+
+    manager.dispose();
+  });
+});

--- a/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
+++ b/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
@@ -239,7 +239,7 @@ describe("createSharedTextureReceiver", () => {
     bridge.dispose();
   });
 
-  it("emits 'error' when importSharedTexture throws and does not call sendSharedTexture", () => {
+  it("emits the prepare error on the same tick's microtask queue when importSharedTexture throws, and does not call sendSharedTexture", async () => {
     const handler = vi.fn();
     mockReceiver.receiveSharedTexture.mockReturnValue(makeFrame());
     mockImportSharedTexture.mockImplementation(() => {
@@ -254,6 +254,7 @@ describe("createSharedTextureReceiver", () => {
     bridge.on("error", handler);
     bridge.start();
     vi.advanceTimersByTime(15);
+    await flushPromises();
 
     expect(handler).toHaveBeenCalled();
     expect(handler.mock.calls[0][0]).toBeInstanceOf(TextureImportError);

--- a/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
+++ b/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
@@ -50,6 +50,13 @@ vi.mock("@napolab/texture-bridge-core", () => ({
 }));
 
 import { createSharedTextureReceiver } from "../shared-texture-receiver";
+import {
+  FrameReceiveError,
+  ReceiverStoppedError,
+  TextureDeliveryError,
+  TextureImportError,
+  UnsupportedPixelFormatError,
+} from "../errors";
 
 const makeFrame = (overrides: Partial<MockFrame> = {}): MockFrame => ({
   width: 1920,
@@ -61,8 +68,12 @@ const makeFrame = (overrides: Partial<MockFrame> = {}): MockFrame => ({
 });
 
 const flushPromises = async () => {
-  await Promise.resolve();
-  await Promise.resolve();
+  // Drain the microtask queue enough rounds to settle chained ResultAsync
+  // combinators — the exact hop count is an implementation detail the tests
+  // must not pin.
+  for (const _ of Array.from({ length: 10 })) {
+    await Promise.resolve();
+  }
 };
 
 describe("createSharedTextureReceiver", () => {
@@ -222,6 +233,7 @@ describe("createSharedTextureReceiver", () => {
 
     expect(handler).toHaveBeenCalled();
     expect(handler.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(handler.mock.calls[0][0]).toBeInstanceOf(FrameReceiveError);
     expect((handler.mock.calls[0][0] as Error).message).toBe("native boom");
 
     bridge.dispose();
@@ -244,6 +256,8 @@ describe("createSharedTextureReceiver", () => {
     vi.advanceTimersByTime(15);
 
     expect(handler).toHaveBeenCalled();
+    expect(handler.mock.calls[0][0]).toBeInstanceOf(TextureImportError);
+    expect((handler.mock.calls[0][0] as Error).message).toBe("import failed");
     expect(mockSendSharedTexture).not.toHaveBeenCalled();
 
     bridge.dispose();
@@ -266,6 +280,8 @@ describe("createSharedTextureReceiver", () => {
     await flushPromises();
     expect(mockImported.release).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalled();
+    expect(handler.mock.calls[0][0]).toBeInstanceOf(TextureDeliveryError);
+    expect((handler.mock.calls[0][0] as Error).message).toBe("send failed");
 
     bridge.dispose();
   });
@@ -538,7 +554,9 @@ describe("createSharedTextureReceiver", () => {
     expect(errorHandler).toHaveBeenCalledTimes(11);
     const finalErr = errorHandler.mock.calls[10][0] as Error;
     expect(finalErr).toBeInstanceOf(Error);
+    expect(finalErr).toBeInstanceOf(ReceiverStoppedError);
     expect(finalErr.message).toMatch(/stopped after 10 consecutive errors/);
+    expect(errorHandler.mock.calls[0][0]).toBeInstanceOf(FrameReceiveError);
 
     // Receiver should now be stopped: further timer advancement must not
     // invoke receiveSharedTexture again.
@@ -709,6 +727,7 @@ describe("createSharedTextureReceiver", () => {
     expect(mockSendSharedTexture).not.toHaveBeenCalled();
     expect(errorHandler).toHaveBeenCalled();
     const err = errorHandler.mock.calls[0][0] as Error;
+    expect(err).toBeInstanceOf(UnsupportedPixelFormatError);
     expect(err.message).toMatch(/unsupported pixelFormat/);
     expect(err.message).toMatch(/something-weird/);
 
@@ -769,6 +788,7 @@ describe("createSharedTextureReceiver", () => {
     expect(errorHandler).toHaveBeenCalledTimes(1);
     const emitted = errorHandler.mock.calls[0][0] as Error;
     expect(emitted).toBeInstanceOf(Error);
+    expect(emitted).toBeInstanceOf(UnsupportedPixelFormatError);
     expect(emitted.message).toMatch(/unsupported pixelFormat/);
     expect(emitted.message).toMatch(/yuv420p/);
 
@@ -801,6 +821,7 @@ describe("createSharedTextureReceiver", () => {
     expect(errorHandler).toHaveBeenCalledTimes(1);
     const emitted = errorHandler.mock.calls[0][0] as Error;
     expect(emitted).toBeInstanceOf(Error);
+    expect(emitted).toBeInstanceOf(TextureImportError);
     expect(emitted.message).toBe("import failed badly");
 
     bridge.dispose();

--- a/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
+++ b/packages/renderer/src/__tests__/shared-texture-receiver.test.ts
@@ -71,7 +71,7 @@ const flushPromises = async () => {
   // Drain the microtask queue enough rounds to settle chained ResultAsync
   // combinators — the exact hop count is an implementation detail the tests
   // must not pin.
-  for (const _ of Array.from({ length: 10 })) {
+  for (const _ of Array.from({ length: 20 })) {
     await Promise.resolve();
   }
 };

--- a/packages/renderer/src/discovery.ts
+++ b/packages/renderer/src/discovery.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { listSenders } from "@napolab/texture-bridge-core";
 import type { SenderInfo } from "@napolab/texture-bridge-core";
+import { Result } from "neverthrow";
 import { toError } from "./to-error";
 
 export interface SenderDiscoveryEvents {
@@ -9,6 +10,9 @@ export interface SenderDiscoveryEvents {
   removed: [senders: SenderInfo[]];
   error: [error: Error];
 }
+
+/** `listSenders` with its throw folded into a Result, bound once at module scope. */
+const safeListSenders = Result.fromThrowable(listSenders, toError);
 
 export class SenderDiscovery extends EventEmitter {
   private _senders: SenderInfo[] = [];
@@ -45,31 +49,30 @@ export class SenderDiscovery extends EventEmitter {
   private _refresh(): void {
     if (this._disposed) return;
 
-    try {
-      const current = listSenders();
-      const prev = this._senders;
+    safeListSenders().match(
+      (current) => this._applyUpdate(current),
+      (error) => {
+        this.emit("error", error);
+      },
+    );
+  }
 
-      // Diff: find added senders (in current but not in prev)
-      const added = current.filter((c) => !prev.some((p) => this._isSame(c, p)));
+  /** Diff `current` against the previous snapshot and emit added/removed/updated. */
+  private _applyUpdate(current: SenderInfo[]): void {
+    const prev = this._senders;
+    const added = current.filter((c) => !prev.some((p) => this._isSame(c, p)));
+    const removed = prev.filter((p) => !current.some((c) => this._isSame(c, p)));
 
-      // Diff: find removed senders (in prev but not in current)
-      const removed = prev.filter((p) => !current.some((c) => this._isSame(c, p)));
+    this._senders = current;
 
-      this._senders = current;
-
-      if (added.length > 0) {
-        this.emit("added", added);
-      }
-
-      if (removed.length > 0) {
-        this.emit("removed", removed);
-      }
-
-      if (added.length > 0 || removed.length > 0) {
-        this.emit("updated", current);
-      }
-    } catch (err) {
-      this.emit("error", toError(err));
+    if (added.length > 0) {
+      this.emit("added", added);
+    }
+    if (removed.length > 0) {
+      this.emit("removed", removed);
+    }
+    if (added.length > 0 || removed.length > 0) {
+      this.emit("updated", current);
     }
   }
 

--- a/packages/renderer/src/errors.ts
+++ b/packages/renderer/src/errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Error classes for the renderer package's error channel (see
+ * .claude/skills/modeling-errors-as-classes). `name` is a stable wire/log
+ * discriminator; in-process discrimination uses `instanceof`. Errors that
+ * wrap a caught value MUST preserve the original message
+ * (`new XError(toError(cause).message, { cause })`) — the public error
+ * events are asserted by message in the test suite.
+ */
+
+/** The native receiver's `receiveSharedTexture()` threw. */
+export class FrameReceiveError extends Error {
+  override name = "FrameReceiveError";
+}
+
+/** Electron's `importSharedTexture` threw before taking handle ownership. */
+export class TextureImportError extends Error {
+  override name = "TextureImportError";
+}
+
+/** Electron's `sendSharedTexture` rejected. */
+export class TextureDeliveryError extends Error {
+  override name = "TextureDeliveryError";
+}
+
+/** A frame arrived with a pixel format Electron cannot import. */
+export class UnsupportedPixelFormatError extends Error {
+  override name = "UnsupportedPixelFormatError";
+  constructor(pixelFormat: string, expected: readonly string[]) {
+    super(
+      `shared texture frame has unsupported pixelFormat "${pixelFormat}" (expected one of ${expected.join(", ")})`,
+    );
+  }
+}
+
+/** Circuit breaker: too many consecutive tick errors; the receiver stopped itself. */
+export class ReceiverStoppedError extends Error {
+  override name = "ReceiverStoppedError";
+  constructor(limit: number) {
+    super(`shared texture receiver stopped after ${limit} consecutive errors`);
+  }
+}
+
+/** Union of every failure the shared-texture send pipeline can produce. */
+export type SendPipelineError =
+  | UnsupportedPixelFormatError
+  | TextureImportError
+  | TextureDeliveryError;

--- a/packages/renderer/src/errors.ts
+++ b/packages/renderer/src/errors.ts
@@ -39,9 +39,3 @@ export class ReceiverStoppedError extends Error {
     super(`shared texture receiver stopped after ${limit} consecutive errors`);
   }
 }
-
-/** Union of every failure the shared-texture send pipeline can produce. */
-export type SendPipelineError =
-  | UnsupportedPixelFormatError
-  | TextureImportError
-  | TextureDeliveryError;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -17,3 +17,11 @@ export type {
 export type { SenderDiscoveryEvents } from "./discovery";
 export type { PaintDefect } from "@napolab/texture-bridge-core";
 export { TextureSendError } from "@napolab/texture-bridge-core";
+export {
+  FrameReceiveError,
+  TextureImportError,
+  TextureDeliveryError,
+  UnsupportedPixelFormatError,
+  ReceiverStoppedError,
+} from "./errors";
+export type { SendPipelineError } from "./errors";

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -24,4 +24,3 @@ export {
   UnsupportedPixelFormatError,
   ReceiverStoppedError,
 } from "./errors";
-export type { SendPipelineError } from "./errors";

--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
 import type { TextureInfo } from "@napolab/texture-bridge-core";
 import { Result, ResultAsync, okAsync } from "neverthrow";
+import { sendImportedTexture } from "./send-imported-texture";
 import { toError } from "./to-error";
 import type { PreviewOptions } from "./types";
 
@@ -97,27 +98,15 @@ export class PreviewManager {
 
     // Preview delivery is best-effort by design: both failure channels are
     // intentionally discarded at this edge (the main bridge already reports
-    // real pipeline errors).
+    // real pipeline errors); sendImportedTexture funnels sync throws and
+    // rejections alike into the ResultAsync error channel.
     void safeImportSharedTexture(texture.textureInfo)
       .asyncAndThen((imported) => {
         if (!imported) return okAsync(undefined);
-
-        // Wrap in an async thunk (as `_deliver` in shared-texture-receiver.ts
-        // does): calling an async function never throws synchronously — a
-        // throw inside becomes a promise rejection instead, so both sync
-        // throws and rejections from sendSharedTexture funnel into the
-        // ResultAsync's error channel rather than escaping sendFrame().
-        const send = async (): Promise<void> => {
-          try {
-            await sharedTexture.sendSharedTexture({
-              frame: win.webContents.mainFrame,
-              importedSharedTexture: imported,
-            });
-          } finally {
-            imported.release();
-          }
-        };
-        return ResultAsync.fromPromise(send(), toError);
+        return ResultAsync.fromPromise(
+          sendImportedTexture(win.webContents.mainFrame, imported),
+          toError,
+        );
       })
       .match(
         () => undefined,

--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
 import type { TextureInfo } from "@napolab/texture-bridge-core";
+import { Result, ResultAsync } from "neverthrow";
+import { toError } from "./to-error";
 import type { PreviewOptions } from "./types";
 
 /**
@@ -11,6 +13,15 @@ import type { PreviewOptions } from "./types";
 const assetPath = (filename: string): string => {
   return path.join(__dirname, "assets", filename);
 };
+
+/**
+ * `importSharedTexture` with its throw folded into a Result, bound once at
+ * module scope (arguments are forwarded — no IIFE-style immediate call).
+ */
+const safeImportSharedTexture = Result.fromThrowable(
+  (textureInfo: TextureInfo) => sharedTexture.importSharedTexture({ textureInfo }),
+  toError,
+);
 
 export class PreviewManager {
   private win: BrowserWindow | null = null;
@@ -81,23 +92,26 @@ export class PreviewManager {
   }
 
   sendFrame(texture: { textureInfo: TextureInfo }): void {
-    if (!this.win || this.win.isDestroyed() || !this.ready) return;
+    const win = this.win;
+    if (!win || win.isDestroyed() || !this.ready) return;
 
-    try {
-      const imported = sharedTexture.importSharedTexture({
-        textureInfo: texture.textureInfo,
-      });
-      if (!imported) return;
-
-      sharedTexture
-        .sendSharedTexture({
-          frame: this.win.webContents.mainFrame,
-          importedSharedTexture: imported,
-        })
-        .catch(() => {});
-    } catch {
-      // Ignore preview send errors
-    }
+    // Preview delivery is best-effort by design: both failure channels are
+    // intentionally discarded at this edge (the main bridge already reports
+    // real pipeline errors).
+    void safeImportSharedTexture(texture.textureInfo)
+      .asyncAndThen((imported) =>
+        ResultAsync.fromPromise(
+          sharedTexture.sendSharedTexture({
+            frame: win.webContents.mainFrame,
+            importedSharedTexture: imported,
+          }),
+          toError,
+        ),
+      )
+      .match(
+        () => undefined,
+        () => undefined,
+      );
   }
 
   updateSize(width: number, height: number): void {

--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
 import type { TextureInfo } from "@napolab/texture-bridge-core";
-import { Result, ResultAsync } from "neverthrow";
+import { Result, ResultAsync, okAsync } from "neverthrow";
 import { toError } from "./to-error";
 import type { PreviewOptions } from "./types";
 
@@ -99,15 +99,26 @@ export class PreviewManager {
     // intentionally discarded at this edge (the main bridge already reports
     // real pipeline errors).
     void safeImportSharedTexture(texture.textureInfo)
-      .asyncAndThen((imported) =>
-        ResultAsync.fromPromise(
-          sharedTexture.sendSharedTexture({
-            frame: win.webContents.mainFrame,
-            importedSharedTexture: imported,
-          }),
-          toError,
-        ),
-      )
+      .asyncAndThen((imported) => {
+        if (!imported) return okAsync(undefined);
+
+        // Wrap in an async thunk (as `_deliver` in shared-texture-receiver.ts
+        // does): calling an async function never throws synchronously — a
+        // throw inside becomes a promise rejection instead, so both sync
+        // throws and rejections from sendSharedTexture funnel into the
+        // ResultAsync's error channel rather than escaping sendFrame().
+        const send = async (): Promise<void> => {
+          try {
+            await sharedTexture.sendSharedTexture({
+              frame: win.webContents.mainFrame,
+              importedSharedTexture: imported,
+            });
+          } finally {
+            imported.release();
+          }
+        };
+        return ResultAsync.fromPromise(send(), toError);
+      })
       .match(
         () => undefined,
         () => undefined,

--- a/packages/renderer/src/send-imported-texture.ts
+++ b/packages/renderer/src/send-imported-texture.ts
@@ -1,0 +1,22 @@
+import { sharedTexture } from "electron";
+
+/**
+ * Deliver an imported shared texture to a frame, releasing the import in all
+ * outcomes. Declared at module scope so its dependencies are explicit
+ * arguments — no inner function declarations. Invoking an async function
+ * never throws synchronously (a throw inside becomes a promise rejection
+ * instead), so callers can hand `sendImportedTexture(...)` straight to
+ * `ResultAsync.fromPromise` and both sync throws and rejections from
+ * `sendSharedTexture` funnel into the error channel.
+ */
+export const sendImportedTexture = async (
+  frame: Electron.WebFrameMain,
+  imported: Electron.SharedTextureImported,
+  extraArgs: readonly unknown[] = [],
+): Promise<void> => {
+  try {
+    await sharedTexture.sendSharedTexture({ frame, importedSharedTexture: imported }, ...extraArgs);
+  } finally {
+    imported.release();
+  }
+};

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -13,6 +13,15 @@ import { sharedTexture } from "electron";
 import type { WebContents } from "electron";
 import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge-core";
 import type { SharedTextureFrame } from "@napolab/texture-bridge-core";
+import { Result, ResultAsync, ok, err, okAsync, errAsync } from "neverthrow";
+import {
+  FrameReceiveError,
+  ReceiverStoppedError,
+  TextureDeliveryError,
+  TextureImportError,
+  UnsupportedPixelFormatError,
+} from "./errors";
+import type { SendPipelineError } from "./errors";
 import { FpsCounter } from "./fps-counter";
 import { toError } from "./to-error";
 
@@ -51,6 +60,22 @@ const isValidPixelFormat = (value: string): value is SharedTexturePixelFormat =>
  * permanently broken.
  */
 const MAX_CONSECUTIVE_TICK_ERRORS = 10;
+
+/**
+ * Throwable native/Electron calls, each bound once to a named
+ * `Result.fromThrowable` wrapper (arguments are forwarded — no per-call
+ * wrapping, no IIFE-style immediate invocation).
+ */
+const safeReceiveSharedTexture = Result.fromThrowable(
+  (receiver: InstanceType<typeof TextureReceiver>) => receiver.receiveSharedTexture(),
+  (cause) => new FrameReceiveError(toError(cause).message, { cause }),
+);
+
+const safeImportSharedTexture = Result.fromThrowable(
+  (textureInfo: Electron.SharedTextureImportTextureInfo) =>
+    sharedTexture.importSharedTexture({ textureInfo }),
+  (cause) => new TextureImportError(toError(cause).message, { cause }),
+);
 
 export interface SharedTextureReceiverOptions {
   readonly senderName: string;
@@ -204,12 +229,7 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
     this._consecutiveErrors += 1;
     if (this._consecutiveErrors >= MAX_CONSECUTIVE_TICK_ERRORS) {
       this.stop();
-      this.emit(
-        "error",
-        new Error(
-          `shared texture receiver stopped after ${MAX_CONSECUTIVE_TICK_ERRORS} consecutive errors`,
-        ),
-      );
+      this.emit("error", new ReceiverStoppedError(MAX_CONSECUTIVE_TICK_ERRORS));
     }
   }
 
@@ -259,12 +279,13 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
    * error case return `null` (the tick has nothing further to do either way).
    */
   private _receiveFrame(): SharedTextureFrame | null {
-    try {
-      return this.receiver.receiveSharedTexture();
-    } catch (err) {
-      this._recordTickError(toError(err));
-      return null;
-    }
+    return safeReceiveSharedTexture(this.receiver).match(
+      (frame) => frame,
+      (error) => {
+        this._recordTickError(error);
+        return null;
+      },
+    );
   }
 
   /** Run `_send()` with the `_inFlight` drop-latest flag held for its duration. */
@@ -280,75 +301,96 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   private async _send(frame: SharedTextureFrame): Promise<SendResult> {
     if (this.target.isDestroyed()) {
       // Target is gone — handle was minted but Electron will never consume it.
-      // Release it directly via the native helper so we don't leak
-      // NT HANDLE / IOSurface per frame during window teardown.
       releaseUnconsumedHandle(frame.handle);
       return "skipped";
     }
 
-    if (!isValidPixelFormat(frame.pixelFormat)) {
-      const error = new Error(
-        `shared texture frame has unsupported pixelFormat "${frame.pixelFormat}" (expected one of ${VALID_PIXEL_FORMATS.join(", ")})`,
-      );
-      this.emit("error", error);
-      // Handle was minted but will never reach importSharedTexture — release it
-      // here to avoid leaking an NT HANDLE / IOSurface on unknown pixelFormat.
-      releaseUnconsumedHandle(frame.handle);
-      return "failed";
-    }
-
-    // Wrap the raw handle under the platform-specific key that Electron's
-    // SharedTextureHandle expects.
-    const handle =
-      process.platform === "win32" ? { ntHandle: frame.handle } : { ioSurface: frame.handle };
-
-    const textureInfo: Electron.SharedTextureImportTextureInfo = {
-      codedSize: { width: frame.width, height: frame.height },
-      handle,
-      pixelFormat: frame.pixelFormat,
-    };
-
-    const imported = this._importFrame(textureInfo, frame.handle);
-    if (!imported) return "failed";
-
-    const targetFrame = this.target.mainFrame;
-    if (!targetFrame) {
-      imported.release();
-      return "skipped";
-    }
-
-    try {
-      await sharedTexture.sendSharedTexture(
-        { frame: targetFrame, importedSharedTexture: imported },
-        ...this.extraArgs,
-      );
-      return "delivered";
-    } catch (err) {
-      if (this._disposed) return "skipped";
-      this.emit("error", toError(err));
-      return "failed";
-    } finally {
-      imported.release();
-    }
+    // Both `.match` calls sit at the same consumption edge (the "error"
+    // event). Prepare failures collapse on the sync Result so validation /
+    // import errors emit in the same tick they occur — the pre-neverthrow
+    // behavior the test suite pins — while only delivery is genuinely async.
+    return this._prepare(frame).match(
+      (imported) =>
+        this._deliver(imported).match(
+          (result) => result,
+          (error) => {
+            this.emit("error", error);
+            return "failed" as const;
+          },
+        ),
+      (error) => {
+        this.emit("error", error);
+        return Promise.resolve<SendResult>("failed");
+      },
+    );
   }
 
   /**
-   * Import one frame into Electron. On throw, emits the error, releases the
-   * unconsumed native handle (importSharedTexture threw before taking
-   * ownership — without this we leak a per-frame NT HANDLE / IOSurface), and
-   * returns `null`.
+   * Validate the frame's pixel format and import it into Electron. On any
+   * failure the unconsumed native handle is released here (importSharedTexture
+   * never took ownership — without this we leak a per-frame NT HANDLE /
+   * IOSurface) and the typed error propagates to `_send`'s single `.match`.
    */
-  private _importFrame(
-    textureInfo: Electron.SharedTextureImportTextureInfo,
-    rawHandle: Buffer,
-  ): Electron.SharedTextureImported | null {
-    try {
-      return sharedTexture.importSharedTexture({ textureInfo });
-    } catch (err) {
-      this.emit("error", toError(err));
-      releaseUnconsumedHandle(rawHandle);
-      return null;
+  private _prepare(
+    frame: SharedTextureFrame,
+  ): Result<Electron.SharedTextureImported, SendPipelineError> {
+    return this._validate(frame)
+      .andThen((textureInfo) => safeImportSharedTexture(textureInfo))
+      .orElse((error) => {
+        releaseUnconsumedHandle(frame.handle);
+        return err(error);
+      });
+  }
+
+  /** Reject unknown pixel formats; wrap the raw handle for Electron. */
+  private _validate(
+    frame: SharedTextureFrame,
+  ): Result<Electron.SharedTextureImportTextureInfo, UnsupportedPixelFormatError> {
+    if (!isValidPixelFormat(frame.pixelFormat)) {
+      return err(new UnsupportedPixelFormatError(frame.pixelFormat, VALID_PIXEL_FORMATS));
     }
+    const handle =
+      process.platform === "win32" ? { ntHandle: frame.handle } : { ioSurface: frame.handle };
+    return ok({
+      codedSize: { width: frame.width, height: frame.height },
+      handle,
+      pixelFormat: frame.pixelFormat,
+    });
+  }
+
+  /**
+   * Deliver one imported texture to the target renderer. Releases `imported`
+   * on every path (the `finally` inside `send`). Disposal mid-send maps the
+   * rejection to `"skipped"` instead of an error, as before.
+   */
+  private _deliver(
+    imported: Electron.SharedTextureImported,
+  ): ResultAsync<SendResult, TextureDeliveryError> {
+    const targetFrame = this.target.mainFrame;
+    if (!targetFrame) {
+      imported.release();
+      return okAsync("skipped");
+    }
+    const send = async (): Promise<void> => {
+      try {
+        await sharedTexture.sendSharedTexture(
+          { frame: targetFrame, importedSharedTexture: imported },
+          ...this.extraArgs,
+        );
+      } finally {
+        imported.release();
+      }
+    };
+    return ResultAsync.fromPromise(
+      send(),
+      (cause) => new TextureDeliveryError(toError(cause).message, { cause }),
+    )
+      .map((): SendResult => "delivered")
+      .orElse((error) =>
+        this._disposed
+          ? okAsync<SendResult, TextureDeliveryError>("skipped")
+          : errAsync<SendResult, TextureDeliveryError>(error),
+      );
   }
 }
 

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -21,7 +21,6 @@ import {
   TextureImportError,
   UnsupportedPixelFormatError,
 } from "./errors";
-import type { SendPipelineError } from "./errors";
 import { FpsCounter } from "./fps-counter";
 import { toError } from "./to-error";
 
@@ -333,7 +332,7 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
    */
   private _prepare(
     frame: SharedTextureFrame,
-  ): Result<Electron.SharedTextureImported, SendPipelineError> {
+  ): Result<Electron.SharedTextureImported, UnsupportedPixelFormatError | TextureImportError> {
     return this._validate(frame)
       .andThen((textureInfo) => safeImportSharedTexture(textureInfo))
       .orElse((error) => {

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -304,24 +304,19 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       return "skipped";
     }
 
-    // Both `.match` calls sit at the same consumption edge (the "error"
-    // event). Prepare failures collapse on the sync Result so validation /
-    // import errors emit in the same tick they occur — the pre-neverthrow
-    // behavior the test suite pins — while only delivery is genuinely async.
-    return this._prepare(frame).match(
-      (imported) =>
-        this._deliver(imported).match(
-          (result) => result,
-          (error) => {
-            this.emit("error", error);
-            return "failed" as const;
-          },
-        ),
-      (error) => {
-        this.emit("error", error);
-        return Promise.resolve<SendResult>("failed");
-      },
-    );
+    // Single pipeline, single consumption edge: prepare (sync) chains into
+    // delivery (async), and every pipeline error collapses to one emit at the
+    // same `.match`. Prepare-stage errors therefore emit one microtask later
+    // than the pre-neverthrow code — unobservable to event listeners.
+    return this._prepare(frame)
+      .asyncAndThen((imported) => this._deliver(imported))
+      .match(
+        (result) => result,
+        (error) => {
+          this.emit("error", error);
+          return "failed" as const;
+        },
+      );
   }
 
   /**

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -22,6 +22,7 @@ import {
   UnsupportedPixelFormatError,
 } from "./errors";
 import { FpsCounter } from "./fps-counter";
+import { sendImportedTexture } from "./send-imported-texture";
 import { toError } from "./to-error";
 
 /**
@@ -351,9 +352,9 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   }
 
   /**
-   * Deliver one imported texture to the target renderer. Releases `imported`
-   * on every path (the `finally` inside `send`). Disposal mid-send maps the
-   * rejection to `"skipped"` instead of an error, as before.
+   * Deliver one imported texture to the target renderer. `sendImportedTexture`
+   * releases `imported` on every path. Disposal mid-send maps the rejection
+   * to `"skipped"` instead of an error, as before.
    */
   private _deliver(
     imported: Electron.SharedTextureImported,
@@ -363,18 +364,8 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       imported.release();
       return okAsync("skipped");
     }
-    const send = async (): Promise<void> => {
-      try {
-        await sharedTexture.sendSharedTexture(
-          { frame: targetFrame, importedSharedTexture: imported },
-          ...this.extraArgs,
-        );
-      } finally {
-        imported.release();
-      }
-    };
     return ResultAsync.fromPromise(
-      send(),
+      sendImportedTexture(targetFrame, imported, this.extraArgs),
       (cause) => new TextureDeliveryError(toError(cause).message, { cause }),
     )
       .map((): SendResult => "delivered")

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -323,17 +323,15 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
    * Validate the frame's pixel format and import it into Electron. On any
    * failure the unconsumed native handle is released here (importSharedTexture
    * never took ownership — without this we leak a per-frame NT HANDLE /
-   * IOSurface) and the typed error propagates to `_send`'s single `.match`.
+   * IOSurface) via `orTee`, which taps the `Err` side and passes it through
+   * unchanged; the typed error still propagates to `_send`'s single `.match`.
    */
   private _prepare(
     frame: SharedTextureFrame,
   ): Result<Electron.SharedTextureImported, UnsupportedPixelFormatError | TextureImportError> {
     return this._validate(frame)
       .andThen((textureInfo) => safeImportSharedTexture(textureInfo))
-      .orElse((error) => {
-        releaseUnconsumedHandle(frame.handle);
-        return err(error);
-      });
+      .orTee(() => releaseUnconsumedHandle(frame.handle));
   }
 
   /** Reject unknown pixel formats; wrap the raw handle for Electron. */

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -213,7 +213,8 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
    * Emit `"error"` and count it toward the circuit breaker. If the consecutive
    * count crosses `MAX_CONSECUTIVE_TICK_ERRORS`, stop the receiver and emit a
    * final shutdown error. Does NOT call `dispose()` — releasing native
-   * resources is the caller's responsibility.
+   * resources is the caller's responsibility. Called from `_tick`, the single
+   * consumer of both `_receiveFrame()`'s and `_send()`'s `Result` values.
    */
   private _recordTickError(error: Error): void {
     this.emit("error", error);
@@ -221,9 +222,9 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   }
 
   /**
-   * Count a tick-level error without re-emitting. Used when `_send()` already
-   * emitted the error itself (so we don't emit twice) but the failure should
-   * still count toward the circuit breaker.
+   * Bump the consecutive-error counter and, once it crosses the threshold,
+   * stop the receiver and emit the circuit-breaker error. Shared bookkeeping
+   * behind `_recordTickError`.
    */
   private _countTickError(): void {
     this._consecutiveErrors += 1;
@@ -234,62 +235,87 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   }
 
   /**
-   * One poll tick. Drop-latest: if a previous send is still in flight (the
-   * Electron `sendSharedTexture` Promise has not resolved yet), this tick is a
-   * no-op. That keeps at most one imported-texture reference alive on the main
+   * One poll tick — the single consumer of both `_receiveFrame()`'s and
+   * `_send()`'s `Result` values; each `.match()` here is the one place a
+   * pipeline value crosses from the `Result` channel into `"error"` emits /
+   * circuit-breaker bookkeeping. Producers (`_receiveFrame`, `_send`,
+   * `_prepare`, `_deliver`) only ever return `Result`/`ResultAsync` — they
+   * never emit or consume themselves.
+   *
+   * Drop-latest: if a previous send is still in flight (the Electron
+   * `sendSharedTexture` Promise has not resolved yet), this tick is a no-op.
+   * That keeps at most one imported-texture reference alive on the main
    * process at any time and prevents frame pile-up when the renderer is slow.
+   *
+   * Receive errors are consumed synchronously (same-tick circuit-breaker
+   * accounting — matches the pre-neverthrow behavior); send/prepare/deliver
+   * errors are consumed after the `await` — one microtask later than the
+   * pre-neverthrow code, an already-accepted contract (see `_send`).
    */
   private async _tick(): Promise<void> {
     if (this._disposed || this._inFlight) return;
 
-    const frame = this._receiveFrame();
-    if (!frame) return;
-
-    const result = await this._sendTracked(frame);
-
-    if (this._disposed) return;
-
-    switch (result) {
-      case "failed":
-        // The error itself was already emitted inside `_send()`. Still count it
-        // toward the circuit breaker so a stuck pipeline eventually stops.
-        this._countTickError();
-        return;
-      case "skipped":
-        // Not a failure (e.g. destroyed target during teardown). Don't touch the
-        // error counter and don't tick FPS.
-        return;
-      case "delivered": {
-        // Successful frame delivery — reset the consecutive-error counter.
-        this._consecutiveErrors = 0;
-        const fps = this.fpsCounter.tick();
-        if (fps !== null) this.emit("fps", fps);
-        return;
-      }
-      default: {
-        const _exhaustive: never = result;
-        throw new Error(`unhandled send result: ${JSON.stringify(_exhaustive)}`);
-      }
-    }
-  }
-
-  /**
-   * Poll the native receiver once. Errors are recorded against the circuit
-   * breaker and reported via the `"error"` event; both the no-frame and the
-   * error case return `null` (the tick has nothing further to do either way).
-   */
-  private _receiveFrame(): SharedTextureFrame | null {
-    return safeReceiveSharedTexture(this.receiver).match(
-      (frame) => frame,
+    const frame = this._receiveFrame().match(
+      (value) => value,
       (error) => {
         this._recordTickError(error);
         return null;
       },
     );
+    if (!frame) return;
+
+    const sent = await this._sendTracked(frame);
+
+    if (this._disposed) return;
+
+    sent.match(
+      (result) => {
+        switch (result) {
+          case "skipped":
+            // Not a failure (e.g. destroyed target during teardown). Don't touch
+            // the error counter and don't tick FPS.
+            return;
+          case "delivered": {
+            // Successful frame delivery — reset the consecutive-error counter.
+            this._consecutiveErrors = 0;
+            const fps = this.fpsCounter.tick();
+            if (fps !== null) this.emit("fps", fps);
+            return;
+          }
+          default: {
+            const _exhaustive: never = result;
+            throw new Error(`unhandled send result: ${JSON.stringify(_exhaustive)}`);
+          }
+        }
+      },
+      (error) => {
+        this._recordTickError(error);
+      },
+    );
   }
 
-  /** Run `_send()` with the `_inFlight` drop-latest flag held for its duration. */
-  private async _sendTracked(frame: SharedTextureFrame): Promise<SendResult> {
+  /**
+   * Poll the native receiver once. Returns `Ok(frame | null)` on the success
+   * channel — `null` means no new frame, not a failure — or the typed
+   * `FrameReceiveError` on the `Err` side. A pure producer: consumption
+   * (recording against the circuit breaker, emitting) happens once, in
+   * `_tick`, the single usage site.
+   */
+  private _receiveFrame(): Result<SharedTextureFrame | null, FrameReceiveError> {
+    return safeReceiveSharedTexture(this.receiver);
+  }
+
+  /**
+   * Run `_send()` with the `_inFlight` drop-latest flag held for its
+   * duration. Awaiting a `ResultAsync` yields a `Result` — that's not
+   * consumption, just unwrapping the promise; the `Result` still flows
+   * through to `_tick`'s `.match()`.
+   */
+  private async _sendTracked(
+    frame: SharedTextureFrame,
+  ): Promise<
+    Result<SendResult, UnsupportedPixelFormatError | TextureImportError | TextureDeliveryError>
+  > {
     this._inFlight = true;
     try {
       return await this._send(frame);
@@ -298,26 +324,22 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
     }
   }
 
-  private async _send(frame: SharedTextureFrame): Promise<SendResult> {
+  private _send(
+    frame: SharedTextureFrame,
+  ): ResultAsync<
+    SendResult,
+    UnsupportedPixelFormatError | TextureImportError | TextureDeliveryError
+  > {
     if (this.target.isDestroyed()) {
       // Target is gone — handle was minted but Electron will never consume it.
       releaseUnconsumedHandle(frame.handle);
-      return "skipped";
+      return okAsync("skipped");
     }
 
-    // Single pipeline, single consumption edge: prepare (sync) chains into
-    // delivery (async), and every pipeline error collapses to one emit at the
-    // same `.match`. Prepare-stage errors therefore emit one microtask later
-    // than the pre-neverthrow code — unobservable to event listeners.
-    return this._prepare(frame)
-      .asyncAndThen((imported) => this._deliver(imported))
-      .match(
-        (result) => result,
-        (error) => {
-          this.emit("error", error);
-          return "failed" as const;
-        },
-      );
+    // Single pipeline: prepare (sync) chains into delivery (async). No
+    // consumption here — the combined Result/ResultAsync propagates to
+    // `_tick`'s single `.match()`.
+    return this._prepare(frame).asyncAndThen((imported) => this._deliver(imported));
   }
 
   /**
@@ -325,7 +347,7 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
    * failure the unconsumed native handle is released here (importSharedTexture
    * never took ownership — without this we leak a per-frame NT HANDLE /
    * IOSurface) via `orTee`, which taps the `Err` side and passes it through
-   * unchanged; the typed error still propagates to `_send`'s single `.match`.
+   * unchanged; the typed error still propagates to `_tick`'s single `.match`.
    */
   private _prepare(
     frame: SharedTextureFrame,
@@ -378,17 +400,17 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
 }
 
 /**
- * Outcome of a single `_send()` call.
+ * `Ok` outcome of a single `_send()` call — pipeline failures (invalid pixel
+ * format, `importSharedTexture` throw, `sendSharedTexture` rejection) ride
+ * the `Err` channel instead (see `_prepare` / `_deliver`) and are consumed by
+ * `_tick`.
  *
  * - `"delivered"`: frame reached `sendSharedTexture` and resolved. Resets the
  *   circuit-breaker counter and ticks FPS.
- * - `"failed"`: a user-visible pipeline error fired (invalid pixel format,
- *   `importSharedTexture` threw, `sendSharedTexture` rejected). Counts toward
- *   the circuit breaker.
  * - `"skipped"`: an expected non-error path (target webContents destroyed, no
  *   mainFrame, disposed mid-send). Neither counts nor resets.
  */
-type SendResult = "delivered" | "failed" | "skipped";
+type SendResult = "delivered" | "skipped";
 
 /**
  * Create a shared-texture receiver bridge.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       electron:
         specifier: '>=40.0.0'
         version: 40.2.1
+      neverthrow:
+        specifier: ^8.2.0
+        version: 8.2.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0


### PR DESCRIPTION
## Summary

旧 stacked PR **#62** の再実装（計画: `docs/superpowers/plans/2026-08-12-refactor-stack-revival.md` Task 4/5）。**#73 の上に stack**。オーナーレビューの設計裁定 4 件を反映済み。

### エラー型（新規公開 export は class 5 種のみ）
`FrameReceiveError` / `TextureImportError` / `TextureDeliveryError` / `UnsupportedPixelFormatError` / `ReceiverStoppedError` — core の `TextureSendError` と同じ最小 shape（`override name` + message + `cause`）。**Result は公開面に一切出ない**（dist 型で検証）。

### 内部構造 — オーナー裁定を反映した producer / driver 分離
- **producer は Result を返すだけ**: `_receiveFrame(): Result<frame | null, FrameReceiveError>`、`_send(): ResultAsync<SendResult, Unsupported | Import | Delivery>`、`_prepare` / `_deliver`
- **消費（.match）はドライバ `_tick` のみ**: 受信エラーは同期 match（circuit breaker の同 tick 契約維持）、pipeline エラーは await 後に emit + count
- `SendResult` は `"delivered" | "skipped"` に縮小 — 失敗はエラーチャンネルが運ぶため ok 側の `"failed"` variant は削除。旧構造の二重 emit 回避ヘルパーの歪みが構造的に消滅
- `_send` は canonical chain（`_prepare().asyncAndThen(_deliver).match` 相当の消費は `_tick` へ）。prepare 段エラーの emit は microtask 1 個遅延（リスナーに観測不能、コメントで契約明記）
- `_prepare` のエラー時 handle 解放は `.orTee`（手動 `err()` 再ラップ廃止）
- inner thunk 宣言を廃止 — **`send-imported-texture.ts`** の module-scope ヘルパー `sendImportedTexture(frame, imported, extraArgs?)` に統一（release-in-finally + 同期 throw 不可の保証を集約）

### バグ修正（未マージ #62 に潜在、レビューで初検出）
preview `sendFrame` で同期 throw が best-effort 契約を破って bridge の公開 `error` イベントへ漏れる + falsy import ガード欠落 → async ヘルパー経由 + ガード復元で修正し、**preview-manager.test.ts（新規 4 件）** でロック。

- module-scope named `fromThrowable` binding ×4（`safeDispatchSend` 系と同スタイル）
- discovery: `safeListSenders`。`_refresh` / preview `sendFrame` はドライバ/公開 edge として消費側を維持

## Test plan
- renderer **177/177**（errors 5 件 + preview-manager 4 件を新規追加。既存は flush タイミング適応 2 件のみ・assertion 無劣化）
- 全失敗経路の emit 一意性・class/message/cause 保持・circuit breaker・drop-latest を opus re-review でトレース済み
- `pnpm lint`（0 errors）/ `pnpm typecheck` clean

旧 #62 は close のまま（本 PR が後継）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)