### PR TITLE
docs(skills): codify Result consumption rulings (producer/driver, orTee, ok-channel narrowing)

### DIFF
--- a/.claude/skills/chaining-neverthrow-results/SKILL.md
+++ b/.claude/skills/chaining-neverthrow-results/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chaining-neverthrow-results
-description: Use when composing or chaining neverthrow Result / ResultAsync values — sequencing multi-step operations where each step can fail, recovering from a specific error, or deciding where to turn a Result into a plain value or HTTP response. Also when reaching for .match mid-pipeline, _unsafeUnwrap, isErr()+.value unwrapping, safeTry / yield*, or a try/catch around Result-returning code.
+description: Use when composing or chaining neverthrow Result / ResultAsync values — sequencing multi-step operations where each step can fail, recovering from a specific error, or deciding where to turn a Result into a plain value or HTTP response. Also when reaching for .match mid-pipeline, .match inside a value-producing private method, _unsafeUnwrap, isErr()+.value unwrapping, safeTry / yield*, or a try/catch around Result-returning code.
 ---
 
 # Chaining neverthrow Results
@@ -20,6 +20,7 @@ This generalizes the route-boundary rule. **RELATED:** `backend-typescript-roadm
 | `.mapErr(fn)` | Normalize the error — e.g. into the shared `ApplicationError` union so the final `.match` is exhaustive. |
 | `.orElse(fn)` | **Recover** from an error: return `okAsync(fallback)` for the case you handle, `errAsync(e)` to re-propagate the rest. |
 | `.andTee(fn)` | Fire a side-effect (notify, log) without changing the value. |
+| `.orTee(fn)` | Fire a side-effect on the **error** side (release a handle, log) — the `Err` passes through unchanged, synchronously. Not for recovery; that is `.orElse`. |
 | `.asyncAndThen(fn)` | Bridge a **sync** `Result` into an async chain (the first async step). |
 | `fromPromise(p, e => new XError(...))` | Bring a throwing promise into the chain — the one place a throw is caught. |
 | `Result.fromThrowable(fn, e => new XError(...))` | Bring a throwing **sync** function into the chain. **Bind it once to a named const** — `const safeFn = Result.fromThrowable(fn, wrap)` (arguments are forwarded), module scope when `fn` takes its dependencies as arguments, a local const otherwise. Never call it inline as `Result.fromThrowable(...)()` — that is the banned IIFE shape (see functional-programming rules). |
@@ -58,11 +59,57 @@ function handle(raw: unknown): Promise<Response> {
 
 `.match` belongs only where the Result leaves your code for the outside world: the Hono route handler, a CLI `main`, a top-level effect, or a test assertion (tests may also use `isOk()/isErr()`). Service/domain/helper layers return the `ResultAsync` onward — they never `.match`.
 
+## Inside a class: producers return, the driver consumes
+
+The same edge rule applies *within* a class (owner ruling, 2026-08-12). A value-producing private method is a **producer**: it returns the `Result`/`ResultAsync` as-is. Consumption happens only in the **driver** — the tick loop, the public void method, the event boundary — where errors become their final vocabulary (an `"error"` event, a counter, a response).
+
+Two corollaries:
+
+- **No failure variants in the ok channel.** If the error channel carries the failures, an ok value like `"delivered" | "skipped" | "failed"` is a smell — `"failed"` is dead weight duplicating the `Err` side. Narrow the ok union and let the driver's `.match` err branch do the failure bookkeeping. (This also deletes the double-emit hazards that count-only helper methods exist to work around.)
+- **`await` is not consumption.** Awaiting a `ResultAsync` yields a `Result` — a pass-through layer that only manages a flag may `await` and return the `Result` untouched:
+
+```ts
+// ❌ producer consumes: caller loses the typed error, "failed" leaks into ok
+private async _send(frame: Frame): Promise<"delivered" | "skipped" | "failed"> {
+  return this._prepare(frame).asyncAndThen((i) => this._deliver(i)).match(
+    (r) => r,
+    (e) => { this.emit("error", e); return "failed" as const; },
+  );
+}
+
+// ✅ producer returns; the driver (_tick) owns the single .match
+private _send(frame: Frame): ResultAsync<"delivered" | "skipped", PrepareError | DeliverError> {
+  return this._prepare(frame).asyncAndThen((imported) => this._deliver(imported));
+}
+
+private async _sendTracked(frame: Frame) {   // pass-through: await ≠ consumption
+  this._inFlight = true;
+  try {
+    return await this._send(frame);
+  } finally {
+    this._inFlight = false;
+  }
+}
+
+private async _tick(): Promise<void> {       // the driver — the only .match
+  const sent = await this._sendTracked(frame);
+  sent.match(
+    (result) => this._handleOutcome(result),
+    (error) => { this.emit("error", error); this._countTickError(); },
+  );
+}
+```
+
+A sync `Result` matched in the driver keeps same-tick timing (e.g. a circuit breaker); only genuinely async stages defer by a microtask.
+
 ## Anti-patterns
 
 | Instead of | Do |
 |---|---|
 | `.match` mid-pipeline to branch then re-wrap in `ok`/`err` | `.andThen` (success path) / `.orElse` (recovery) |
+| `.match` inside a value-producing private method | Return the `Result`; the driver (tick loop / public void method / event boundary) holds the only `.match` |
+| `.orElse((e) => { sideEffect(); return err(e); })` — tap then re-wrap | `.orTee(sideEffect)` — `Err` passthrough is implicit; keep `.orElse` for conditional recovery only |
+| A `"failed"`-style variant in the ok channel mirroring the error channel | Narrow the ok union; failures ride the `Err` side to the driver's `.match` |
 | Recovering via `match(ok, err => …)` then `okAsync(...)` | `.orElse((e) => handled ? okAsync(x) : errAsync(e))` |
 | `_unsafeUnwrap()` / `_unsafeUnwrapErr()` in production code | Carry the `Result`; collapse only at the edge with `.match` |
 | `if (r.isErr()) return …; const v = r.value` mid-flow | `.andThen` (`isErr`/`.value` is for tests, not production flow) |
@@ -78,3 +125,6 @@ function handle(raw: unknown): Promise<Response> {
 - About to `import { safeTry }` or `yield*` a Result → use combinators.
 - A `try/catch` wrapping code that already returns a Result → wrap the throwing promise once with `fromPromise`.
 - About to write `)()` right after `Result.fromThrowable(...)` → bind it to a named const first; forward arguments instead of closing over them.
+- About to `.match` inside a private method that returns a value → return the `Result`/`ResultAsync`; consume in the driver.
+- About to write an ok variant named like a failure (`"failed"`, `"errored"`) → the error channel already carries it; narrow the ok union.
+- About to `.orElse` only to run a side-effect and `return err(e)` → `.orTee`.

--- a/.claude/skills/chaining-neverthrow-results/SKILL.md
+++ b/.claude/skills/chaining-neverthrow-results/SKILL.md
@@ -109,6 +109,7 @@ A sync `Result` matched in the driver keeps same-tick timing (e.g. a circuit bre
 | `.match` mid-pipeline to branch then re-wrap in `ok`/`err` | `.andThen` (success path) / `.orElse` (recovery) |
 | `.match` inside a value-producing private method | Return the `Result`; the driver (tick loop / public void method / event boundary) holds the only `.match` |
 | `.orElse((e) => { sideEffect(); return err(e); })` — tap then re-wrap | `.orTee(sideEffect)` — `Err` passthrough is implicit; keep `.orElse` for conditional recovery only |
+| A side-effect (release, log) smuggled into the `fromPromise` / `fromThrowable` error mapper | Keep mappers pure — they only build the error. Put the effect in `.orTee(...)` on the chain |
 | A `"failed"`-style variant in the ok channel mirroring the error channel | Narrow the ok union; failures ride the `Err` side to the driver's `.match` |
 | Recovering via `match(ok, err => …)` then `okAsync(...)` | `.orElse((e) => handled ? okAsync(x) : errAsync(e))` |
 | `_unsafeUnwrap()` / `_unsafeUnwrapErr()` in production code | Carry the `Result`; collapse only at the edge with `.match` |
@@ -128,3 +129,4 @@ A sync `Result` matched in the driver keeps same-tick timing (e.g. a circuit bre
 - About to `.match` inside a private method that returns a value → return the `Result`/`ResultAsync`; consume in the driver.
 - About to write an ok variant named like a failure (`"failed"`, `"errored"`) → the error channel already carries it; narrow the ok union.
 - About to `.orElse` only to run a side-effect and `return err(e)` → `.orTee`.
+- About to do anything but construct an error inside a `fromPromise` / `fromThrowable` error mapper → move the effect to `.orTee`.


### PR DESCRIPTION
## Summary

2026-08-12 のレビューセッション（PR #74 の内部 neverthrow 採用）で確立したオーナー裁定を `chaining-neverthrow-results` スキルに永続化。**superpowers:writing-skills の TDD サイクル（RED→GREEN→REFACTOR）で検証済み。**

### 追記内容
1. **producer / driver 分離**: 値を返す private method は `Result`/`ResultAsync` を返す producer に徹し、`.match` はドライバ（tick ループ・公開 void メソッド・イベント境界）のみが持つ。系論 2 つ — **ok チャンネルに `"failed"` 的な失敗 variant を持たせない**、**await は消費ではない**（フラグ管理だけの中間層は素通し可）。before/after 例付き
2. **エラー側 tap は `.orTee`**: `.orElse` + `err()` 再ラップは smell。`.orElse` は条件付き回復専用。combinator 表に `.orTee` を追加
3. **mapper は純粋に保つ**: `fromPromise` / `fromThrowable` の error mapper に副作用を忍ばせない（REFACTOR で追加）
4. description・Anti-patterns 表・Red Flags に対応トリガーを追加

### 検証（同一シナリオ = neverthrow 未導入の poller class を締切圧下でリファクタさせる課題、fresh-context subagent）

| Phase | Skill | 結果 |
|---|---|---|
| **RED** | 変更前（main） | **3/3 が違反** — producer 内 `.match` で `Frame \| null` へ潰す、ok チャンネルに `"failed"` 維持。最悪例は `orElse` → `okAsync("failed")` で全エラーを ok に埋葬しエラーチャンネルが `never` 化 |
| **GREEN** | 追記後 | **3/3 準拠** — producer は Result を返し、消費は driver の単一 `.match`、`"failed"` 消滅。reps がほぼ同一形に収束 |
| **REFACTOR** | mapper 純粋性の反例追加後 | **2/2 準拠** — GREEN で 1/3 に出た「error mapper 内で handle 解放」の変異が消え、`.orTee` に収束 |

旧 skill の「edge = route handler / CLI main」という語彙は class 内部の producer を拘束できていなかった、という仮説が baseline で裏付けられました。

`.claude/` は gitignore のため `git add -f`（PR #65 と同じ運用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)