### PR TITLE
feat: Claude Code plugin marketplace with texture-bridge skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "electron-texture-bridge",
+  "owner": {
+    "name": "naporin0624",
+    "url": "https://github.com/naporin0624"
+  },
+  "metadata": {
+    "description": "Claude Code plugins for @napolab/texture-bridge — zero-copy GPU texture sharing between Electron and VJ apps (Syphon / Spout)",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "texture-bridge",
+      "source": "./plugins/texture-bridge",
+      "description": "Skills for installing, choosing, migrating to, and receiving from @napolab/texture-bridge APIs (forwardSharedTexture / forwardFrames / shared-texture receivers)",
+      "category": "development",
+      "keywords": [
+        "electron",
+        "syphon",
+        "spout",
+        "shared-texture",
+        "offscreen-rendering",
+        "vj"
+      ]
+    }
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 naporin0624
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/superpowers/specs/2026-08-13-claude-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-08-13-claude-plugin-marketplace-design.md
@@ -1,0 +1,153 @@
+# Claude Plugin Marketplace for electron-texture-bridge — Design
+
+Date: 2026-08-13
+Status: Approved in chat (brainstorming session), pending spec review
+Branch: `feat/claude-plugin-marketplace` (based on `feat/forward-frames-multiviewer`)
+
+## Overview
+
+Turn the electron-texture-bridge repository into a Claude Code plugin
+marketplace that ships one plugin, `texture-bridge`, containing four skills.
+The skills teach a consumer project's Claude session how to set up, choose,
+migrate to, and receive from the library's APIs — including the new
+`forwardSharedTexture` / `forwardFrames` primitives.
+
+Users install with:
+
+```
+/plugin marketplace add naporin0624/electron-texture-bridge
+/plugin install texture-bridge
+```
+
+## Goals
+
+- Distribute up-to-date usage knowledge alongside the library in the same
+  repository, so API changes and skill updates land in the same PR.
+- Give existing users (e.g. Cannelloni) a guided migration path from
+  capturePage-based previews and manual paint wiring to the new APIs.
+- Encode the multiviewer receiver recipe (preload receiver + demux + rAF
+  composition) as a reusable skill.
+
+## Non-goals
+
+- No slash commands, no agents, no hooks — skills only.
+- No separate plugins repo; this repo is the marketplace.
+- No Japanese translations of skills (English only).
+
+## Key Constraint: Self-Contained Skills
+
+The plugin is installed into **consumer projects** (Cannelloni, Genovese,
+third-party apps). Skill bodies MUST NOT reference files in this repository
+(no `packages/example/...` paths, no repo-relative doc links). All recipes
+are inlined in the skill or placed in the skill's own `references/*.md`.
+The `packages/example` multiviewer implementation is the source of truth
+when *authoring* the recipes, but the extracted code must stand alone.
+
+## Directory Structure
+
+```
+electron-texture-bridge/
+├── .claude-plugin/
+│   └── marketplace.json          # marketplace definition
+└── plugins/
+    └── texture-bridge/
+        ├── .claude-plugin/
+        │   └── plugin.json       # name, description, version, author
+        └── skills/
+            ├── setting-up-texture-bridge/
+            │   └── SKILL.md
+            ├── choosing-texture-bridge-api/
+            │   └── SKILL.md
+            ├── migrating-to-forward-frames/
+            │   └── SKILL.md
+            └── receiving-shared-textures/
+                └── SKILL.md
+```
+
+Long recipes may add `references/*.md` under the skill directory
+(progressive disclosure); keep SKILL.md focused on triggers and the core
+workflow.
+
+## marketplace.json
+
+- Marketplace name: `electron-texture-bridge`
+- Owner: `naporin0624`
+- One plugin entry: `texture-bridge`, source `./plugins/texture-bridge`
+
+## Versioning
+
+The plugin uses its own semver starting at `0.1.0`, independent of the
+npm packages. It is intentionally **not** added to the release-please
+`linked-versions` group — plugin content changes (prose) should not force
+npm releases. Bump the plugin version manually when skill content changes.
+
+## Skills
+
+All skills are written in English, follow superpowers:writing-skills
+conventions (gerund names, trigger-focused descriptions), and are validated
+before merge.
+
+### 1. setting-up-texture-bridge
+
+- **Triggers:** installing or bootstrapping the library, first-time wiring,
+  "add texture-bridge to my Electron app".
+- **Content:** `pnpm add @napolab/texture-bridge`; Electron 40+ requirement;
+  `OffscreenBrowserWindow` with `useSharedTexture: true`; electron-vite
+  preload entry configuration; platform notes (Syphon on macOS, Spout on
+  Windows) at the level a consumer needs (prebuilt binaries; vendor SDK
+  builds only for source builds).
+
+### 2. choosing-texture-bridge-api
+
+- **Triggers:** "which API should I use", designing a new integration,
+  reviewing an integration plan.
+- **Content:** decision table for simple vs core vs `forwardSharedTexture`
+  vs `forwardFrames`; anti-pattern catalog: capturePage polling previews,
+  GPU→CPU readback + IPC bitmap transfer, per-tag window sprawl and the
+  transfer-volume/CPU concerns that motivate atlasing.
+
+### 3. migrating-to-forward-frames
+
+- **Triggers:** replacing an existing preview/transfer implementation,
+  upgrading to the release that ships the new APIs.
+- **Content:** two migration paths:
+  1. capturePage-based preview → `forwardFrames` (Cannelloni deck preview
+     pattern; one-line insertion
+     `bridge.forwardFrames(webContents, { extraArgs })`).
+  2. Manual `handlePaint` + `TextureSender` wiring → `forwardSharedTexture`.
+- Version prerequisites (Electron 40+, texture-bridge version that ships the
+  APIs) and the v0.14.0 explicit-dispose semantics change.
+
+### 4. receiving-shared-textures
+
+- **Triggers:** implementing the receiving side of forwarded frames,
+  building a multiviewer/preview grid.
+- **Content:** preload recipe `installSharedTextureReceiver` +
+  `consumeSharedTexture` demux + rAF composition; multi-source grid
+  pattern; stale-frame guards; disconnect cleanup (clearing quadrants,
+  release/dispose obligations).
+
+## Quality Gates
+
+- `plugin-dev:plugin-validator` agent over the plugin directory.
+- `plugin-dev:skill-reviewer` agent over each skill.
+- Local install smoke test: `/plugin marketplace add <local path>` and
+  verify the four skills load in a scratch project.
+- `pnpm lint && pnpm typecheck` remain green (no TS code is added, but the
+  gates must not regress).
+
+## Branch / Review Strategy
+
+- Implement on `feat/claude-plugin-marketplace`, branched from
+  `feat/forward-frames-multiviewer` so skill content can cite the new API
+  docs and example.
+- Separate PR from the multiviewer PR; merge after it.
+- Every commit goes through difit review per project workflow; no
+  unsolicited commits.
+
+## Testing Strategy
+
+Skills are prose, not code, so vitest TDD does not apply. Verification is:
+validator + reviewer agents (above), local install smoke test, and manual
+trigger checks (paste representative user prompts, confirm the intended
+skill fires).

