### PR TITLE
build(renderer): copy assets via tsdown instead of unix cp

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -25,7 +25,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsdown && cp -r src/assets dist/assets && node scripts/esm-shim-guard.mjs",
+    "build": "tsdown && node scripts/esm-shim-guard.mjs",
     "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/renderer/tsdown.config.mts
+++ b/packages/renderer/tsdown.config.mts
@@ -11,4 +11,15 @@ export default defineConfig({
   // The shim helper is inlined from tsdown's own package; this is intentional,
   // so silence the "dependency bundled" warning (which would fail CI on warn).
   inlineOnly: false,
+  // PreviewManager loads `preview.html` / `preview-preload.js` from
+  // `dist/assets/` at runtime, so they must ship alongside the bundle. This
+  // used to be a `cp -r src/assets dist/assets` step in the build script,
+  // which fails on Windows (pnpm runs scripts through cmd.exe, where `cp`
+  // only exists if Git's usr/bin happens to be on PATH).
+  //
+  // `flatten: false` preserves each match's path relative to the first
+  // non-glob segment of `from` (`src/`), so `src/assets/x` lands at
+  // `dist/assets/x` — hence `to: "dist"`, not `to: "dist/assets"`. This
+  // matches `cp -r` for any future subdirectory under `src/assets`.
+  copy: { from: "src/assets/**/*", to: "dist", flatten: false },
 });


### PR DESCRIPTION
## 背景

Windows で multiviewer を動かすと `entry.bridge.forwardFrames is not a function` で落ちる、という報告から調査した副産物です。

その報告自体の直接原因は **ビルド不足**でした（コード修正不要）:

- `forwardFrames` は 66c9d13 で追加されたばかり
- `packages/renderer/dist/` は `.gitignore` 済みなので `git pull` では降ってこない
- `packages/example/electron.vite.config.ts` の `externalizeDepsPlugin()` により、main プロセスは実行時に workspace リンク経由で `packages/renderer/dist/index.cjs` を `require` する → 古い prototype がロードされる
- ルートの `pnpm build` は `build:native && build:core && build:renderer` の直列チェーンなので、Windows で native ビルド（Rust + `vendor/Spout2`）が失敗すると renderer まで到達しない

対処は Windows 側で `pnpm build:core && pnpm build:renderer` を実行するだけです。

## この PR で直すもの

上記を実行しようとすると Windows では**次の壁に当たる**ため、そちらを修正します。

`packages/renderer` の build スクリプトが Unix の `cp` を呼んでいました:

```
tsdown && cp -r src/assets dist/assets && node scripts/esm-shim-guard.mjs
```

pnpm は Windows では既定で cmd.exe 経由でスクリプトを起動するため、Git の `usr/bin` が PATH に無い標準的な Windows 開発機では `cp` が解決できません。順序上 tsdown は先に走るのでバンドル自体は生成されますが、そこで中断して `dist/assets/` が空のまま残ります。`packages/renderer/src/preview-manager.ts` は `preview.html` / `preview-preload.js` をこのディレクトリから実行時に解決するので、preview ウィンドウ機能が壊れます。

CI がこれを検出できないのは、GitHub Actions の Windows イメージには `cp.exe` が PATH にあるためです。

## 変更内容

コピー処理を tsdown 自身の `copy` オプションに移し、シェル非依存にしました。

```ts
copy: { from: "src/assets/**/*", to: "dist", flatten: false },
```

`flatten: false` のベースは **`from` の最初の非 glob セグメント (`src/`)** です。したがって `src/assets/x` は `dist/assets/x` に着地するため、`to` は `"dist/assets"` ではなく `"dist"` が正解です（`"dist/assets"` にすると `dist/assets/assets/x` と二重にネストします）。

## 検証

- クリーンビルド後、`diff -r packages/renderer/src/assets packages/renderer/dist/assets` が完全一致
- `src/assets` 配下にネストしたサブディレクトリを置いて再ビルドし、`cp -r` と同じく構造が保持されることを確認
- `pnpm lint` → 0 errors（1 warning は `packages/example/src/preload/index.ts` の空ファイルで、本変更とは無関係の既存分）
- `pnpm typecheck` → core / renderer / example すべて成功
- `pnpm test` → 223 passed (core 33 / renderer 190)

## 補足

コミット種別を `fix:` ではなく `build:` にしています。公開される成果物の内容は変わらず（macOS / CI では既に正しくコピーされていた）、ビルドの可搬性のみの修正なので、release-please のリリース PR を発火させない意図です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)