### PR TITLE
refactor(renderer): exhaustive SendResult switch + rule-compliant PreviewManager

### DIFF
--- a/packages/renderer/src/preview-manager.ts
+++ b/packages/renderer/src/preview-manager.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain, sharedTexture } from "electron";
 import path from "path";
+import type { TextureInfo } from "@napolab/texture-bridge-core";
 import type { PreviewOptions } from "./types";
 
 /**
@@ -7,9 +8,9 @@ import type { PreviewOptions } from "./types";
  * natively in CJS output and injected via tsdown's `--shims` flag in ESM output
  * (see package.json build script), so this works in both module formats.
  */
-function assetPath(filename: string): string {
+const assetPath = (filename: string): string => {
   return path.join(__dirname, "assets", filename);
-}
+};
 
 export class PreviewManager {
   private win: BrowserWindow | null = null;
@@ -17,6 +18,7 @@ export class PreviewManager {
   private width: number;
   private height: number;
   private title: string;
+  private previewReadyListener: ((event: Electron.IpcMainEvent) => void) | null = null;
 
   constructor(width: number, height: number, options?: PreviewOptions) {
     this.width = width;
@@ -32,11 +34,17 @@ export class PreviewManager {
     return this.win !== null && !this.win.isDestroyed();
   }
 
-  private onPreviewReady = (_event: Electron.IpcMainEvent): void => {
+  private handlePreviewReady(event: Electron.IpcMainEvent): void {
     if (!this.win || this.win.isDestroyed()) return;
-    if (_event.sender.id !== this.win.webContents.id) return;
+    if (event.sender.id !== this.win.webContents.id) return;
     this.ready = true;
-  };
+  }
+
+  private removePreviewReadyListener(): void {
+    if (!this.previewReadyListener) return;
+    ipcMain.removeListener("preview-ready", this.previewReadyListener);
+    this.previewReadyListener = null;
+  }
 
   open(): void {
     if (this.isOpen) return;
@@ -55,25 +63,29 @@ export class PreviewManager {
       },
     });
 
-    ipcMain.on("preview-ready", this.onPreviewReady);
+    const listener = (event: Electron.IpcMainEvent): void => {
+      this.handlePreviewReady(event);
+    };
+    this.previewReadyListener = listener;
+    ipcMain.on("preview-ready", listener);
 
     this.win.loadFile(assetPath("preview.html"), {
-      query: { w: String(this.width), h: String(this.height) },
+      query: { w: `${this.width}`, h: `${this.height}` },
     });
 
     this.win.on("closed", () => {
       this.win = null;
       this.ready = false;
-      ipcMain.removeListener("preview-ready", this.onPreviewReady);
+      this.removePreviewReadyListener();
     });
   }
 
-  sendFrame(texture: { textureInfo: unknown }): void {
+  sendFrame(texture: { textureInfo: TextureInfo }): void {
     if (!this.win || this.win.isDestroyed() || !this.ready) return;
 
     try {
       const imported = sharedTexture.importSharedTexture({
-        textureInfo: texture.textureInfo as Electron.SharedTextureImportTextureInfo,
+        textureInfo: texture.textureInfo,
       });
       if (!imported) return;
 
@@ -91,9 +103,10 @@ export class PreviewManager {
   updateSize(width: number, height: number): void {
     this.width = width;
     this.height = height;
-    if (!this.isOpen) return;
-    this.win!.loadFile(assetPath("preview.html"), {
-      query: { w: String(width), h: String(height) },
+    const win = this.win;
+    if (!win || win.isDestroyed()) return;
+    win.loadFile(assetPath("preview.html"), {
+      query: { w: `${width}`, h: `${height}` },
     });
   }
 
@@ -105,7 +118,7 @@ export class PreviewManager {
   }
 
   dispose(): void {
-    ipcMain.removeListener("preview-ready", this.onPreviewReady);
+    this.removePreviewReadyListener();
     this.close();
   }
 }

--- a/packages/renderer/src/shared-texture-receiver.ts
+++ b/packages/renderer/src/shared-texture-receiver.ts
@@ -42,7 +42,7 @@ type SharedTexturePixelFormat = "bgra" | "rgba" | "rgbaf16";
 const VALID_PIXEL_FORMATS: readonly SharedTexturePixelFormat[] = ["bgra", "rgba", "rgbaf16"];
 
 const isValidPixelFormat = (value: string): value is SharedTexturePixelFormat => {
-  return (VALID_PIXEL_FORMATS as readonly string[]).includes(value);
+  return VALID_PIXEL_FORMATS.some((format) => format === value);
 };
 
 /**
@@ -222,43 +222,59 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
   private async _tick(): Promise<void> {
     if (this._disposed || this._inFlight) return;
 
-    let frame: SharedTextureFrame | null;
-    try {
-      frame = this.receiver.receiveSharedTexture();
-    } catch (err) {
-      this._recordTickError(toError(err));
-      return;
-    }
+    const frame = this._receiveFrame();
     if (!frame) return;
 
-    this._inFlight = true;
-    let result: SendResult;
-    try {
-      result = await this._send(frame);
-    } finally {
-      this._inFlight = false;
-    }
+    const result = await this._sendTracked(frame);
 
     if (this._disposed) return;
 
-    if (result === "failed") {
-      // The error itself was already emitted inside `_send()`. Still count it
-      // toward the circuit breaker so a stuck pipeline eventually stops.
-      this._countTickError();
-      return;
+    switch (result) {
+      case "failed":
+        // The error itself was already emitted inside `_send()`. Still count it
+        // toward the circuit breaker so a stuck pipeline eventually stops.
+        this._countTickError();
+        return;
+      case "skipped":
+        // Not a failure (e.g. destroyed target during teardown). Don't touch the
+        // error counter and don't tick FPS.
+        return;
+      case "delivered": {
+        // Successful frame delivery — reset the consecutive-error counter.
+        this._consecutiveErrors = 0;
+        const fps = this.fpsCounter.tick();
+        if (fps !== null) this.emit("fps", fps);
+        return;
+      }
+      default: {
+        const _exhaustive: never = result;
+        throw new Error(`unhandled send result: ${JSON.stringify(_exhaustive)}`);
+      }
     }
+  }
 
-    if (result === "skipped") {
-      // Not a failure (e.g. destroyed target during teardown). Don't touch the
-      // error counter and don't tick FPS.
-      return;
+  /**
+   * Poll the native receiver once. Errors are recorded against the circuit
+   * breaker and reported via the `"error"` event; both the no-frame and the
+   * error case return `null` (the tick has nothing further to do either way).
+   */
+  private _receiveFrame(): SharedTextureFrame | null {
+    try {
+      return this.receiver.receiveSharedTexture();
+    } catch (err) {
+      this._recordTickError(toError(err));
+      return null;
     }
+  }
 
-    // Successful frame delivery — reset the consecutive-error counter.
-    this._consecutiveErrors = 0;
-
-    const fps = this.fpsCounter.tick();
-    if (fps !== null) this.emit("fps", fps);
+  /** Run `_send()` with the `_inFlight` drop-latest flag held for its duration. */
+  private async _sendTracked(frame: SharedTextureFrame): Promise<SendResult> {
+    this._inFlight = true;
+    try {
+      return await this._send(frame);
+    } finally {
+      this._inFlight = false;
+    }
   }
 
   private async _send(frame: SharedTextureFrame): Promise<SendResult> {
@@ -292,16 +308,8 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       pixelFormat: frame.pixelFormat,
     };
 
-    let imported: Electron.SharedTextureImported;
-    try {
-      imported = sharedTexture.importSharedTexture({ textureInfo });
-    } catch (err) {
-      this.emit("error", toError(err));
-      // importSharedTexture threw before taking ownership — release the handle
-      // ourselves so we don't leak a per-frame NT HANDLE / IOSurface.
-      releaseUnconsumedHandle(frame.handle);
-      return "failed";
-    }
+    const imported = this._importFrame(textureInfo, frame.handle);
+    if (!imported) return "failed";
 
     const targetFrame = this.target.mainFrame;
     if (!targetFrame) {
@@ -321,6 +329,25 @@ class SharedTextureReceiverBridgeImpl extends EventEmitter implements SharedText
       return "failed";
     } finally {
       imported.release();
+    }
+  }
+
+  /**
+   * Import one frame into Electron. On throw, emits the error, releases the
+   * unconsumed native handle (importSharedTexture threw before taking
+   * ownership — without this we leak a per-frame NT HANDLE / IOSurface), and
+   * returns `null`.
+   */
+  private _importFrame(
+    textureInfo: Electron.SharedTextureImportTextureInfo,
+    rawHandle: Buffer,
+  ): Electron.SharedTextureImported | null {
+    try {
+      return sharedTexture.importSharedTexture({ textureInfo });
+    } catch (err) {
+      this.emit("error", toError(err));
+      releaseUnconsumedHandle(rawHandle);
+      return null;
     }
   }
 }


### PR DESCRIPTION
旧 #73 の再作成（#72 マージ時に base ブランチが削除され GitHub に auto-close されたため。内容は同一・レビュー済み）。

旧 stacked PR **#60** の再実装（計画: `docs/superpowers/plans/2026-08-12-refactor-stack-revival.md` Task 3/5）。

### shared-texture-receiver.ts
- `let frame` / `let result` / `let imported` を解消 — `_receiveFrame` / `_sendTracked` / `_importFrame` に抽出（`return await` による in-flight 保証・emit/release の順序は完全維持）
- `SendResult` の if-chain → **exhaustive `switch`**（inline `never` default で variant 追加漏れをコンパイル時検出）
- `(VALID_PIXEL_FORMATS as readonly string[]).includes(...)` → cast-free の `isValidPixelFormat` type guard

### preview-manager.ts（旧 #60 の hunk とバイト一致）
- `onPreviewReady =` arrow property → **method shorthand + stored listener 参照**（`removeListener` の参照同一性を維持）
- `this.win!` 非 null assertion → narrowed local、`String(...)` → template literal ×4
- `sendFrame` の `as Electron.SharedTextureImportTextureInfo` cast を除去（`TextureInfo` 型受け）

## Test plan
- renderer **168/168 無変更 green**（挙動保存の回帰証明）
- `pnpm lint`（0 errors）/ `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)