--- a/plugins/texture-bridge/.claude-plugin/plugin.json
+++ b/plugins/texture-bridge/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "texture-bridge",
+  "version": "0.1.0",
+  "description": "Usage, migration, and receiver skills for @napolab/texture-bridge — zero-copy GPU texture sharing for Electron offscreen windows (Syphon / Spout / renderer-to-renderer forwarding)",
+  "author": {
+    "name": "naporin0624",
+    "url": "https://github.com/naporin0624"
+  },
+  "homepage": "https://github.com/naporin0624/electron-texture-bridge",
+  "repository": "https://github.com/naporin0624/electron-texture-bridge",
+  "license": "MIT",
+  "keywords": [
+    "electron",
+    "syphon",
+    "spout",
+    "shared-texture",
+    "forwardFrames",
+    "offscreen-rendering"
+  ]
+}

--- a/plugins/texture-bridge/README.md
+++ b/plugins/texture-bridge/README.md
@@ -1,0 +1,30 @@
+# texture-bridge plugin
+
+Claude Code skills for using [`@napolab/texture-bridge`](https://github.com/naporin0624/electron-texture-bridge) — zero-copy GPU texture sharing between Electron offscreen windows and VJ software (Syphon / Spout), plus renderer-to-renderer frame forwarding.
+
+## Install
+
+```
+/plugin marketplace add naporin0624/electron-texture-bridge
+/plugin install texture-bridge
+```
+
+## Skills
+
+Skills activate automatically from conversation context — no commands to learn.
+
+| Skill | Fires when you ask about |
+|-------|--------------------------|
+| `setting-up-texture-bridge` | Installing the library, adding Syphon/Spout output to an Electron app, electron-vite config, black/garbled output right after setup |
+| `choosing-texture-bridge-api` | Which API tier to use — simple vs core, `forwardSharedTexture` vs `forwardFrames`, send vs receive paths — and integration-plan review |
+| `migrating-to-forward-frames` | Replacing `capturePage` polling / bitmap-IPC previews / Syphon loopbacks with zero-copy forwarding |
+| `receiving-shared-textures` | The receiving side: consuming forwarded frames, multiviewer grids, `VideoFrame` lifecycle, frames reappearing after disconnect |
+
+## Why these skills exist
+
+Models asked to integrate this library without them consistently fabricate plausible-looking APIs (`publishSharedTexture`, `subscribeFrames`, options objects that don't exist). Each skill was written test-first against those observed failures and verified to make an agent produce the real API surface.
+
+## Requirements
+
+- Electron 40+ (`useSharedTexture` paint events)
+- `@napolab/texture-bridge-renderer` (high-level) or `@napolab/texture-bridge-core` (low-level)

--- a/plugins/texture-bridge/skills/choosing-texture-bridge-api/SKILL.md
+++ b/plugins/texture-bridge/skills/choosing-texture-bridge-api/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: choosing-texture-bridge-api
+description: Use when deciding which @napolab/texture-bridge API tier to use for a feature — simple vs core, Syphon/Spout output vs in-app preview/monitor, forwardSharedTexture vs forwardFrames — when reviewing an integration plan that uses the library, or when unsure whether a texture-bridge function, method, or option actually exists.
+---
+
+# Choosing a texture-bridge API
+
+## Overview
+
+Three tiers, one decision rule: **who owns the offscreen window, and where do frames go?** All signatures below are the real, current API — do not improvise names.
+
+## Decision Table
+
+| You want | Use | Package |
+|----------|-----|---------|
+| One offscreen page → Syphon/Spout, library owns the window | `await createTextureBridge(options)` (async, call after `app.whenReady()`) | `@napolab/texture-bridge-renderer` |
+| Your own BrowserWindow + paint loop, full send control | `new TextureSender(name, w, h)` + `sendTextureFromPaintEvent(sender, textureInfo)` | `@napolab/texture-bridge-core` |
+| In-app monitor of a bridge's output (no Syphon hop) | `bridge.forwardFrames(target, { extraArgs })` | method on `TextureBridge` |
+| Forward frames from your **own** paint loop to a renderer | `forwardSharedTexture(textureInfo, target, extraArgs?)` | `@napolab/texture-bridge-core/electron` |
+| Receive external Syphon/Spout into your app (display only) | `createSharedTextureReceiver({ senderName, target })` + `.start()` | `@napolab/texture-bridge-renderer` |
+| Receive external Syphon/Spout as pixels in JS (analysis/export) | `createTextureReceiver({ senderName })` + `.start()` | `@napolab/texture-bridge-renderer` |
+| Raw RGBA push without Electron (sanity check / CI) | `sender.sendRgbaBuffer(buf, w, h)` | `@napolab/texture-bridge-core` |
+
+Any window that consumes forwarded or received shared-texture frames uses the same receiving pair: `installSharedTextureReceiver()` + `consumeSharedTexture(handlers)` from `@napolab/texture-bridge-renderer/client` (see receiving-shared-textures skill).
+
+## forwardFrames vs forwardSharedTexture
+
+Same zero-copy path (`sharedTexture.importSharedTexture` → `sendSharedTexture`), different altitude:
+
+- `bridge.forwardFrames(target, { extraArgs: [slot] })` — **driver**: registers a target for every subsequent paint frame of that bridge. Returns a `FrameForward`; `forward.dispose()` unregisters (idempotent; `bridge.dispose()` clears all). Best-effort: forward failures never surface on the bridge's `"error"` / `frameDropped`, and Syphon/Spout sending is completely independent of forwarding.
+- `forwardSharedTexture(textureInfo, target, extraArgs?)` — **primitive** for manual paint loops. Async, never throws synchronously; resolves `undefined` on success or a `ForwardDefect` (`target-destroyed` / `import-failed` / `send-failed`). Lives on the `/electron` subpath so the core main entry stays importable without Electron.
+
+```typescript
+// manual paint loop: Syphon and renderer-forward are independent, per frame
+win.webContents.on("paint", async (e) => {
+  sendTextureFromPaintEvent(sender, e.texture?.textureInfo);              // → Syphon/Spout
+  if (e.texture) await forwardSharedTexture(e.texture.textureInfo, monitorWC, [slot]); // → renderer
+  e.texture?.release();
+});
+```
+
+## Anti-Patterns
+
+| Anti-pattern | Instead |
+|--------------|---------|
+| `capturePage()` polling for previews/monitors (GPU→CPU readback + bitmap IPC per frame) | `bridge.forwardFrames(previewWC, { extraArgs: [id] })` — see migrating-to-forward-frames skill |
+| Syphon loopback for in-app preview (publish + receive your own output) | `forwardFrames` — no external dependency, works on both platforms |
+| `receiveFrame()` RGBA readback when you only display the frames | `createSharedTextureReceiver` — zero-copy `VideoFrame` |
+| Mixing `createTextureBridge` with your own `paint` handler on the same window | Pick one tier. The factory already consumes paint; double handling double-releases textures |
+| Holding shared textures to build queues/backpressure buffers | Latest-frame-wins: hold at most one, release/close superseded frames immediately |
+| Skipping `texture.release()` (manual loop) or `sender.stop()` / `bridge.dispose()` / `receiver.dispose()` at teardown | Resource lifecycle is deterministic — nothing is GC-cleaned |
+| Unpacking `textureInfo.handle` yourself for platform branching | `sendTextureFromPaintEvent` / `forwardSharedTexture` already handle IOSurface vs NT-handle |
+
+## APIs That Do Not Exist
+
+Fabrications seen in the wild — if you find yourself writing these, stop and use the table above: `publishSharedTexture(win, opts)`, `forwardFrames({ sources, target })` as a free function, `receiveFrames()` / `subscribeFrames()`, `@napolab/texture-bridge/preload`, `sender.dispose()` (it's `stop()`), `new TextureSender({ name })` (it's positional `(name, width, height)`).

--- a/plugins/texture-bridge/skills/migrating-to-forward-frames/SKILL.md
+++ b/plugins/texture-bridge/skills/migrating-to-forward-frames/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: migrating-to-forward-frames
+description: Use when replacing an existing Electron preview/monitor implementation with @napolab/texture-bridge zero-copy forwarding — capturePage polling, paint-event bitmap IPC, toBitmap/toPNG transfers, or a Syphon loopback feeding an in-app window — or when upgrading to the release that ships forwardFrames / forwardSharedTexture.
+---
+
+# Migrating to forwardFrames
+
+## Overview
+
+`forwardFrames` pushes a bridge's paint frames to any renderer `WebContents` as zero-copy GPU handles — full resolution, paint-rate, no readback. It replaces CPU preview paths (`capturePage` polling, bitmap IPC) with one registration per source.
+
+**Prerequisites:** Electron 40+, and a `@napolab/texture-bridge-renderer` version that ships `TextureBridge.forwardFrames` (check `bridge.forwardFrames` exists in your installed `node_modules` types before starting; upgrade if not).
+
+## Path A: capturePage preview → forwardFrames
+
+Applies when sources are `TextureBridge` instances and previews poll `capturePage` (or IPC bitmaps from paint events).
+
+**Delete:** the capture timer, the bitmap IPC channel (send + `ipcRenderer.on` + `putImageData`/`drawImage` of bitmaps), and any downscale logic — receivers draw the full-resolution `VideoFrame` scaled by canvas.
+
+**Add (sender, main process):** one line per source:
+
+```typescript
+const forward = deck.bridge.forwardFrames(previewWindow.webContents, {
+  extraArgs: [deckIndex],   // arrives verbatim as trailing onFrame args — the demux tag
+});
+// teardown: forward.dispose()  — idempotent; bridge.dispose() also clears it
+```
+
+The option is `extraArgs` (an array). There is no `sourceId`, `channel`, or `maxFps` option. The handle's cleanup method is `dispose()`, not `stop()` or `unsubscribe()`.
+
+**Add (receiver):** the preview window consumes exactly like any shared-texture receiver — `installSharedTextureReceiver()` once + `consumeSharedTexture({ onFrame: (frame, deckIndex) => ... })`, both imported from `@napolab/texture-bridge-renderer/client` (the `/client` subpath — the package root exports the main-process API only), in a preload, window running `nodeIntegration: true, contextIsolation: false, sandbox: false`. Full recipe (frame cloning, coalescing, rAF, cleanup): see the receiving-shared-textures skill.
+
+## Path B: manual paint wiring → forwardSharedTexture
+
+Applies when you run your own offscreen window + `paint` handler (core tier) and currently copy pixels out for a monitor. Forward inside the same handler:
+
+```typescript
+import { forwardSharedTexture } from "@napolab/texture-bridge-core/electron";
+
+win.webContents.on("paint", async (e) => {
+  sendTextureFromPaintEvent(sender, e.texture?.textureInfo);   // existing Syphon/Spout send
+  if (e.texture) await forwardSharedTexture(e.texture.textureInfo, monitorWC, [slot]);
+  e.texture?.release();   // still exactly once, after both consumers
+});
+```
+
+`forwardSharedTexture` imports and releases its own imported texture internally (release-in-finally) — your `e.texture.release()` obligation is unchanged. It never throws synchronously; it resolves `undefined` or a `ForwardDefect` (`target-destroyed` / `import-failed` / `send-failed`) — check it if you want failure metrics, ignore it for best-effort.
+
+## Contract Changes to Communicate
+
+- **Best-effort forwarding:** forward failures do NOT appear on the bridge's `"error"` event or `frameDropped`. A dead preview window never affects the live Syphon/Spout output, and vice versa — the two paths are fully independent per frame.
+- **Paint-driven cadence:** no timer. An idle source produces no preview frames (previous frame stays on screen — receivers should not clear canvases between frames, only on disconnect).
+- **Dispose semantics (since v0.14.0):** `bridge.dispose()` destroys the offscreen window synchronously via `destroy()`. `disposed` listeners must not touch `bridge.renderWindow.webContents`; remove any external `bridge.renderWindow.destroy()` workarounds — a second destroy can throw.
+
+## Migration Checklist
+
+1. Verify library version ships `forwardFrames`; verify Electron ≥ 40.
+2. Register forwards (Path A) or add the primitive to the paint handler (Path B).
+3. Build the receiving preload per receiving-shared-textures skill.
+4. Delete the old CPU path only after the new one renders.
+5. Wire teardown: `forward.dispose()` when a preview closes or a source disconnects; dispose before destroying source windows.
+6. Confirm CPU drop (the readback + IPC cost disappears; remaining cost is constant per source).
+
+## Common Mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| `bridge.forwardFrames(wc, { sourceId })` / `{ channel }` / `{ maxFps }` | Only `{ extraArgs: [...] }` exists. Rate control belongs to the receiver's rAF coalescing. |
+| `forward.stop()` / `subscription.unsubscribe()` | `forward.dispose()`. |
+| Expecting forward failures on `bridge.on("error")` | Best-effort: defects are discarded by the driver. Use `forwardSharedTexture`'s returned defect if you need visibility. |
+| Preview window with default `webPreferences` | Shared-texture consumption needs the receiver preload setup — see receiving-shared-textures skill. |
+| Calling `frame.videoFrame.close()` on the frame passed to `onFrame` | The consumer pool closes the original after your handler settles. `clone()` if you hold it; close only clones. |
+| Keeping a `capturePage` fallback "just in case" | Delete it once verified — a hidden 30fps readback timer defeats the migration. |

--- a/plugins/texture-bridge/skills/receiving-shared-textures/SKILL.md
+++ b/plugins/texture-bridge/skills/receiving-shared-textures/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: receiving-shared-textures
+description: Use when implementing the receiving side of @napolab/texture-bridge shared-texture frames in an Electron renderer — consuming forwardFrames/forwardSharedTexture output, displaying createSharedTextureReceiver frames, building a multiviewer/preview grid, or debugging leaked VideoFrames, black canvases, or frames from a disconnected source reappearing.
+---
+
+# Receiving Shared Textures
+
+## Overview
+
+Every shared-texture producer in `@napolab/texture-bridge` — `bridge.forwardFrames`, `forwardSharedTexture`, `createSharedTextureReceiver` — delivers to a renderer through the same consuming pair:
+
+```typescript
+import {
+  installSharedTextureReceiver,
+  consumeSharedTexture,
+} from "@napolab/texture-bridge-renderer/client";   // the /client subpath — not the package root
+```
+
+`installSharedTextureReceiver()` — once at startup, before any consume call. It binds Electron's **single** `sharedTexture.setSharedTextureReceiver` slot to a pool so multiple consumers coexist. Idempotent. Never call `sharedTexture.setSharedTextureReceiver` yourself alongside it.
+
+## Window Setup
+
+The consuming code must run where `electron` is resolvable — a **preload script**, with:
+
+```typescript
+new BrowserWindow({
+  webPreferences: {
+    preload: path.join(__dirname, "../preload/monitor.js"),
+    nodeIntegration: true,
+    contextIsolation: false,
+    sandbox: false,
+  },
+});
+```
+
+Importing `/client` from a Vite-driven renderer page fails in dev (Vite cannot pre-bundle the `electron` CJS module) — keep it in the preload. For context-isolated production setups: consume in the preload, then `window.postMessage(videoFrame, "*", [videoFrame])` each frame into the isolated world (`VideoFrame` is transferable; the receiving side closes it).
+
+## The Frame Lifecycle Contract
+
+This is where implementations go wrong:
+
+1. `onFrame(frame, ...extraArgs)` receives `{ textureId, videoFrame }`. The `extraArgs` are whatever the producer passed (`forwardFrames`' demux tag, etc.).
+2. **The pool closes `frame.videoFrame` after your handler settles.** Do not close it yourself. There is no `frame.release()` — that's the sender-side paint-event API.
+3. **To use a frame beyond the handler, `clone()` it.** Close every clone you make, exactly once: when replaced by a newer frame, on disconnect, and on `beforeunload`.
+
+## Canonical Recipe: N-source Monitor Grid
+
+Latest-frame coalescing + rAF draw. Draw cost stays fixed at display refresh rate no matter how many sources or how fast they paint; decks keep showing the last frame between arrivals instead of flickering.
+
+```typescript
+// preload/monitor.ts
+import {
+  installSharedTextureReceiver,
+  consumeSharedTexture,
+} from "@napolab/texture-bridge-renderer/client";
+import type { SharedTextureConsumerFrame } from "@napolab/texture-bridge-renderer/client";
+
+installSharedTextureReceiver();
+
+const SLOT_COUNT = 4;
+const W = 480, H = 270;
+
+// One held clone per slot; undefined = nothing to draw.
+const latest: (SharedTextureConsumerFrame | undefined)[] = Array.from({ length: SLOT_COUNT });
+// dispose() doesn't cancel deliveries already in flight, so a stray tagged
+// frame can arrive just after disconnect — this guard drops it instead of
+// letting it resurrect the slot.
+const connected: boolean[] = Array.from({ length: SLOT_COUNT }, () => false);
+
+consumeSharedTexture({
+  onFrame: (frame, ...args) => {
+    const slot = args[0];
+    if (typeof slot !== "number" || slot < 0 || slot >= SLOT_COUNT) return;
+    if (!connected[slot]) return;
+    latest[slot]?.videoFrame.close();                      // close the superseded clone
+    latest[slot] = { textureId: frame.textureId, videoFrame: frame.videoFrame.clone() };
+  },
+  onError: (err) => console.error("[monitor]", err),
+});
+
+const draw = (): void => {
+  for (const [slot, held] of latest.entries()) {
+    if (!held) continue;
+    const deckCtx = deckContexts[slot];
+    deckCtx?.drawImage(held.videoFrame, 0, 0, W, H);       // GPU blit; draw scales full-res frame
+    // 2x2 composite = renderer-side atlas: blit each held frame into its quadrant
+    compositeCtx.drawImage(held.videoFrame, (slot % 2) * W, Math.floor(slot / 2) * H, W, H);
+    // do NOT close here — the held clone is redrawn every tick until replaced
+  }
+  requestAnimationFrame(draw);
+};
+requestAnimationFrame(draw);
+
+const disconnectSlot = (slot: number): void => {
+  connected[slot] = false;                                  // before disposing the producer
+  latest[slot]?.videoFrame.close();
+  latest[slot] = undefined;
+  deckContexts[slot]?.clearRect(0, 0, W, H);
+  compositeCtx.clearRect((slot % 2) * W, Math.floor(slot / 2) * H, W, H);  // clear the quadrant too
+};
+
+window.addEventListener("beforeunload", () => {
+  for (const held of latest) held?.videoFrame.close();
+});
+```
+
+Main-process side per slot: `bridge.forwardFrames(monitorWC, { extraArgs: [slot] })` (local source) or `createSharedTextureReceiver({ senderName, target: monitorWC, extraArgs: [slot] })` + `.start()` (external Syphon/Spout source) — both feed this same consumer. On disconnect, `dispose()` the producer AND run `disconnectSlot`.
+
+For WebGPU, replace `drawImage` with `device.importExternalTexture({ source: held.videoFrame })` — also zero-copy.
+
+## Common Mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| `frame.videoFrame.close()` (or an invented `frame.release()`) inside `onFrame` | The pool closes the original after the handler settles. Close only your clones. |
+| Drawing directly in `onFrame` | Ties draw cost to arrival rate (N sources × paint rate). Hold latest clone, draw in one rAF loop. |
+| Closing the held frame after drawing it | Held clone is redrawn every tick — closing it blanks the deck until the next arrival. Close only when superseded, disconnected, or unloading. |
+| Skipping the `connected` guard | In-flight frames arriving after disconnect resurrect the slot with a stale image. |
+| Clearing canvases between frames | Paint-driven sources go idle legitimately; clearing causes flicker. Clear only on disconnect (deck AND composite quadrant). |
+| `setSharedTextureReceiver` directly, or importing `/client` in a Vite renderer page | Single-slot API conflicts with the pool; Vite dev can't pre-bundle `electron`. Preload + `installSharedTextureReceiver()`. |
+| Inventing `exposeFrameReceiver` / `subscribeFrames` / `@napolab/texture-bridge/preload` | None exist. The receiving surface is exactly `installSharedTextureReceiver` + `consumeSharedTexture` (+ `createMultiDispatcher` for custom fan-out adapters). |

--- a/plugins/texture-bridge/skills/setting-up-texture-bridge/SKILL.md
+++ b/plugins/texture-bridge/skills/setting-up-texture-bridge/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: setting-up-texture-bridge
+description: Use when installing or bootstrapping @napolab/texture-bridge in an Electron app — adding Syphon/Spout output, wiring an offscreen window with useSharedTexture, configuring electron-vite for the native addon, or debugging black/garbled output right after setup.
+---
+
+# Setting Up texture-bridge
+
+## Overview
+
+`@napolab/texture-bridge` publishes Electron offscreen-rendered frames to Syphon (macOS) / Spout (Windows) as zero-copy GPU textures. Setup is almost entirely main-process; the renderer just draws.
+
+**Install the right package.** The code ships as a dependency chain — you normally depend on exactly one:
+
+| Package | Use |
+|---------|-----|
+| `@napolab/texture-bridge-renderer` | **High-level (start here):** `createTextureBridge()`, receivers, discovery |
+| `@napolab/texture-bridge-core` | Low-level: `TextureSender`, `sendTextureFromPaintEvent` (root); `forwardSharedTexture` (`/electron` subpath only) |
+| `@napolab/texture-bridge` | Raw napi-rs binding — never install directly for app work |
+
+```bash
+pnpm add @napolab/texture-bridge-renderer
+```
+
+Requires Electron 40+ (first version with `useSharedTexture` paint events).
+
+## Recommended Setup: `createTextureBridge`
+
+The factory **owns the offscreen BrowserWindow** — do not create one yourself, pass a `rendererUrl` instead:
+
+```typescript
+// main process
+import { app } from "electron";
+import { createTextureBridge } from "@napolab/texture-bridge-renderer";
+
+app.whenReady().then(async () => {
+  const bridge = await createTextureBridge({
+    name: "MyApp",              // Syphon/Spout sender name
+    width: 1920,
+    height: 1080,
+    frameRate: 60,
+    rendererUrl: "path/to/index.html",  // file path, file://, or http(s)://
+    preview: { enabled: true },         // optional preview window
+    // includeAlpha: true,              // forward per-pixel alpha (transparency)
+    // pixelExact: true,                // REQUIRED on Electron 40 + scaled displays
+  });
+  bridge.on("fps", (fps) => console.log(fps));
+  bridge.on("error", (err) => console.error(err));
+  // bridge.dispose() on teardown — destroys the offscreen window synchronously
+});
+```
+
+Renderer page: draw continuously (rAF loop); a static page stops producing paint frames. For worker-based rendering use `createWorkerRenderer` from `@napolab/texture-bridge-renderer/client` with `canvas.transferControlToOffscreen()`.
+
+## Electron 40 Retina/DPI Warning
+
+The #1 cause of black or garbled receiver output on Electron 40: the offscreen framebuffer is sized in DIP × display scaleFactor, so a 1920×1080 bridge on Retina produces a 3840×2160 texture that mismatches the declared sender size. Fix: `pixelExact: true`. On Electron ≥ 41 the bridge pins `deviceScaleFactor: 1` automatically and this is a non-issue.
+
+## electron-vite (ESM)
+
+- Add `externalizeDepsPlugin()` to **both** `main` and `preload` configs so the `.node` binary is never bundled.
+- ESM mode emits preload as `index.mjs` — reference it as `../preload/index.mjs`, not `.js`.
+- pnpm 10 may need the native package approved in `pnpm.onlyBuiltDependencies`.
+- Packaging: keep `**/*.node` and `@napolab/texture-bridge*` out of asar (`asarUnpack`).
+
+## Manual (core) Path
+
+Only when you own the window and paint loop yourself:
+
+```typescript
+import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
+
+const win = new BrowserWindow({
+  show: false,
+  webPreferences: { offscreen: { useSharedTexture: true } },  // object form, not `offscreen: true`
+});
+const sender = new TextureSender("MyApp", 1920, 1080);
+
+win.webContents.on("paint", (details) => {
+  const texture = details.texture;
+  if (texture === undefined) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release();   // always — leaking stalls the shared-texture pool
+  }
+});
+win.webContents.setFrameRate(60);
+// teardown: sender.stop()
+```
+
+On this path YOU own DPR correctness: Electron ≥ 41 pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }`; Electron 40 reconcile declared size with DIP×scaleFactor yourself.
+
+## Common Mistakes
+
+| Mistake | Reality |
+|---------|---------|
+| `pnpm add @napolab/texture-bridge` for app work | That's the raw binding. Install `@napolab/texture-bridge-renderer`. |
+| Inventing a setup API like `publishSharedTexture(win, ...)` / `forwardSharedTexture(win.webContents, { name })` | No such setup API. High-level setup is `createTextureBridge(options)` and it creates the window itself. `forwardSharedTexture` is a per-frame forwarding primitive (see choosing-texture-bridge-api skill), not a Syphon publisher. |
+| `new TextureSender({ name })` / `sender.sendSurface(textureInfo)` / `sender.dispose()` | Real API: `new TextureSender(name, width, height)`; per-paint sends go through `sendTextureFromPaintEvent(sender, textureInfo)`; teardown is `sender.stop()` (terminal, idempotent). |
+| `offscreen: true` | CPU path — `details.texture` never arrives. Use `offscreen: { useSharedTexture: true }`. |
+| Ignoring display scaling on Electron 40 | Black/garbled output on Retina / Windows 150%. Use `pixelExact: true` or upgrade to Electron ≥ 41. |
+| `app.disableHardwareAcceleration()` anywhere | Shared textures require GPU compositing. |
+
+## Verify
+
+`sendRgbaBuffer` needs no Electron — fastest way to split "Electron problem vs bridge problem":
+
+```typescript
+// npx tsx sanity.ts — look for sender "CHECK" in your VJ app
+import { TextureSender } from "@napolab/texture-bridge-core";
+const s = new TextureSender("CHECK", 512, 512);
+setInterval(() => s.sendRgbaBuffer(Buffer.alloc(512 * 512 * 4, 0x80), 512, 512), 33);
+```


### PR DESCRIPTION
## Summary

Turns the repository into a Claude Code plugin marketplace shipping one skills-only plugin, `texture-bridge`, so consumer projects can install up-to-date usage knowledge with:

```
/plugin marketplace add naporin0624/electron-texture-bridge
/plugin install texture-bridge
```

- `.claude-plugin/marketplace.json` — marketplace definition (repo root)
- `plugins/texture-bridge/` — plugin manifest (independent semver 0.1.0, intentionally outside the release-please linked-versions group) + README + 4 skills
- `docs/superpowers/specs/2026-08-13-claude-plugin-marketplace-design.md` — design spec
- `LICENSE` — MIT text the README badge already links to

## Skills (written test-first)

Per superpowers:writing-skills TDD: baseline subagents WITHOUT the skills consistently fabricated the API surface (`publishSharedTexture`, `subscribeFrames`, `{ sourceId }`, consumer-side `frame.release()`, `@napolab/texture-bridge/preload`, …). Each skill encodes the real signatures, lifecycle contracts, and a Common Mistakes table built from those observed fabrications, and was re-verified to make an agent produce the real API with zero fabrications.

| Skill | Covers |
|-------|--------|
| setting-up-texture-bridge | install, createTextureBridge wiring, electron-vite/ESM, E40 DPR pitfall |
| choosing-texture-bridge-api | tier decision table, forwardFrames vs forwardSharedTexture, anti-patterns |
| migrating-to-forward-frames | capturePage/bitmap-IPC → zero-copy migration (both paths), dispose semantics |
| receiving-shared-textures | consumer pool lifecycle (clone-to-hold), coalescing + rAF grid recipe, disconnect guards |

## Verification

- plugin-dev:plugin-validator — PASS (warnings resolved: plugin README, LICENSE)
- plugin-dev:skill-reviewer — PASS, actionable minor findings applied
- `pnpm lint` / `pnpm typecheck` / `pnpm build` / `pnpm test` (core 26 + renderer 183) — green
- Skills are self-contained (installed into consumer projects; no repo-relative references)

## Notes

- Based on `feat/forward-frames-multiviewer` — merge that PR first; skills document the forwardFrames API it ships.
- Local smoke test for reviewers: `/plugin marketplace add <checkout path>` then `/plugin install texture-bridge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTdLhbr8SdWaE9FRHm76sL