### PR TITLE
refactor(example): coding-rules compliance for the demo app

### DIFF
--- a/packages/example/src/main/index.ts
+++ b/packages/example/src/main/index.ts
@@ -20,14 +20,14 @@ app.commandLine.appendSwitch("force-device-scale-factor", "1");
 // mirrors the `activeReceiver` null-guard pattern used for the receiver.
 let activeBridge: TextureBridge | null = null;
 
-function getRendererUrl(): string {
+const getRendererUrl = (): string => {
   if (process.env.ELECTRON_RENDERER_URL) {
     return `${process.env.ELECTRON_RENDERER_URL}/index.html`;
   }
   return path.join(__dirname, "../renderer/index.html");
-}
+};
 
-app.whenReady().then(async () => {
+const bootstrap = async (): Promise<void> => {
   console.log("[example] app ready");
   console.log(`[example] Electron: ${process.versions.electron}`);
 
@@ -78,11 +78,10 @@ app.whenReady().then(async () => {
   type SharedTextureReceiver = ReturnType<typeof createSharedTextureReceiver>;
   let activeReceiver: SharedTextureReceiver | null = null;
 
-  const stopActiveReceiver = () => {
-    if (activeReceiver) {
-      activeReceiver.dispose();
-      activeReceiver = null;
-    }
+  const stopActiveReceiver = (): void => {
+    if (!activeReceiver) return;
+    activeReceiver.dispose();
+    activeReceiver = null;
   };
 
   // Receiver window needs `nodeIntegration: true` + `contextIsolation: false`
@@ -125,21 +124,22 @@ app.whenReady().then(async () => {
     stopActiveReceiver();
     console.log(`[receiver-test] connecting to "${senderName}" (zero-copy, flipY=${flipY})`);
 
-    activeReceiver = createSharedTextureReceiver({
+    const receiver = createSharedTextureReceiver({
       senderName,
       target: receiverWindow.webContents,
       pollIntervalMs: 8,
       flipY,
     });
-    activeReceiver.on("fps", (fps) => {
+    receiver.on("fps", (fps) => {
       if (!receiverWindow.isDestroyed()) {
         receiverWindow.webContents.send("receiver-fps", fps);
       }
     });
-    activeReceiver.on("error", (err) => {
+    receiver.on("error", (err) => {
       console.error("[receiver-test] bridge error:", err.message);
     });
-    activeReceiver.start();
+    receiver.start();
+    activeReceiver = receiver;
   });
 
   ipcMain.handle("set-flip-y", (_event, flipY: boolean) => {
@@ -162,7 +162,9 @@ app.whenReady().then(async () => {
     ipcMain.removeHandler("set-flip-y");
     ipcMain.removeHandler("disconnect-receiver");
   });
-});
+};
+
+void app.whenReady().then(bootstrap);
 
 app.on("window-all-closed", () => {
   app.quit();

--- a/packages/example/src/preload/receiver.ts
+++ b/packages/example/src/preload/receiver.ts
@@ -99,15 +99,20 @@ const refreshSenders = async (): Promise<void> => {
   }
 };
 
+const getElement = <T extends HTMLElement>(id: string, ctor: new () => T): T | null => {
+  const element = document.getElementById(id);
+  return element instanceof ctor ? element : null;
+};
+
 window.addEventListener("DOMContentLoaded", () => {
-  const canvas = document.getElementById("canvas") as HTMLCanvasElement | null;
+  const canvas = getElement("canvas", HTMLCanvasElement);
   const ctx = canvas?.getContext("2d");
-  const info = document.getElementById("info") as HTMLDivElement | null;
-  const senderList = document.getElementById("senderList") as HTMLSelectElement | null;
-  const refreshBtn = document.getElementById("refreshBtn") as HTMLButtonElement | null;
-  const connectBtn = document.getElementById("connectBtn") as HTMLButtonElement | null;
-  const disconnectBtn = document.getElementById("disconnectBtn") as HTMLButtonElement | null;
-  const flipYCheckbox = document.getElementById("flipYCheckbox") as HTMLInputElement | null;
+  const info = getElement("info", HTMLDivElement);
+  const senderList = getElement("senderList", HTMLSelectElement);
+  const refreshBtn = getElement("refreshBtn", HTMLButtonElement);
+  const connectBtn = getElement("connectBtn", HTMLButtonElement);
+  const disconnectBtn = getElement("disconnectBtn", HTMLButtonElement);
+  const flipYCheckbox = getElement("flipYCheckbox", HTMLInputElement);
 
   if (
     !canvas ||
@@ -123,7 +128,16 @@ window.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  ui = { canvas, ctx, info, senderList, refreshBtn, connectBtn, disconnectBtn, flipYCheckbox };
+  ui = {
+    canvas,
+    ctx,
+    info,
+    senderList,
+    refreshBtn,
+    connectBtn,
+    disconnectBtn,
+    flipYCheckbox,
+  };
   state.lastFpsTime = performance.now();
 
   senderList.addEventListener("change", () => {
@@ -155,7 +169,7 @@ window.addEventListener("DOMContentLoaded", () => {
       senderList.disabled = true;
       formatInfo();
     } catch (err) {
-      info.textContent = `Error: ${(err as Error).message}`;
+      info.textContent = `Error: ${err instanceof Error ? err.message : `${err}`}`;
     }
   });
 

--- a/packages/example/src/renderer/render-worker.ts
+++ b/packages/example/src/renderer/render-worker.ts
@@ -17,11 +17,16 @@ declare const self: DedicatedWorkerGlobalScope;
 // Worker State
 // ============================================================================
 
-let renderer: THREE.WebGLRenderer | null = null;
-let scene: THREE.Scene | null = null;
-let camera: THREE.OrthographicCamera | null = null;
-let material: THREE.ShaderMaterial | null = null;
-let startTime: number = 0;
+/** Everything `init()` creates — present together or not at all. */
+interface RenderContext {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.OrthographicCamera;
+  material: THREE.ShaderMaterial;
+}
+
+let context: RenderContext | null = null;
+let startTime = 0;
 let canvasSize = { width: 1920, height: 1080 };
 
 const audioData = {
@@ -32,46 +37,45 @@ const audioData = {
 };
 
 // ============================================================================
-// Message Handler
+// Rendering
 // ============================================================================
 
-self.onmessage = (e: MessageEvent) => {
-  const { type, ...data } = e.data;
-
-  switch (type) {
-    case "init":
-      init(data.canvas as OffscreenCanvas);
-      break;
-
-    case "resize":
-      resize(data.width, data.height);
-      break;
-
-    case "audio":
-      audioData.bass = lerp(audioData.bass, data.bass ?? audioData.bass, 0.3);
-      audioData.mid = lerp(audioData.mid, data.mid ?? audioData.mid, 0.3);
-      audioData.high = lerp(audioData.high, data.high ?? audioData.high, 0.3);
-      break;
-
-    case "beat":
-      audioData.beat = 1.0;
-      break;
-  }
+const lerp = (a: number, b: number, t: number): number => {
+  return a + (b - a) * t;
 };
 
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
+const animate = (): void => {
+  requestAnimationFrame(animate);
 
-// ============================================================================
-// Three.js Initialization
-// ============================================================================
+  if (!context) return;
 
-function init(canvas: OffscreenCanvas) {
+  const elapsed = (performance.now() - startTime) / 1000;
+  context.material.uniforms.u_time.value = elapsed;
+  context.material.uniforms.u_bass.value = audioData.bass;
+  context.material.uniforms.u_mid.value = audioData.mid;
+  context.material.uniforms.u_high.value = audioData.high;
+  context.material.uniforms.u_beat.value = audioData.beat;
+
+  audioData.beat *= 0.92;
+
+  context.renderer.render(context.scene, context.camera);
+};
+
+const resize = (width: number, height: number): void => {
+  if (!context) return;
+
+  canvasSize = { width, height };
+  context.renderer.setSize(width, height, false);
+  context.material.uniforms.u_resolution.value.set(width, height);
+
+  console.log(`[render-worker] Resized to ${width}x${height}`);
+};
+
+const init = (canvas: OffscreenCanvas): void => {
   canvasSize = { width: canvas.width, height: canvas.height };
   startTime = performance.now();
 
-  renderer = new THREE.WebGLRenderer({
+  const renderer = new THREE.WebGLRenderer({
     canvas: canvas as unknown as HTMLCanvasElement,
     antialias: true,
     // alpha:true + clearAlpha:0 lets the fragment shader's gl_FragColor.a
@@ -89,10 +93,10 @@ function init(canvas: OffscreenCanvas) {
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.setClearColor(0x000000, 0);
 
-  scene = new THREE.Scene();
-  camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
-  material = new THREE.ShaderMaterial({
+  const material = new THREE.ShaderMaterial({
     vertexShader,
     fragmentShader,
     uniforms: {
@@ -113,38 +117,48 @@ function init(canvas: OffscreenCanvas) {
   const mesh = new THREE.Mesh(geometry, material);
   scene.add(mesh);
 
+  context = { renderer, scene, camera, material };
+
   animate();
 
   console.log("[render-worker] Three.js initialized with raymarching shader");
-}
-
-function resize(width: number, height: number) {
-  if (!renderer || !material) return;
-
-  canvasSize = { width, height };
-  renderer.setSize(width, height, false);
-  material.uniforms.u_resolution.value.set(width, height);
-
-  console.log(`[render-worker] Resized to ${width}x${height}`);
-}
+};
 
 // ============================================================================
-// Animation Loop
+// Message Handler
 // ============================================================================
 
-function animate() {
-  requestAnimationFrame(animate);
+type WorkerEvent =
+  | { type: "init"; canvas: OffscreenCanvas }
+  | { type: "resize"; width: number; height: number }
+  | { type: "audio"; bass?: number; mid?: number; high?: number }
+  | { type: "beat" };
 
-  if (!renderer || !scene || !camera || !material) return;
+self.onmessage = (e: MessageEvent<WorkerEvent>) => {
+  const msg = e.data;
 
-  const elapsed = (performance.now() - startTime) / 1000;
-  material.uniforms.u_time.value = elapsed;
-  material.uniforms.u_bass.value = audioData.bass;
-  material.uniforms.u_mid.value = audioData.mid;
-  material.uniforms.u_high.value = audioData.high;
-  material.uniforms.u_beat.value = audioData.beat;
+  switch (msg.type) {
+    case "init":
+      init(msg.canvas);
+      break;
 
-  audioData.beat *= 0.92;
+    case "resize":
+      resize(msg.width, msg.height);
+      break;
 
-  renderer.render(scene, camera);
-}
+    case "audio":
+      audioData.bass = lerp(audioData.bass, msg.bass ?? audioData.bass, 0.3);
+      audioData.mid = lerp(audioData.mid, msg.mid ?? audioData.mid, 0.3);
+      audioData.high = lerp(audioData.high, msg.high ?? audioData.high, 0.3);
+      break;
+
+    case "beat":
+      audioData.beat = 1.0;
+      break;
+
+    default: {
+      const _exhaustive: never = msg;
+      throw new Error(`unhandled worker message: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+};


### PR DESCRIPTION
## Summary

旧 stacked PR **#63** の再実装（計画: `docs/superpowers/plans/2026-08-12-refactor-stack-revival.md` Task 5/5 — シリーズ最終）。base = main（renderer stack と独立）。

- `main/index.ts`: `getRendererUrl` / `bootstrap` の arrow const 化。`let activeBridge` / `let activeReceiver` は **plain let 維持**（slot-object 不採用の既決事項）。最近追加された `frameDropped` listener / before-quit `dispose()` は無変更
- `preload/receiver.ts`: `getElement<T>(id, ctor)`（instanceof ガード）で `as HTMLXElement | null` cast **7 箇所**を置換、`(err as Error)` → `instanceof Error` ガード。self-contained
- `render-worker.ts`: 旧 #63 の `worker = { context: null as ... }` slot-object は**不採用** — 単一 `let context: RenderContext | null = null` に統合。`WorkerEvent` union の exhaustive `switch`（`never` default）+ arrow 化を移植

## Test plan
- `pnpm lint`（0 errors）/ `pnpm typecheck` clean（example 含む）
- 起動スモーク: `[example] FPS:` 安定出力・`dropped`/`Error` 0 行・全プロセス kill 確認

旧 #63 は close のまま（本 PR が後継）。これで旧 #58–#64 の再スコープ 5 PR（#71 merged / #72 / #73 / #74 / 本 PR）が出揃いました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)