### PR TITLE
docs: restructure README and document the bundled agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ A napi-rs native addon for bidirectional GPU texture sharing with Electron. **Se
 
 ```bash
 npm i @napolab/texture-bridge-renderer
+# or
+pnpm add @napolab/texture-bridge-renderer
 ```
 
-The code ships as several `@napolab/*` packages:
+That one package pulls in the whole chain — prebuilt native binaries included. You normally depend on just it.
 
 | Use case | Package | What it gives you |
 |----------|---------|-------------------|
@@ -24,7 +26,133 @@ The code ships as several `@napolab/*` packages:
 | Native binding | [`@napolab/texture-bridge`](https://www.npmjs.com/package/@napolab/texture-bridge) | Raw napi-rs classes (`TextureSender`, `TextureReceiver`) |
 | Prebuilt binary | `@napolab/texture-bridge-darwin-arm64`, etc. | Platform `.node`, resolved automatically via `optionalDependencies` |
 
-Dependency direction: `texture-bridge-renderer` → `texture-bridge-core` → `texture-bridge` → `texture-bridge-<platform>`. Installing `-renderer` pulls in the whole chain — you normally depend on just one package.
+Dependency direction: `texture-bridge-renderer` → `texture-bridge-core` → `texture-bridge` → `texture-bridge-<platform>`.
+
+> Building from source, full prerequisites, packaging, and integration walkthroughs: **[docs/INSTALLATION.md](docs/INSTALLATION.md)**.
+
+## AI Agent Skills
+
+This repo ships **agent skills** that teach coding agents the real API surface of this library.
+
+They exist because models asked to integrate texture-bridge without them consistently invent plausible-looking APIs that do not exist (`publishSharedTexture`, `subscribeFrames`, options objects that were never defined). Each skill was written test-first against those observed failures and verified to make an agent produce the actual API.
+
+### Claude Code (plugin)
+
+```
+/plugin marketplace add naporin0624/electron-texture-bridge
+/plugin install texture-bridge
+```
+
+### Any other agent (Skills CLI)
+
+Works with Codex, GitHub Copilot, Amp, Cursor, Antigravity, and others via [skills.sh](https://skills.sh/naporin0624/electron-texture-bridge). **Install one skill per command** — passing several at once only installs the first:
+
+```bash
+npx skills add naporin0624/electron-texture-bridge@setting-up-texture-bridge
+npx skills add naporin0624/electron-texture-bridge@choosing-texture-bridge-api
+npx skills add naporin0624/electron-texture-bridge@migrating-to-forward-frames
+npx skills add naporin0624/electron-texture-bridge@receiving-shared-textures
+npx skills add naporin0624/electron-texture-bridge@managing-frame-forward-lifecycle
+npx skills add naporin0624/electron-texture-bridge@delivering-imported-textures
+npx skills add naporin0624/electron-texture-bridge@handling-texture-bridge-failures
+```
+
+Add `-g` to install globally instead of into the current project.
+
+> Omitting the `@skill-name` suffix installs **every** skill in the repository, including this project's own internal development-rule skills (`ci`, `smart-commit`, and others) that are not about texture-bridge at all. Name the skills you want.
+
+### What each skill covers
+
+Skills activate automatically from conversation context — there are no commands to learn.
+
+| Skill | Fires when you ask about |
+|-------|--------------------------|
+| `setting-up-texture-bridge` | Installing the library, adding Syphon/Spout output to an Electron app, electron-vite config, black/garbled output right after setup |
+| `choosing-texture-bridge-api` | Which API tier to use — simple vs core, `forwardSharedTexture` vs `forwardFrames`, send vs receive paths — and integration-plan review |
+| `migrating-to-forward-frames` | Replacing `capturePage` polling / bitmap-IPC previews / Syphon loopbacks with zero-copy forwarding |
+| `receiving-shared-textures` | The receiving side: consuming forwarded frames, multiviewer grids, `VideoFrame` lifecycle, frames reappearing after disconnect |
+| `managing-frame-forward-lifecycle` | Registering and tearing down `forwardFrames` targets: monitor windows that close and reopen, repeated connect/disconnect, `MaxListenersExceededWarning`, leaks around forwarding |
+| `delivering-imported-textures` | Delivering a texture to a renderer from main: `importSharedTexture` / `sendSharedTexture` / `release()` by hand, where `release()` belongs, `sendImportedTexture` vs `forwardSharedTexture` |
+| `handling-texture-bridge-failures` | Error handling and telemetry: which calls throw, reject, model a defect, or emit — what to wrap with `Result.fromThrowable`, silently black output, a main-process crash from a bridge call |
+
+## Quick Start
+
+### Sending: Electron → VJ software
+
+The factory handles offscreen window creation, paint event wiring, Syphon/Spout sender, and optional preview window — all in one call.
+
+```typescript
+// main process
+import { app } from "electron";
+import { createTextureBridge } from "@napolab/texture-bridge-renderer";
+
+app.whenReady().then(async () => {
+  const bridge = await createTextureBridge({
+    name: "MyApp",
+    width: 1920,
+    height: 1080,
+    frameRate: 60,
+    rendererUrl: "path/to/index.html",  // Your renderer page with Web Worker
+    preview: { enabled: true },
+  });
+
+  bridge.on("fps", (fps) => console.log(`FPS: ${fps.toFixed(1)}`));
+  bridge.resize(3840, 2160);  // Resizes all layers automatically
+  // bridge.dispose();         // Clean up when done
+});
+```
+
+```html
+<!-- renderer page (index.html) -->
+<canvas id="canvas" width="1920" height="1080"></canvas>
+<script type="module">
+  import MyWorker from './my-worker?worker';
+  const canvas = document.getElementById('canvas');
+  const offscreen = canvas.transferControlToOffscreen();
+  const worker = new MyWorker();
+  worker.postMessage({ type: 'init', canvas: offscreen }, [offscreen]);
+</script>
+```
+
+More sending recipes — capturing a live web page, transparency (`includeAlpha`), the low-level paint loop, DPI correctness, electron-vite (ESM) integration — are in **[docs/SENDING.md](docs/SENDING.md)**.
+
+### Receiving: VJ software → Electron
+
+Pull textures from external Syphon/Spout servers into your Electron app.
+
+```typescript
+// main process
+import { app } from "electron";
+import { createTextureReceiver, SenderDiscovery } from "@napolab/texture-bridge-renderer";
+
+app.whenReady().then(() => {
+  // Discover available servers
+  const discovery = new SenderDiscovery();
+  discovery.on("added", (senders) => {
+    console.log("New senders:", senders);
+  });
+  discovery.start(1000); // Poll every second
+
+  // Receive from a specific server
+  const receiver = createTextureReceiver({
+    senderName: "Resolume Arena",
+  });
+
+  receiver.on("frame", (frame) => {
+    // frame: { data: Buffer, width: number, height: number }
+    console.log(`Received ${frame.width}x${frame.height} frame`);
+  });
+
+  receiver.on("fps", (fps) => console.log(`Receive FPS: ${fps.toFixed(1)}`));
+  receiver.start();
+
+  // Clean up
+  // receiver.dispose();
+  // discovery.dispose();
+});
+```
+
+That example uses the **RGBA readback** path. For the **zero-copy GPU** path (`createSharedTextureReceiver`, `consumeSharedTexture`, renderer context isolation), see **[docs/RECEIVING.md](docs/RECEIVING.md)**.
 
 ## Which API should I use?
 
@@ -35,11 +163,11 @@ Do you just want OSR (useSharedTexture) → Syphon/Spout, and let the library ow
 
 Do you have your own BrowserWindow / paint loop you want to bolt sending onto?
   YES → TextureSender + sendTextureFromPaintEvent()  (@napolab/texture-bridge-core)
-        You own DPR correctness yourself — see the Retina/DPI warning below (§ "macOS Retina / Windows DPI").
+        You own DPR correctness yourself — see docs/SENDING.md § "macOS Retina / Windows DPI".
 
 Do you want to push raw RGBA without Electron at all (test / CI / sanity check)?
   YES → new TextureSender(...).sendRgbaBuffer()  (@napolab/texture-bridge-core)
-        See "Minimal sanity check (no Electron)" below.
+        See docs/SENDING.md § "Minimal sanity check (no Electron)".
 ```
 
 ### Package roles and dependency direction
@@ -130,919 +258,10 @@ The texture stays GPU-resident from the sender all the way to the consumer canva
 ## Requirements
 
 - **Node.js** 20+
-- **pnpm** 10+
-- **Rust** toolchain (via [rustup](https://rustup.rs/))
 - **Electron** 40.0.0+
+- **macOS** 11.0+ (Metal), or **Windows** with a DirectX 11 compatible GPU
 
-### macOS
-
-- Xcode Command Line Tools
-- macOS 11.0+ (Metal support)
-
-### Windows
-
-- Visual Studio Build Tools 2019+ with "Desktop development with C++" workload
-- Windows SDK 10.0.19041.0+
-- DirectX 11 compatible GPU
-
-## Installation
-
-> **Detailed guide:** See [docs/INSTALLATION.md](docs/INSTALLATION.md) for step-by-step instructions covering prerequisites, building from source, integration, packaging, and troubleshooting.
-
-### As a library (recommended)
-
-```bash
-npm install @napolab/texture-bridge-renderer
-# or
-pnpm add @napolab/texture-bridge-renderer
-```
-
-`@napolab/texture-bridge-renderer` is the high-level package for most users. It includes `@napolab/texture-bridge-core` and `@napolab/texture-bridge` as dependencies.
-
-For advanced use cases that need direct control over the pipeline:
-
-```bash
-npm install @napolab/texture-bridge-core
-```
-
-### Building from source
-
-```bash
-# Clone with submodules (Syphon source)
-git clone --recursive https://github.com/naporin0624/electron-texture-bridge.git
-cd electron-texture-bridge
-```
-
-#### macOS: Build Syphon Framework
-
-```bash
-cd vendor/syphon-src
-xcodebuild -project Syphon.xcodeproj \
-  -scheme Syphon \
-  -configuration Release \
-  -derivedDataPath build \
-  ONLY_ACTIVE_ARCH=NO \
-  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-cp -R build/Build/Products/Release/Syphon.framework ../Syphon.framework
-cd ../..
-```
-
-#### Windows: Fetch Spout2 SDK
-
-The native addon compiles sources from both `SpoutDX/` (C++ wrapper) and
-`SpoutGL/` (shared-memory + D3D helpers that `SpoutDX.h` relative-includes), so
-preserve the Spout2 subdirectory layout under `vendor/Spout2/`:
-
-```powershell
-git clone --depth 1 https://github.com/leadedge/Spout2.git _spout2_tmp
-New-Item -ItemType Directory -Force vendor/Spout2 | Out-Null
-Copy-Item -Recurse _spout2_tmp/SPOUTSDK/SpoutDirectX vendor/Spout2/SpoutDirectX
-Copy-Item -Recurse _spout2_tmp/SPOUTSDK/SpoutGL vendor/Spout2/SpoutGL
-Remove-Item -Recurse -Force _spout2_tmp
-```
-
-#### Build
-
-```bash
-pnpm install
-pnpm build          # Builds native addon + core + renderer packages
-```
-
-## Quick Start
-
-### High-Level: Factory API (recommended)
-
-The simplest way to use electron-texture-bridge. The factory handles offscreen window creation, paint event wiring, Syphon/Spout sender, and optional preview window — all in one call.
-
-```typescript
-// main process
-import { app } from "electron";
-import { createTextureBridge } from "@napolab/texture-bridge-renderer";
-
-app.whenReady().then(async () => {
-  const bridge = await createTextureBridge({
-    name: "MyApp",
-    width: 1920,
-    height: 1080,
-    frameRate: 60,
-    rendererUrl: "path/to/index.html",  // Your renderer page with Web Worker
-    preview: { enabled: true },
-  });
-
-  bridge.on("fps", (fps) => console.log(`FPS: ${fps.toFixed(1)}`));
-  bridge.resize(3840, 2160);  // Resizes all layers automatically
-  // bridge.dispose();         // Clean up when done
-});
-```
-
-```html
-<!-- renderer page (index.html) -->
-<canvas id="canvas" width="1920" height="1080"></canvas>
-<script type="module">
-  import MyWorker from './my-worker?worker';
-  const canvas = document.getElementById('canvas');
-  const offscreen = canvas.transferControlToOffscreen();
-  const worker = new MyWorker();
-  worker.postMessage({ type: 'init', canvas: offscreen }, [offscreen]);
-</script>
-```
-
-### Capturing an external page (`rendererUrl` + `webPreferences`)
-
-`rendererUrl` is not limited to local HTML — pass any `http(s)://` URL to capture a live web page (e.g. a YouTube watch page) and forward it to Syphon/Spout. `webPreferences` is merged into the offscreen `BrowserWindow`, so you can set a `partition` (for an isolated/logged-in session), relax `autoplayPolicy`, or disable the sandbox as needed.
-
-```typescript
-const bridge = await createTextureBridge({
-  name: "WebCapture",
-  width: 1920,
-  height: 1080,
-  rendererUrl: "https://www.youtube.com/watch?v=...",
-  preview: { enabled: true },            // open a preview window for instant eyeballing
-  webPreferences: {
-    partition: "persist:capture",        // isolated session (cookies/login persist here)
-    autoplayPolicy: "no-user-gesture-required",
-    sandbox: false,
-  },
-});
-```
-
-### Sending with transparency (`includeAlpha`)
-
-Pass `includeAlpha: true` to forward the page's per-pixel alpha into the shared BGRA texture. VJ software (Resolume, VDMX, etc.) will then receive the layer with its transparency mask intact, so it can be composited over other layers.
-
-```typescript
-const bridge = await createTextureBridge({
-  name: "MyApp",
-  width: 1920,
-  height: 1080,
-  rendererUrl: "path/to/index.html",
-  includeAlpha: true,
-});
-```
-
-The flag is opt-in (default `false`). When set, `createTextureBridge` builds the offscreen `BrowserWindow` with `transparent: true` and `backgroundColor: "#00000000"` — both keys are required for Chromium's compositor to emit a transparent backdrop into the shared texture. The page itself must also use a transparent background or the alpha will be overwritten:
-
-```css
-html, body { background: transparent; }
-```
-
-WebGL/Canvas content rendered with non-1.0 alpha (or pre-multiplied alpha disabled appropriately for your pipeline) will then flow through to the shared texture's alpha channel.
-
-### Receiving: Factory API
-
-Pull textures from external Syphon/Spout servers into your Electron app.
-
-```typescript
-// main process
-import { app } from "electron";
-import { createTextureReceiver, SenderDiscovery } from "@napolab/texture-bridge-renderer";
-
-app.whenReady().then(() => {
-  // Discover available servers
-  const discovery = new SenderDiscovery();
-  discovery.on("added", (senders) => {
-    console.log("New senders:", senders);
-  });
-  discovery.start(1000); // Poll every second
-
-  // Receive from a specific server
-  const receiver = createTextureReceiver({
-    senderName: "Resolume Arena",
-  });
-
-  receiver.on("frame", (frame) => {
-    // frame: { data: Buffer, width: number, height: number }
-    console.log(`Received ${frame.width}x${frame.height} frame`);
-  });
-
-  receiver.on("fps", (fps) => console.log(`Receive FPS: ${fps.toFixed(1)}`));
-  receiver.start();
-
-  // Clean up
-  // receiver.dispose();
-  // discovery.dispose();
-});
-```
-
-### Low-Level: Core API
-
-For full control over the pipeline, use `@napolab/texture-bridge-core` directly.
-
-```typescript
-import { BrowserWindow } from "electron";
-import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
-
-const win = new BrowserWindow({
-  width: 1920,
-  height: 1080,
-  show: false,
-  webPreferences: {
-    offscreen: { useSharedTexture: true },
-  },
-});
-
-const sender = new TextureSender("MyApp", 1920, 1080);
-
-win.webContents.on("paint", (event) => {
-  const texture = event.texture;
-  if (!texture) return;
-  try {
-    sendTextureFromPaintEvent(sender, texture.textureInfo);
-  } finally {
-    texture.release?.(); // IMPORTANT: Always release to prevent GPU memory leaks
-  }
-});
-
-win.webContents.setFrameRate(60);
-```
-
-#### Electron version note: the `paint` event shape
-
-This library targets **Electron 40+** (the first version with `useSharedTexture` paint events). On current Electron (42+) the listener receives a single event object and the texture release method is **non-optional**:
-
-```typescript
-win.webContents.on("paint", (details) => {
-  const texture = details.texture;
-  if (texture === undefined) return;
-  try {
-    sendTextureFromPaintEvent(sender, texture.textureInfo);
-  } finally {
-    texture.release();   // Electron 42: non-optional. (Older typings exposed `release?`.)
-  }
-});
-```
-
-Older examples that destructure `(event, dirtyRect, image, texture)` are from a pre-40 API and will not type-check against current Electron. If you build against `electron@>=42` types, drop the optional chaining on `release`.
-
-> ### macOS Retina and Windows DPI scaling
->
-> ⚠️ **This is the #1 cause of a black or garbled output on Electron ≤ 40.** How the offscreen framebuffer relates to your requested `width × height` depends on the Electron version:
->
-> - **Electron ≥ 41:** `createTextureBridge` pins `webPreferences.offscreen.deviceScaleFactor` to `1`, so the framebuffer is always exactly `width × height` pixels — display scaling does not affect the texture. (`Electron 42` changed the OSR default device scale factor to `1.0`; the bridge sets it explicitly from 41, where the option first appeared.) `pixelExact` is trivially satisfied and effectively a no-op. Verified on macOS; Windows display-scaling verification is pending (the investigation report lists it as an open item) — if you hit clamping on Windows, size down or verify with the [probe script](packages/renderer/scripts/osr-scale-probe.cjs).
-> - **Electron 40:** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer delivered to the shared texture is `width × height × display.scaleFactor`. On a macOS Retina display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture. Use `createTextureBridge({ pixelExact: true })` to absorb this, or handle DPR yourself on the low-level core path.
->
-> **Low-level core** (manual `BrowserWindow` + `paint`) has no absorption on any version — on Electron ≥ 41 pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself; on Electron 40 keep the sender's declared size and the actual framebuffer size in agreement manually.
-
-### Minimal sanity check (no Electron)
-
-`TextureSender.sendRgbaBuffer()` does **not** require Electron — you can stand up a Syphon/Spout server from plain Node (e.g. via `tsx`) and push raw RGBA. This is the fastest way to isolate a problem: if this shows up in your VJ app, the native binding and Syphon/Spout publishing are healthy and the issue is on the Electron OSR side.
-
-```typescript
-// sanity.ts — run with: npx tsx sanity.ts
-import { TextureSender, getPlatform } from "@napolab/texture-bridge-core";
-
-const W = 512;
-const H = 512;
-const sender = new TextureSender("CHECK", W, H);
-console.log(getPlatform(), sender.platform()); // e.g. "syphon-metal" "syphon-metal"
-
-const buf = Buffer.alloc(W * H * 4);
-let t = 0;
-setInterval(() => {
-  t += 1;
-  for (let i = 0; i < W * H; i++) {
-    buf[i * 4 + 0] = (i + t) & 0xff; // R
-    buf[i * 4 + 1] = (i * 2 + t) & 0xff; // G
-    buf[i * 4 + 2] = t & 0xff; // B
-    buf[i * 4 + 3] = 0xff; // A
-  }
-  sender.sendRgbaBuffer(buf, W, H);
-}, 1000 / 30);
-```
-
-Open your VJ app (or any Syphon/Spout monitor) and look for a sender named **CHECK** animating. `sendRgbaBuffer` involves a CPU→GPU copy, so it is a debugging/fallback path — not the zero-copy production path — but it is invaluable for splitting "is it Electron or is it the bridge?".
-
-## Using with electron-vite (ESM)
-
-If your app is ESM (`"type": "module"` in `package.json`) and built with **electron-vite**, a few integration details matter:
-
-- **External-ize the native packages.** Add `externalizeDepsPlugin()` to both `main` and `preload` configs so the `.node` binary is never bundled:
-
-  ```typescript
-  // electron.vite.config.ts
-  import { defineConfig, externalizeDepsPlugin } from "electron-vite";
-
-  export default defineConfig({
-    main: { plugins: [externalizeDepsPlugin()] },
-    preload: { plugins: [externalizeDepsPlugin()] },
-    renderer: {},
-  });
-  ```
-
-- **Preload is emitted as `.mjs` in ESM mode.** electron-vite outputs the preload as `index.mjs` (not `index.js`), so reference it accordingly from main: `path.join(import.meta.dirname, "../preload/index.mjs")`. A stale `../preload/index.js` reference produces a "preload not found" failure.
-- **`import.meta.dirname` is auto-injected** by electron-vite for ESM main, so you don't need a `__dirname` shim in your own main code.
-- **Prebuilt binaries resolve via `optionalDependencies`.** With pnpm 10 you may need to approve the native package's build in `onlyBuiltDependencies` (`pnpm.onlyBuiltDependencies` / `allowBuilds`) the first time.
-- **Preview works in ESM.** `createTextureBridge({ preview: { enabled: true } })`'s asset resolution is ESM-safe (the renderer package ships `__dirname` shims in its ESM build), so the preview window opens under `"type": "module"`.
-
-## Receiving textures from Spout/Syphon
-
-There are two receive paths, and they solve different problems:
-
-- **`TextureReceiver.receiveFrame()` / `createTextureReceiver()`** — RGBA readback. The native side performs a GPU→CPU blit (D3D11 staging / Metal blit), then hands you an `ArrayBuffer` via an IPC hop. Roughly ~8 MB per 1080p frame copied through IPC. Use it when you actually want pixel data in JavaScript (analysis, image export, custom color pipelines).
-- **`TextureReceiver.receiveSharedTexture()` / `createSharedTextureReceiver()` / `consumeSharedTexture()`** — zero-copy GPU delivery. The native side mints a platform-native shared handle (DXGI NT handle on Windows, IOSurface pointer on macOS) per frame and passes it through Electron's `sharedTexture.importSharedTexture` + `sendSharedTexture` pair into the renderer as a `VideoFrame`. No CPU readback, no ArrayBuffer IPC copy. `ctx.drawImage(videoFrame, 0, 0)` stays on the GPU and `GPUDevice.importExternalTexture({ source: videoFrame })` exposes the same texture to WebGPU without a copy. Use it when you just want to display or GPU-process the incoming video.
-
-Pick whichever matches what you will do with the frame.
-
-> **Status.** The zero-copy GPU path is verified end-to-end on both Windows (Spout) and macOS (Syphon Metal). On macOS the receiver mints a fresh per-frame `IOSurfaceRef` backed by a per-receiver staging `MTLTexture` and Y-flips it through a tiny render pass so `drawImage(videoFrame)` / `importExternalTexture({ source: videoFrame })` render right-side-up. The same `closeNativeHandle()` ownership contract applies on both platforms.
-
-### Main process: `createSharedTextureReceiver`
-
-```typescript
-// main process
-import { app, BrowserWindow } from "electron";
-import { createSharedTextureReceiver } from "@napolab/texture-bridge-renderer";
-
-app.whenReady().then(() => {
-  const receiverWindow = new BrowserWindow({
-    width: 960,
-    height: 540,
-    webPreferences: {
-      preload: /* path to preload that installs the consumer */ undefined,
-    },
-  });
-
-  const bridge = createSharedTextureReceiver({
-    senderName: "Resolume Arena",   // required
-    target: receiverWindow.webContents,
-    pollIntervalMs: 8,              // optional, defaults to 16
-    appName: undefined,             // optional, macOS filter
-    serverUuid: undefined,          // optional, macOS UUID
-    extraArgs: [],                  // optional, forwarded to sendSharedTexture(..., ...args)
-  });
-
-  bridge.on("fps", (fps) => console.log(`[receiver] ${fps.toFixed(1)} fps`));
-  bridge.on("error", (err) => console.error("[receiver]", err.message));
-  bridge.on("disposed", () => console.log("[receiver] disposed"));
-
-  bridge.start();
-
-  receiverWindow.on("closed", () => {
-    bridge.dispose();   // stops polling, releases the native receiver, emits "disposed"
-  });
-});
-```
-
-The bridge runs with a drop-latest policy: if a previous `sendSharedTexture` is still in flight when the next poll fires, the tick is skipped. This keeps at most one imported-texture reference alive on the main process and prevents frame pile-up when the renderer is slow.
-
-### Renderer process: `installSharedTextureReceiver` + `consumeSharedTexture`
-
-```typescript
-// renderer process (or preload with nodeIntegration: true, contextIsolation: false)
-import {
-  installSharedTextureReceiver,
-  consumeSharedTexture,
-} from "@napolab/texture-bridge-renderer/client";
-
-// Call once at startup. Binds Electron's single
-// sharedTexture.setSharedTextureReceiver slot to an internal pool so multiple
-// consumers can coexist. Idempotent.
-installSharedTextureReceiver();
-
-const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-const ctx = canvas.getContext("2d")!;
-
-const registration = consumeSharedTexture({
-  onFrame: ({ textureId, videoFrame }) => {
-    if (canvas.width !== videoFrame.displayWidth) canvas.width = videoFrame.displayWidth;
-    if (canvas.height !== videoFrame.displayHeight) canvas.height = videoFrame.displayHeight;
-    // Zero-copy GPU blit in Chromium when the source is a shared-texture VideoFrame.
-    ctx.drawImage(videoFrame, 0, 0);
-  },
-  onError: (err) => console.error("[consumer]", err),
-});
-
-// registration.dispose();  // optional — removes this consumer from the pool
-```
-
-`videoFrame` is a standard Web `VideoFrame`. For WebGPU, hand it to `device.importExternalTexture({ source: videoFrame })` instead of `drawImage` — that path is also zero-copy. You do **not** need to call `videoFrame.close()` yourself; the consumer wrapper closes it after your handler's returned promise settles.
-
-### Optional: polling `TextureReceiver.receiveSharedTexture()` directly
-
-If you want to drive the poll loop yourself (e.g. to integrate with a custom scheduler), use the low-level primitive and forward the handle to `sharedTexture.importSharedTexture` by hand:
-
-```typescript
-import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge";
-import { sharedTexture } from "electron";
-
-const receiver = new TextureReceiver("Resolume Arena");
-const frame = receiver.receiveSharedTexture();
-if (frame) {
-  const handle =
-    process.platform === "win32" ? { ntHandle: frame.handle } : { ioSurface: frame.handle };
-  try {
-    const imported = sharedTexture.importSharedTexture({
-      textureInfo: {
-        codedSize: { width: frame.width, height: frame.height },
-        handle,
-        pixelFormat: frame.pixelFormat,   // "bgra" | "rgba" | "rgbaf16"
-      },
-    });
-    // ... deliver `imported` via sendSharedTexture, then imported.release() ...
-  } catch (err) {
-    // importSharedTexture threw before taking ownership — release ourselves.
-    closeNativeHandle(frame.handle);
-    throw err;
-  }
-}
-```
-
-> **Ownership contract.** Every `SharedTextureFrame.handle` returned by `receiveSharedTexture()` is a freshly-minted native handle. On a successful `importSharedTexture` Electron takes ownership and releases it when the imported texture is released. On **any** path that does not feed the handle into `importSharedTexture` (unknown pixel format, target destroyed, `importSharedTexture` threw, you decided to skip the frame), you **must** call `closeNativeHandle(frame.handle)` or you will leak an NT HANDLE (Windows) / `IOSurfaceRef` (macOS) per frame.
-
-### Discovering available senders
-
-```typescript
-import { listSenders } from "@napolab/texture-bridge-renderer";
-
-for (const s of listSenders()) {
-  console.log(s.name, s.appName ?? "", s.uuid ?? "");
-}
-// [{ name: "Resolume Arena", appName: "Resolume Arena", uuid: "..." }, ...]
-```
-
-For continuous change notifications, use `SenderDiscovery` (see [API Reference](#senderdiscovery)).
-
-### Renderer context isolation
-
-Electron's `sharedTexture` module is only accessible from the main and renderer processes that have `electron` resolvable at runtime. Importing `@napolab/texture-bridge-renderer/client` directly from a Vite-driven renderer can fail during dev pre-bundle (`path.join is not a function`), because Vite cannot pre-bundle the `electron` CJS module. Two ways out:
-
-1. **Recommended for simple cases:** put `installSharedTextureReceiver()` and `consumeSharedTexture()` in a **preload script** (bundled by electron-vite / electron-builder with `externalizeDepsPlugin`), and run the receiver window with `nodeIntegration: true, contextIsolation: false`. The example app does this — see [`packages/example/src/preload/receiver.ts`](packages/example/src/preload/receiver.ts).
-2. **Context-isolated setups:** bind the consumer in the preload, then forward each `VideoFrame` to the isolated renderer world via `window.postMessage(videoFrame, "*", [videoFrame])` (the `VideoFrame` is a transferable). Close it on the renderer side after use.
-
-## API Reference
-
-### `@napolab/texture-bridge-renderer`
-
-#### `createTextureBridge(options): Promise<TextureBridge>`
-
-Factory function that creates a fully-wired texture bridge. Must be called after `app.whenReady()`.
-
-```typescript
-interface TextureBridgeOptions {
-  name: string;            // Syphon/Spout sender name
-  width: number;           // Texture width in pixels
-  height: number;          // Texture height in pixels
-  frameRate?: number;      // Target frame rate (default: 60)
-  rendererUrl: string;     // URL to load (file path, file://, or http://)
-  preview?: PreviewOptions;
-  webPreferences?: Electron.WebPreferences;
-  includeAlpha?: boolean;  // Forward per-pixel alpha into the shared texture (default: false)
-  pixelExact?: boolean;    // Pin the framebuffer to exactly width×height regardless of display DPR (default: false)
-}
-
-interface PreviewOptions {
-  enabled?: boolean;       // Open preview window (default: false)
-  width?: number;          // Preview window width
-  height?: number;         // Preview window height
-  title?: string;          // Preview window title
-}
-```
-
-**`pixelExact`** — when `true`, the offscreen framebuffer is pinned to exactly `width × height` pixels regardless of the host display's device pixel ratio. **Electron ≥ 41:** trivially satisfied and effectively a no-op — `createTextureBridge` already pins `offscreen.deviceScaleFactor: 1`, so the framebuffer is always exact whether or not this option is set. **Electron 40:** without it, a Retina (scaleFactor 2) or Windows-scaled (150% / 175%) display produces a framebuffer larger than the declared sender size, which typically shows up as black/garbled output in the receiver (see the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling)). The sender is always registered at the requested pixel size, so receivers see the dimensions you asked for. Note: non-divisible scale ratios (e.g. `1920 / 1.75`) can leave a 1-pixel discrepancy, and only the primary display's scaleFactor at construction time is honored — call `resize()` to re-apply after a DPI change.
-
-#### `createTextureBridgeWith(deps)` (advanced)
-
-```typescript
-interface TextureBridgeDeps {
-  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
-  createSender: (name: string, width: number, height: number) => TextureSender;
-}
-
-function createTextureBridgeWith(
-  deps: TextureBridgeDeps,
-): (options: TextureBridgeOptions) => Promise<TextureBridge>;
-```
-
-Returns `createTextureBridge` bound to injected constructors — lets tests and
-embedders swap the `BrowserWindow` construction or the native `TextureSender`
-construction with test doubles. `createTextureBridge` itself is just
-`createTextureBridgeWith` bound to the real `BrowserWindow` and `TextureSender`.
-The factory still calls Electron's `app` / `screen` globals directly and
-constructs the preview window itself (`PreviewManager`) — this seam does not
-make the factory Electron-free, only its window/sender construction is
-injectable. A fully Electron-free test environment needs `app` / `screen`
-mocked separately.
-
-#### `TextureBridge`
-
-The returned handle provides:
-
-```typescript
-interface TextureBridge {
-  on(event: "fps", listener: (fps: number) => void): this;
-  on(event: "ready", listener: () => void): this;
-  on(event: "error", listener: (error: Error) => void): this;
-  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
-  on(event: "resize", listener: (width: number, height: number) => void): this;
-  on(event: "disposed", listener: () => void): this;
-
-  resize(width: number, height: number): void;  // Cascades to all layers + Worker
-  openPreview(): void;
-  closePreview(): void;
-  forwardFrames(target: WebContents, options?: FrameForwardOptions): FrameForward;
-  dispose(): void;
-
-  readonly renderWindow: BrowserWindow;
-  readonly previewWindow: BrowserWindow | null;
-  readonly isDisposed: boolean;
-  readonly droppedReason: PaintDefect["reason"] | null;
-}
-```
-
-`frameDropped` fires when a paint frame is dropped before reaching the sender
-(`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`).
-It is not an error — but if it fires persistently, receivers see black output.
-Consecutive drops with the same reason are deduped: the event fires once, and
-again only after a successful send or a reason change. If a drop latches
-before your listener is attached (e.g. while the renderer page is still
-loading), read `bridge.droppedReason` — it holds the latest drop reason, or
-`null` after a successful send.
-
-`dispose()` destroys the offscreen `renderWindow` synchronously via
-`destroy()` (not `close()`), so teardown cannot lose the race against
-Electron's `before-quit` and pop a crash dialog. Two things follow from that:
-
-- **`disposed` listeners must not touch `bridge.renderWindow.webContents`** —
-  the offscreen window is already destroyed by the time `disposed` fires.
-- **The render window's `close` event and the page's `beforeunload`/`unload`
-  handlers no longer fire** — that's `destroy()`'s documented behavior. Its
-  `closed` event still fires.
-
-The preview window is unaffected: it's a real, visible window and still
-closes via `close()` with normal close semantics. If you previously worked
-around the old async `close()` by calling `bridge.dispose()` followed by your
-own `bridge.renderWindow.destroy()`, **remove that external `destroy()` call**
-— `dispose()` now does it for you, and Electron does not guarantee a second
-`destroy()` on an already-destroyed window is safe (it can throw "Object has
-been destroyed"). The library's own guard only covers its *internal*
-`destroy()` call inside `dispose()`; it does not protect an external call made
-*after* `dispose()` returns. If you must keep the workaround temporarily,
-either guard it yourself
-(`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`) or
-call it **before** `dispose()`, not after.
-
-#### `TextureBridge.forwardFrames(target, options?)`
-
-```typescript
-const forward = bridge.forwardFrames(monitorWindow.webContents, { extraArgs: [slot] });
-// later
-forward.dispose(); // idempotent
-```
-
-Registers a `WebContents` (e.g. a monitor/multiviewer window) to receive every subsequent paint frame over the same zero-copy shared-texture path `forwardSharedTexture` uses — no pixel readback, just a GPU handle.
-
-**Best-effort contract**, same as the preview path: forward failures (a `ForwardDefect` from the core `forwardSharedTexture` primitive) are discarded by this driver and never surface as an `"error"` event or affect `frameDropped`/`droppedReason`. **Independent of the native Syphon/Spout send** — forwarding runs before `sendTextureFromPaintEvent` inside the paint handler, so a thrown native send failure can't suppress a registered forward, and a forward failure can never block the native send either; the two paths fire regardless of each other's outcome.
-
-`FrameForward.dispose()` unregisters that one target and is idempotent — calling it twice, or after `bridge.dispose()` already cleared it, is a no-op. `bridge.dispose()` clears every registered forward.
-
-The receiving end needs nothing new: a forwarded target consumes frames exactly like a Syphon/Spout receiver does — call `installSharedTextureReceiver()` once at renderer startup, then `consumeSharedTexture({ onFrame: (frame, ...extraArgs) => ... })`. The `extraArgs` passed to `forwardFrames(target, { extraArgs })` arrive verbatim as the handler's trailing arguments, so one target can demultiplex frames forwarded from several sources (e.g. tag each source with its slot index).
-
-The current implementation imports the texture once per registered target per frame. When several targets share the same source frame, there's room to optimize to "import once per frame → send to every target → release only after all sends settle" — documented as a future option rather than built now, since no current caller needs it (a multiviewer slot is one source to one target).
-
-#### `createWorkerRenderer(options)` (from `renderer/client`)
-
-Renderer-process helper for setting up a canvas-to-Worker pipeline with automatic resize propagation.
-
-```typescript
-import { createWorkerRenderer } from "@napolab/texture-bridge-renderer/client";
-
-createWorkerRenderer({
-  worker: new MyWorker(),
-  width: 1920,
-  height: 1080,
-});
-```
-
-#### `installSharedTextureReceiver()` (from `renderer/client`)
-
-```typescript
-import { installSharedTextureReceiver } from "@napolab/texture-bridge-renderer/client";
-
-installSharedTextureReceiver();
-```
-
-Binds Electron's single `sharedTexture.setSharedTextureReceiver` slot to an internal consumer pool so multiple `consumeSharedTexture` calls can coexist. Idempotent — call once at renderer startup before any `consumeSharedTexture` call. Requires Electron 40+.
-
-#### `consumeSharedTexture(handlers)` (from `renderer/client`)
-
-```typescript
-import { consumeSharedTexture } from "@napolab/texture-bridge-renderer/client";
-
-const registration = consumeSharedTexture({
-  onFrame: ({ textureId, videoFrame }, ...extraArgs) => {
-    // videoFrame is a Web VideoFrame backed by the shared texture.
-    // drawImage(videoFrame) — zero-copy GPU blit
-    // device.importExternalTexture({ source: videoFrame }) — WebGPU path
-  },
-  onError: (err) => console.error(err),
-});
-
-registration.dispose();   // remove this consumer from the pool (idempotent)
-```
-
-Registers a consumer in the pool bound by `installSharedTextureReceiver`. Each active consumer receives its own `VideoFrame` per incoming imported texture; the wrapper closes the `VideoFrame` after `onFrame` settles and releases the underlying imported texture exactly once after all consumers have finished.
-
-#### `createMultiDispatcher(options)` (from `renderer/client`)
-
-Low-level fan-out primitive: one `handler(...)` invokes all registered callbacks and reduces their results through a user-supplied `combine` function. `installSharedTextureReceiver` is built on top of it, but it is exported so you can build your own "one upstream slot, many downstream consumers" adapters (e.g. a preload-to-renderer bridge). See JSDoc in `packages/renderer/src/client/multi-dispatcher.ts` for the full API.
-
-#### `createSharedTextureReceiver(options): SharedTextureReceiverBridge`
-
-Factory function that creates a **zero-copy GPU** receiver bridge. Polls `TextureReceiver.receiveSharedTexture()` and delivers each frame to a target renderer via Electron's `sharedTexture.importSharedTexture` + `sendSharedTexture` pair. Verified end-to-end on both Windows (Spout) and macOS (Syphon Metal).
-
-```typescript
-interface SharedTextureReceiverOptions {
-  senderName: string;                 // Syphon server / Spout sender name
-  target: Electron.WebContents;       // Receiver window webContents
-  pollIntervalMs?: number;            // default 16 (~60 fps); drop-latest applied
-  appName?: string;                   // (macOS only) filter by application name
-  serverUuid?: string;                // (macOS only) connect by server UUID
-  extraArgs?: readonly unknown[];     // forwarded to sendSharedTexture(..., ...args)
-}
-
-interface SharedTextureReceiverBridge {
-  on(event: "fps", listener: (fps: number) => void): this;
-  on(event: "error", listener: (error: Error) => void): this;
-  on(event: "disposed", listener: () => void): this;
-
-  start(): void;                      // begin polling
-  stop(): void;                       // pause polling (bridge can be started again)
-  dispose(): void;                    // terminal: stop + release native receiver
-  [Symbol.dispose](): void;           // same as dispose()
-
-  readonly isDisposed: boolean;
-}
-```
-
-`dispose()` is terminal and idempotent. After 10 consecutive `"error"` events the bridge stops itself automatically (circuit breaker) and emits one final error describing the shutdown.
-
-#### `createTextureReceiver(options): TextureReceiverBridge`
-
-Factory function that creates a texture receiver with polling and FPS tracking.
-
-```typescript
-interface TextureReceiverBridgeOptions {
-  senderName: string;      // Syphon server name / Spout sender name
-  appName?: string;        // (macOS only) Filter by application name
-  serverUuid?: string;     // (macOS only) Connect by server UUID
-  pollIntervalMs?: number; // Frame polling interval in ms (default: 16)
-}
-```
-
-#### `TextureReceiverBridge`
-
-```typescript
-interface TextureReceiverBridge {
-  on(event: "frame", listener: (frame: ReceivedFrame) => void): this;
-  on(event: "fps", listener: (fps: number) => void): this;
-  on(event: "error", listener: (error: Error) => void): this;
-  on(event: "disposed", listener: () => void): this;
-
-  start(): void;   // Begin polling for frames
-  stop(): void;    // Pause polling
-  dispose(): void; // Release all resources
-
-  readonly isDisposed: boolean;
-}
-
-interface ReceivedFrame {
-  data: Buffer;    // RGBA pixel data
-  width: number;
-  height: number;
-}
-```
-
-#### `SenderDiscovery`
-
-EventEmitter that polls for available Syphon servers / Spout senders and emits diff events.
-
-```typescript
-const discovery = new SenderDiscovery();
-discovery.on("added", (senders: SenderInfo[]) => { /* new senders appeared */ });
-discovery.on("removed", (senders: SenderInfo[]) => { /* senders disappeared */ });
-discovery.on("updated", (senders: SenderInfo[]) => { /* full current list */ });
-discovery.start(1000); // Poll interval in ms
-discovery.getSenders(); // Current sender list
-discovery.dispose();
-
-interface SenderInfo {
-  name: string;
-  appName?: string;  // macOS only
-  uuid?: string;     // macOS only
-}
-```
-
-#### Worker Protocol Types (from `renderer/worker`)
-
-```typescript
-import type { WorkerMessage } from "@napolab/texture-bridge-renderer/worker";
-
-// In your Worker:
-self.onmessage = (e: MessageEvent<WorkerMessage>) => {
-  switch (e.data.type) {
-    case "init":   /* e.data.canvas: OffscreenCanvas */ break;
-    case "resize": /* e.data.width, e.data.height */   break;
-    case "dispose": break;
-  }
-};
-```
-
-### `@napolab/texture-bridge-core`
-
-#### `sendTextureFromPaintEvent(sender, textureInfo)`
-
-Low-level convenience function that handles platform-specific texture handle extraction and forwarding.
-
-- **macOS**: Reads `handle.ioSurface` buffer → calls `sender.sendSurface()`
-- **Windows**: Reads `handle.ntHandle` buffer as BigInt64LE → calls `sender.send()`
-
-Returns `undefined` when the frame was handed to the sender, or a `PaintDefect`
-(`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`;
-the `unsupported-platform` variant also carries the offending `platform`)
-when the frame was dropped. Drops are normal no-ops, not errors — surface them
-in your own paint loop the same way `createTextureBridge` does with its
-`frameDropped` event. Native send failures throw a `TextureSendError`
-(exported from both packages) — the message is preserved and the original
-thrown value is available on `error.cause`. With `createTextureBridge`,
-these surface on the bridge's `error` event, so you can discriminate with
-`instanceof TextureSendError`.
-
-#### `forwardSharedTexture(textureInfo, target, extraArgs?)` (from `core/electron`)
-
-```typescript
-import { forwardSharedTexture, type ForwardDefect } from "@napolab/texture-bridge-core/electron";
-
-const defect = await forwardSharedTexture(textureInfo, target, extraArgs);
-```
-
-Forwards one paint frame to a renderer `WebContents` via Electron's shared-texture channel (`sharedTexture.importSharedTexture` → `sharedTexture.sendSharedTexture`). Zero-copy: only a GPU handle crosses the process boundary — no pixels move.
-
-This lives on a **separate subpath**, `@napolab/texture-bridge-core/electron`, not the package's main entry. The main entry must stay importable without Electron installed — the plain-Node `sendRgbaBuffer` sanity check (see "Minimal sanity check (no Electron)" above) depends on that — so the static `import { sharedTexture } from "electron"` this function needs is quarantined to this subpath and enforced at build time by an electron-free guard on the main entry's output.
-
-Returns `undefined` when the frame was handed to Electron for delivery, or a `ForwardDefect` describing why it was not — the same reporting idiom as `sendTextureFromPaintEvent`'s `PaintDefect | undefined`: the low-level tier reports, the caller decides.
-
-```typescript
-type ForwardDefect =
-  | { reason: "target-destroyed" }   // target.isDestroyed(), or its mainFrame is gone
-  | { reason: "import-failed"; cause: Error }
-  | { reason: "send-failed"; cause: Error };
-```
-
-Because it's an `async` function, it can never throw synchronously — a defect always surfaces through the returned promise, never as a thrown exception at the call site. When the import succeeds, the imported texture is released in a `finally` regardless of whether the subsequent send succeeds or fails (release-in-finally).
-
-Low-level callers driving their own paint loop can call it directly, alongside `sendTextureFromPaintEvent`. Release the texture in a `finally` — otherwise a thrown `TextureSendError` from `sendTextureFromPaintEvent` (native send failures throw) skips `texture.release()` and leaks the frame. `forwardSharedTexture` never throws synchronously (see above), so it's safe to fire-and-forget before `sendTextureFromPaintEvent` runs — no `await` needed to guarantee the dispatch already started:
-
-```typescript
-win.webContents.on("paint", (e) => {
-  const texture = e.texture;
-  if (!texture) return;
-  try {
-    void forwardSharedTexture(texture.textureInfo, monitorWC, [slot]); // → renderer (dispatch is synchronous)
-    sendTextureFromPaintEvent(sender, texture.textureInfo);           // → Syphon/Spout (throws on failure)
-  } finally {
-    texture.release();
-  }
-});
-```
-
-#### `sendImportedTexture(frame, imported, extraArgs?)` (from `core/electron`)
-
-```typescript
-import { sendImportedTexture } from "@napolab/texture-bridge-core/electron";
-
-await sendImportedTexture(targetFrame, importedSharedTexture, extraArgs);
-```
-
-Delivers an **already-imported** shared texture (the result of
-`sharedTexture.importSharedTexture(...)`) to a target `WebFrameMain`,
-releasing it in a `finally` regardless of whether the send succeeds or
-fails — release-in-finally, same contract as `forwardSharedTexture`'s
-internal delivery step. This is the shared helper both `forwardSharedTexture`
-(above) and the renderer package's shared-texture receiver path
-(`shared-texture-receiver.ts`, `preview-manager.ts`) call into, so there is
-one implementation of "deliver + always release" instead of duplicated
-copies. Most callers want `forwardSharedTexture`, which also does the
-`importSharedTexture` step; reach for `sendImportedTexture` directly only
-when you already hold an imported texture from elsewhere (e.g. a receiver
-polling loop) and just need the send-and-release half.
-
-#### `TextureSender`
-
-Native class for sending textures to Syphon/Spout receivers.
-
-```typescript
-class TextureSender {
-  constructor(name: string, width: number, height: number);
-  send(handle: number, width: number, height: number): void;
-  sendSurface(surfaceBuffer: Buffer, width: number, height: number): void;
-  sendRgbaBuffer(data: Buffer, width: number, height: number, bytesPerRow?: number): void;
-  platform(): string;
-  stop(): void;  // Terminal — releases native resources immediately
-}
-```
-
-#### `TextureReceiver`
-
-Native class for receiving textures from Syphon/Spout senders.
-
-```typescript
-class TextureReceiver {
-  constructor(senderName: string, appName?: string, serverUuid?: string);
-  hasNewFrame(): boolean;
-  receiveFrame(): ReceivedFrame | null;                  // RGBA readback
-  receiveSharedTexture(): SharedTextureFrame | null;     // zero-copy GPU handle (Windows + macOS)
-  isConnected(): boolean;
-  getWidth(): number;
-  getHeight(): number;
-  platform(): string;
-  stop(): void;  // Terminal — releases native resources immediately
-}
-
-interface SharedTextureFrame {
-  width: number;
-  height: number;
-  pixelFormat: "bgra" | "rgba" | "rgbaf16";
-  ownerPid: number;        // process ID that owns the handle (usually process.pid)
-  handle: Buffer;          // 8-byte LE: NT HANDLE on Windows, IOSurfaceRef pointer on macOS
-}
-```
-
-Each `handle` is a fresh, owning native reference. Either hand it to `sharedTexture.importSharedTexture` (Electron takes ownership) or call `closeNativeHandle(handle)` — otherwise you leak an NT HANDLE / IOSurface per frame.
-
-#### `closeNativeHandle(handle)`
-
-```typescript
-function closeNativeHandle(handle: Buffer): void;
-```
-
-Releases a native shared-texture handle (NT HANDLE on Windows, `IOSurfaceRef` on macOS) that was minted by `receiveSharedTexture()` but never consumed by Electron's `importSharedTexture`. Only call this for handles you have **not** forwarded to Electron; Electron releases handles it has taken ownership of on its own.
-
-#### Resource Lifecycle
-
-Both `TextureSender` and `TextureReceiver` follow deterministic disposal semantics:
-
-1. **`stop()` releases native resources immediately.** Do not rely on garbage collection for cleanup.
-2. **`stop()` is terminal.** The instance cannot be reused afterward. Any operational method called after `stop()` will throw an error (sender) or return a safe terminal value (receiver).
-3. **`stop()` is idempotent.** Repeated calls are safe and return without error.
-4. **Higher-level `dispose()` methods** (on `TextureBridge`, `TextureReceiverBridge`) forward to native `stop()` and are also terminal.
-
-```typescript
-// Recommended pattern
-const sender = new TextureSender("MyApp", 1920, 1080);
-try {
-  // ... use sender ...
-} finally {
-  sender.stop();
-}
-
-// Also supports Symbol.dispose for use with `using` declarations.
-// Requires Node.js 22+ (or a runtime with Symbol.dispose support) and
-// `"lib": ["ESNext.Disposable"]` in your tsconfig.json.
-// Import from @napolab/texture-bridge-core for runtime Symbol.dispose patching.
-using sender = new TextureSender("MyApp", 1920, 1080);
-```
-
-#### `listSenders()`
-
-```typescript
-function listSenders(): Array<{ name: string; appName?: string; uuid?: string }>;
-```
-
-#### `getPlatform()`
-
-```typescript
-function getPlatform(): "spout" | "syphon-metal" | "unsupported";
-```
-
-`getPlatform()` and the instance method `sender.platform()` / `receiver.platform()` return the same string set:
-
-| Value | Meaning |
-|-------|---------|
-| `"syphon-metal"` | macOS — Syphon Metal backend active |
-| `"spout"` | Windows — Spout backend active |
-| `"unsupported"` | Platform without a backend (no-op sends/receives) |
-
-#### Types
-
-```typescript
-type PixelFormat = "bgra" | "nv12" | "rgba" | "rgbaf16";
-
-interface TextureInfo {
-  pixelFormat: PixelFormat;
-  codedSize: { width: number; height: number };
-  visibleRect: { x: number; y: number; width: number; height: number };
-  handle: {
-    ntHandle?: Buffer;   // Windows (Electron 40+)
-    ioSurface?: Buffer;  // macOS
-  };
-}
-
-interface PaintTexture {
-  textureInfo: TextureInfo;
-  release?: () => void;
-}
-
-type Platform = "spout" | "syphon-metal" | "unsupported";
-```
+Building from source additionally needs a Rust toolchain, pnpm 10+, and platform build tools — see [docs/INSTALLATION.md § Prerequisites](docs/INSTALLATION.md#prerequisites).
 
 ## Performance
 
@@ -1104,218 +323,18 @@ pnpm --filter @napolab/texture-bridge-example run build:win
 
 > **Packaging your own app.** Native `.node` addons cannot load from inside an ASAR archive, so add `asarUnpack: "node_modules/@napolab/texture-bridge*"` to your electron-builder config, and on macOS bundle + codesign `Syphon.framework` into `Frameworks/`. Copy-pasteable electron-builder / electron-forge snippets are in [docs/INSTALLATION.md → Packaging for Distribution](docs/INSTALLATION.md#packaging-for-distribution).
 
-## Project Structure
+## Documentation
 
-```
-electron-texture-bridge/
-├── packages/
-│   ├── native/                # @napolab/texture-bridge (napi-rs)
-│   │   ├── src/
-│   │   │   ├── lib.rs         # napi-rs entry point, TextureSender/Receiver API
-│   │   │   ├── types.rs       # RawTextureHandle type alias
-│   │   │   ├── mac/           # macOS: Syphon Metal sender + receiver + FFI
-│   │   │   └── win/           # Windows: Spout sender + receiver + FFI
-│   │   ├── cpp/
-│   │   │   ├── mac/           # ObjC++ Syphon Metal bridge (send + receive + discovery)
-│   │   │   └── win/           # C++ Spout bridge (send + receive + discovery)
-│   │   ├── build.rs           # Platform-specific build configuration
-│   │   └── Cargo.toml
-│   ├── core/                  # @napolab/texture-bridge-core (TypeScript)
-│   │   └── src/
-│   │       ├── index.ts       # sendTextureFromPaintEvent + re-exports (sender + receiver)
-│   │       └── types.ts       # TextureInfo, PaintTexture, SenderInfo, ReceivedFrame
-│   ├── renderer/              # @napolab/texture-bridge-renderer (TypeScript)
-│   │   └── src/
-│   │       ├── index.ts       # createTextureBridge + createTextureReceiver + SenderDiscovery
-│   │       ├── bridge.ts      # Sender factory implementation (EventEmitter)
-│   │       ├── receiver.ts    # Receiver factory (polling + FPS tracking)
-│   │       ├── discovery.ts   # SenderDiscovery (polling + diff events)
-│   │       ├── types.ts       # TextureBridgeOptions, TextureBridge
-│   │       ├── preview-manager.ts  # Preview window lifecycle
-│   │       ├── fps-counter.ts # FPS measurement utility
-│   │       ├── client/        # Renderer-process helpers
-│   │       │   ├── index.ts   # createWorkerRenderer
-│   │       │   └── worker-protocol.ts  # Worker message types
-│   │       └── assets/        # Static files (preview.html, preload)
-│   └── example/               # Electron VJ demo app (private)
-│       └── src/
-│           ├── main/          # Electron main process (~30 LOC)
-│           └── renderer/      # Three.js + GLSL + Web Worker
-├── vendor/                    # Third-party SDKs (gitignored, built locally)
-│   ├── syphon-src/            # Syphon Framework source (git submodule)
-│   ├── Syphon.framework/     # Built framework (macOS)
-│   └── Spout2/               # Spout SDK (Windows) — SpoutDirectX/ + SpoutGL/
-├── specs/
-│   └── ARCHITECTURE.md        # Detailed architecture documentation
-├── Cargo.toml                 # Rust workspace root
-├── pnpm-workspace.yaml        # pnpm monorepo config
-└── package.json               # Root workspace scripts
-```
-
-## Troubleshooting
-
-### Paint event not firing
-
-- Ensure `win.webContents.setFrameRate(60)` is set
-- Paint events fire even with `show: false`
-- Verify that a `requestAnimationFrame` loop is running in the renderer/worker
-
-### Black texture output
-
-- **DPR / Retina size mismatch (most common).** **Electron ≤ 40:** on a Retina display or under Windows display scaling, the real framebuffer is `width × height × scaleFactor`, so a sender declared at the logical size disagrees with it and the receiver goes black/garbled. Use `createTextureBridge({ pixelExact: true })`, or — on the low-level core path — declare the sender at the true framebuffer size or neutralize DPR yourself. **Electron ≥ 41:** `createTextureBridge` pins the OSR device scale factor to `1`, so this mismatch no longer occurs — see [Migration: Electron 42 / OSR device scale](#migration-electron-42--osr-device-scale); on the low-level core path, pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself. See the [Retina/DPI warning](#macos-retina-and-windows-dpi-scaling).
-- **Isolate Electron vs. the bridge** with the [no-Electron sanity check](#minimal-sanity-check-no-electron) — if `sendRgbaBuffer` shows up in your VJ app, the native side is fine and the problem is in the Electron OSR path.
-- `preserveDrawingBuffer` is not needed (Chromium compositor reads directly)
-- Check pixel format mismatch: Chromium outputs BGRA, ensure the receiver expects BGRA
-- Subscribe to `bridge.on("frameDropped", ...)` (or check the return value of
-  `sendTextureFromPaintEvent`) — a persistent `no-nt-handle` / `no-io-surface`
-  reason means Chromium is not delivering a shareable GPU handle, which
-  otherwise manifests only as black output.
-
-### Syphon receiver not showing output (macOS)
-
-- Verify `vendor/Syphon.framework` exists and was built correctly
-- Clear Gatekeeper quarantine: `xattr -dr com.apple.quarantine vendor/Syphon.framework`
-- Check Console.app for error logs
-
-### Spout receiver not showing output (Windows)
-
-- Verify Spout2 is installed on the system
-- Ensure GPU drivers are up to date
-- DirectX 11 compatible GPU is required
-
-### Zero-copy shared-texture receiver
-
-- **Requires Electron 40+** — uses the `sharedTexture.importSharedTexture` / `sendSharedTexture` / `setSharedTextureReceiver` module. Older Electron will throw at import time.
-- **`listSenders()` shows `<sender>_1` suffixes.** A previous sender process of the same name was killed uncleanly and its shared-memory directory entry is lingering. Start (or restart) the real sender — it will either reclaim the clean name or the stale suffix will go away on its own on the next publisher cycle.
-- **Handle leak after the target window closes.** If you poll `receiveSharedTexture()` directly, always call `closeNativeHandle(frame.handle)` on any path that does not forward the handle to `sharedTexture.importSharedTexture` — including "target was destroyed", "unknown pixel format", and "I decided to drop this frame". `createSharedTextureReceiver` does this for you.
-- **Windows staging texture.** The receiver creates its staging texture with `MISC_SHARED_NTHANDLE | MISC_SHARED` (no keyed mutex), so consumers do not need to `AcquireSync` per frame — Electron imports it directly.
-
-### Freezing / paint events stop
-
-- **Always call `texture.release()`** after processing. The texture pool is small (a few frames). Failing to release will exhaust the pool and stall the paint event pipeline.
-- When using `createTextureBridge()`, this is handled automatically.
-- When using the low-level core API, use `try/finally`:
-
-```typescript
-win.webContents.on("paint", (event) => {
-  const texture = event.texture;
-  if (!texture) return;
-  try {
-    sendTextureFromPaintEvent(sender, texture.textureInfo);
-  } finally {
-    texture.release?.();
-  }
-});
-```
-
-## Migration: Electron 42 / OSR device scale
-
-Electron 42 changed offscreen rendering's default device scale factor to `1.0`
-([breaking change](https://www.electronjs.org/docs/latest/breaking-changes)).
-From the texture-bridge release that includes this change (see CHANGELOG),
-`createTextureBridge` pins `offscreen.deviceScaleFactor: 1` on Electron ≥ 41,
-making `width`/`height` mean exact pixels on every display.
-
-- **If you used `pixelExact: true`** (e.g. on Electron 40): keep it — it is a
-  no-op on Electron ≥ 41 and still required on 40.
-- **If you worked around scaling yourself** (`force-device-scale-factor=1`,
-  manual DIP math, removing `pixelExact` after a quarter-resolution output on
-  Electron 42): those workarounds are no longer needed once you upgrade.
-- **If you intentionally want a scaled framebuffer**, pass your own
-  `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` —
-  a user-supplied `offscreen` block always wins.
-
-Empirical background: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`.
-
-## Migration: Synchronous dispose (v0.14+)
-
-Starting from v0.14, `dispose()` also `destroy()`s the offscreen
-`renderWindow` synchronously instead of `close()`-ing it — see the
-`dispose()` notes under [`TextureBridge`](#texturebridge) above for the two
-consumer-visible changes this brings (disposed-time window access, missing
-close/beforeunload events).
-
-If you previously worked around the old async `close()` by calling
-`bridge.dispose()` and then your own `bridge.renderWindow.destroy()`,
-**remove that external `destroy()` call** — calling it after `dispose()` now
-targets an already-destroyed window, and Electron does not guarantee a second
-`destroy()` is safe. Guard it or move it before `dispose()` if you can't
-remove it right away
-(`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`, or
-call it **before** `dispose()`, not after).
-
-## Migration: Explicit Disposal (v0.6+)
-
-Starting from v0.6, `stop()` and `dispose()` are **terminal operations** that immediately release native GPU/IPC resources. Previously, resource cleanup depended on JavaScript garbage collection timing.
-
-### What changed
-
-| Behavior | Before (v0.5) | After (v0.6+) |
-|----------|---------------|---------------|
-| `sender.stop()` | No-op (GC handles cleanup) | Drops native resources immediately |
-| `sender.send()` after `stop()` | Silently worked | Throws `"TextureSender has been stopped"` |
-| `receiver.receiveFrame()` after `stop()` | Returned stale/null | Returns `null` |
-| `receiver.hasNewFrame()` after `stop()` | Returned stale value | Returns `false` |
-| `bridge.dispose()` | Stopped timers only | Fully tears down native sender + preview |
-
-### How to migrate
-
-**Sender** — always pair with explicit teardown:
-
-```typescript
-const sender = new TextureSender("MyApp", 1920, 1080);
-try {
-  sender.send(handle, w, h);
-} finally {
-  sender.stop(); // resources released immediately
-}
-```
-
-**Receiver** — same pattern:
-
-```typescript
-const receiver = new TextureReceiver("MySender");
-try {
-  const frame = receiver.receiveFrame();
-} finally {
-  receiver.stop();
-}
-```
-
-**High-level bridge** — no code changes needed if you already call `dispose()`:
-
-```typescript
-const bridge = await createTextureBridge({ ... });
-// ... use bridge ...
-bridge.dispose(); // now deterministic
-```
-
-**`using` declarations** (Node.js 22+, `"lib": ["ESNext.Disposable"]`):
-
-```typescript
-// Import from @napolab/texture-bridge-core for Symbol.dispose support
-using sender = new TextureSender("MyApp", 1920, 1080);
-// resources automatically released at end of scope
-```
-
-### Key rules
-
-1. Once `stop()` or `dispose()` is called, the instance is permanently closed
-2. Repeated `stop()` / `dispose()` calls are safe (idempotent)
-3. Do not reuse stopped instances — create a new one instead
-4. Do not rely on GC to release native resources
-
-## CI/CD
-
-GitHub Actions builds native binaries for all supported platforms:
-
-| Runner | Target | Output |
-|--------|--------|--------|
-| `macos-14` | `aarch64-apple-darwin` | `texture-bridge.darwin-arm64.node` |
-| `macos-13` | `x86_64-apple-darwin` | `texture-bridge.darwin-x64.node` |
-| `windows-latest` | `x86_64-pc-windows-msvc` | `texture-bridge.win32-x64-msvc.node` |
-
-Publishing to npm is triggered by version tags (`v*`).
+| Document | What's in it |
+|----------|--------------|
+| [docs/INSTALLATION.md](docs/INSTALLATION.md) | Prerequisites, building from source, integrating into your app, packaging, verification |
+| [docs/SENDING.md](docs/SENDING.md) | Capturing external pages, `includeAlpha` transparency, the low-level core paint loop, Retina/DPI correctness, no-Electron sanity check, electron-vite (ESM) |
+| [docs/RECEIVING.md](docs/RECEIVING.md) | Both receive paths, `createSharedTextureReceiver`, `installSharedTextureReceiver` / `consumeSharedTexture`, handle ownership, renderer context isolation |
+| [docs/API.md](docs/API.md) | Full API reference for every exported symbol in all three packages |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Black output, paint events not firing, freezing, receiver problems per platform |
+| [docs/MIGRATION.md](docs/MIGRATION.md) | Electron 42 / OSR device scale, synchronous dispose (v0.14+), explicit disposal (v0.6+) |
+| [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) | Repository layout and CI |
+| [specs/ARCHITECTURE.md](specs/ARCHITECTURE.md) | Detailed internal architecture |
 
 ## License
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,478 @@
+# API Reference
+
+Complete reference for every exported symbol. See the [README](../README.md) for a guided introduction, [SENDING.md](SENDING.md) for sending recipes, and [RECEIVING.md](RECEIVING.md) for the receive paths.
+
+## `@napolab/texture-bridge-renderer`
+
+### `createTextureBridge(options): Promise<TextureBridge>`
+
+Factory function that creates a fully-wired texture bridge. Must be called after `app.whenReady()`.
+
+```typescript
+interface TextureBridgeOptions {
+  name: string;            // Syphon/Spout sender name
+  width: number;           // Texture width in pixels
+  height: number;          // Texture height in pixels
+  frameRate?: number;      // Target frame rate (default: 60)
+  rendererUrl: string;     // URL to load (file path, file://, or http://)
+  preview?: PreviewOptions;
+  webPreferences?: Electron.WebPreferences;
+  includeAlpha?: boolean;  // Forward per-pixel alpha into the shared texture (default: false)
+  pixelExact?: boolean;    // Pin the framebuffer to exactly width×height regardless of display DPR (default: false)
+}
+
+interface PreviewOptions {
+  enabled?: boolean;       // Open preview window (default: false)
+  width?: number;          // Preview window width
+  height?: number;         // Preview window height
+  title?: string;          // Preview window title
+}
+```
+
+**`pixelExact`** — when `true`, the offscreen framebuffer is pinned to exactly `width × height` pixels regardless of the host display's device pixel ratio. **Electron ≥ 41:** trivially satisfied and effectively a no-op — `createTextureBridge` already pins `offscreen.deviceScaleFactor: 1`, so the framebuffer is always exact whether or not this option is set. **Electron 40:** without it, a Retina (scaleFactor 2) or Windows-scaled (150% / 175%) display produces a framebuffer larger than the declared sender size, which typically shows up as black/garbled output in the receiver (see the [Retina/DPI warning](SENDING.md#macos-retina-and-windows-dpi-scaling)). The sender is always registered at the requested pixel size, so receivers see the dimensions you asked for. Note: non-divisible scale ratios (e.g. `1920 / 1.75`) can leave a 1-pixel discrepancy, and only the primary display's scaleFactor at construction time is honored — call `resize()` to re-apply after a DPI change.
+
+### `createTextureBridgeWith(deps)` (advanced)
+
+```typescript
+interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => TextureSender;
+}
+
+function createTextureBridgeWith(
+  deps: TextureBridgeDeps,
+): (options: TextureBridgeOptions) => Promise<TextureBridge>;
+```
+
+Returns `createTextureBridge` bound to injected constructors — lets tests and
+embedders swap the `BrowserWindow` construction or the native `TextureSender`
+construction with test doubles. `createTextureBridge` itself is just
+`createTextureBridgeWith` bound to the real `BrowserWindow` and `TextureSender`.
+The factory still calls Electron's `app` / `screen` globals directly and
+constructs the preview window itself (`PreviewManager`) — this seam does not
+make the factory Electron-free, only its window/sender construction is
+injectable. A fully Electron-free test environment needs `app` / `screen`
+mocked separately.
+
+### `TextureBridge`
+
+The returned handle provides:
+
+```typescript
+interface TextureBridge {
+  on(event: "fps", listener: (fps: number) => void): this;
+  on(event: "ready", listener: () => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
+  on(event: "resize", listener: (width: number, height: number) => void): this;
+  on(event: "disposed", listener: () => void): this;
+
+  resize(width: number, height: number): void;  // Cascades to all layers + Worker
+  openPreview(): void;
+  closePreview(): void;
+  forwardFrames(target: WebContents, options?: FrameForwardOptions): FrameForward;
+  dispose(): void;
+
+  readonly renderWindow: BrowserWindow;
+  readonly previewWindow: BrowserWindow | null;
+  readonly isDisposed: boolean;
+  readonly droppedReason: PaintDefect["reason"] | null;
+}
+```
+
+`frameDropped` fires when a paint frame is dropped before reaching the sender
+(`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`).
+It is not an error — but if it fires persistently, receivers see black output.
+Consecutive drops with the same reason are deduped: the event fires once, and
+again only after a successful send or a reason change. If a drop latches
+before your listener is attached (e.g. while the renderer page is still
+loading), read `bridge.droppedReason` — it holds the latest drop reason, or
+`null` after a successful send.
+
+`dispose()` destroys the offscreen `renderWindow` synchronously via
+`destroy()` (not `close()`), so teardown cannot lose the race against
+Electron's `before-quit` and pop a crash dialog. Two things follow from that:
+
+- **`disposed` listeners must not touch `bridge.renderWindow.webContents`** —
+  the offscreen window is already destroyed by the time `disposed` fires.
+- **The render window's `close` event and the page's `beforeunload`/`unload`
+  handlers no longer fire** — that's `destroy()`'s documented behavior. Its
+  `closed` event still fires.
+
+The preview window is unaffected: it's a real, visible window and still
+closes via `close()` with normal close semantics. If you previously worked
+around the old async `close()` by calling `bridge.dispose()` followed by your
+own `bridge.renderWindow.destroy()`, **remove that external `destroy()` call**
+— `dispose()` now does it for you, and Electron does not guarantee a second
+`destroy()` on an already-destroyed window is safe (it can throw "Object has
+been destroyed"). The library's own guard only covers its *internal*
+`destroy()` call inside `dispose()`; it does not protect an external call made
+*after* `dispose()` returns. If you must keep the workaround temporarily,
+either guard it yourself
+(`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`) or
+call it **before** `dispose()`, not after.
+
+### `TextureBridge.forwardFrames(target, options?)`
+
+```typescript
+const forward = bridge.forwardFrames(monitorWindow.webContents, { extraArgs: [slot] });
+// later
+forward.dispose(); // idempotent
+```
+
+Registers a `WebContents` (e.g. a monitor/multiviewer window) to receive every subsequent paint frame over the same zero-copy shared-texture path `forwardSharedTexture` uses — no pixel readback, just a GPU handle.
+
+**Best-effort contract**, same as the preview path: forward failures (a `ForwardDefect` from the core `forwardSharedTexture` primitive) are discarded by this driver and never surface as an `"error"` event or affect `frameDropped`/`droppedReason`. **Independent of the native Syphon/Spout send** — forwarding runs before `sendTextureFromPaintEvent` inside the paint handler, so a thrown native send failure can't suppress a registered forward, and a forward failure can never block the native send either; the two paths fire regardless of each other's outcome.
+
+`FrameForward.dispose()` unregisters that one target and is idempotent — calling it twice, or after `bridge.dispose()` already cleared it, is a no-op. `bridge.dispose()` clears every registered forward.
+
+The receiving end needs nothing new: a forwarded target consumes frames exactly like a Syphon/Spout receiver does — call `installSharedTextureReceiver()` once at renderer startup, then `consumeSharedTexture({ onFrame: (frame, ...extraArgs) => ... })`. The `extraArgs` passed to `forwardFrames(target, { extraArgs })` arrive verbatim as the handler's trailing arguments, so one target can demultiplex frames forwarded from several sources (e.g. tag each source with its slot index).
+
+The current implementation imports the texture once per registered target per frame. When several targets share the same source frame, there's room to optimize to "import once per frame → send to every target → release only after all sends settle" — documented as a future option rather than built now, since no current caller needs it (a multiviewer slot is one source to one target).
+
+### `createWorkerRenderer(options)` (from `renderer/client`)
+
+Renderer-process helper for setting up a canvas-to-Worker pipeline with automatic resize propagation.
+
+```typescript
+import { createWorkerRenderer } from "@napolab/texture-bridge-renderer/client";
+
+createWorkerRenderer({
+  worker: new MyWorker(),
+  width: 1920,
+  height: 1080,
+});
+```
+
+### `installSharedTextureReceiver()` (from `renderer/client`)
+
+```typescript
+import { installSharedTextureReceiver } from "@napolab/texture-bridge-renderer/client";
+
+installSharedTextureReceiver();
+```
+
+Binds Electron's single `sharedTexture.setSharedTextureReceiver` slot to an internal consumer pool so multiple `consumeSharedTexture` calls can coexist. Idempotent — call once at renderer startup before any `consumeSharedTexture` call. Requires Electron 40+.
+
+### `consumeSharedTexture(handlers)` (from `renderer/client`)
+
+```typescript
+import { consumeSharedTexture } from "@napolab/texture-bridge-renderer/client";
+
+const registration = consumeSharedTexture({
+  onFrame: ({ textureId, videoFrame }, ...extraArgs) => {
+    // videoFrame is a Web VideoFrame backed by the shared texture.
+    // drawImage(videoFrame) — zero-copy GPU blit
+    // device.importExternalTexture({ source: videoFrame }) — WebGPU path
+  },
+  onError: (err) => console.error(err),
+});
+
+registration.dispose();   // remove this consumer from the pool (idempotent)
+```
+
+Registers a consumer in the pool bound by `installSharedTextureReceiver`. Each active consumer receives its own `VideoFrame` per incoming imported texture; the wrapper closes the `VideoFrame` after `onFrame` settles and releases the underlying imported texture exactly once after all consumers have finished.
+
+### `createMultiDispatcher(options)` (from `renderer/client`)
+
+Low-level fan-out primitive: one `handler(...)` invokes all registered callbacks and reduces their results through a user-supplied `combine` function. `installSharedTextureReceiver` is built on top of it, but it is exported so you can build your own "one upstream slot, many downstream consumers" adapters (e.g. a preload-to-renderer bridge). See JSDoc in `packages/renderer/src/client/multi-dispatcher.ts` for the full API.
+
+### `createSharedTextureReceiver(options): SharedTextureReceiverBridge`
+
+Factory function that creates a **zero-copy GPU** receiver bridge. Polls `TextureReceiver.receiveSharedTexture()` and delivers each frame to a target renderer via Electron's `sharedTexture.importSharedTexture` + `sendSharedTexture` pair. Verified end-to-end on both Windows (Spout) and macOS (Syphon Metal).
+
+```typescript
+interface SharedTextureReceiverOptions {
+  senderName: string;                 // Syphon server / Spout sender name
+  target: Electron.WebContents;       // Receiver window webContents
+  pollIntervalMs?: number;            // default 16 (~60 fps); drop-latest applied
+  appName?: string;                   // (macOS only) filter by application name
+  serverUuid?: string;                // (macOS only) connect by server UUID
+  extraArgs?: readonly unknown[];     // forwarded to sendSharedTexture(..., ...args)
+}
+
+interface SharedTextureReceiverBridge {
+  on(event: "fps", listener: (fps: number) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "disposed", listener: () => void): this;
+
+  start(): void;                      // begin polling
+  stop(): void;                       // pause polling (bridge can be started again)
+  dispose(): void;                    // terminal: stop + release native receiver
+  [Symbol.dispose](): void;           // same as dispose()
+
+  readonly isDisposed: boolean;
+}
+```
+
+`dispose()` is terminal and idempotent. After 10 consecutive `"error"` events the bridge stops itself automatically (circuit breaker) and emits one final error describing the shutdown.
+
+### `createTextureReceiver(options): TextureReceiverBridge`
+
+Factory function that creates a texture receiver with polling and FPS tracking.
+
+```typescript
+interface TextureReceiverBridgeOptions {
+  senderName: string;      // Syphon server name / Spout sender name
+  appName?: string;        // (macOS only) Filter by application name
+  serverUuid?: string;     // (macOS only) Connect by server UUID
+  pollIntervalMs?: number; // Frame polling interval in ms (default: 16)
+}
+```
+
+### `TextureReceiverBridge`
+
+```typescript
+interface TextureReceiverBridge {
+  on(event: "frame", listener: (frame: ReceivedFrame) => void): this;
+  on(event: "fps", listener: (fps: number) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "disposed", listener: () => void): this;
+
+  start(): void;   // Begin polling for frames
+  stop(): void;    // Pause polling
+  dispose(): void; // Release all resources
+
+  readonly isDisposed: boolean;
+}
+
+interface ReceivedFrame {
+  data: Buffer;    // RGBA pixel data
+  width: number;
+  height: number;
+}
+```
+
+### `SenderDiscovery`
+
+EventEmitter that polls for available Syphon servers / Spout senders and emits diff events.
+
+```typescript
+const discovery = new SenderDiscovery();
+discovery.on("added", (senders: SenderInfo[]) => { /* new senders appeared */ });
+discovery.on("removed", (senders: SenderInfo[]) => { /* senders disappeared */ });
+discovery.on("updated", (senders: SenderInfo[]) => { /* full current list */ });
+discovery.start(1000); // Poll interval in ms
+discovery.getSenders(); // Current sender list
+discovery.dispose();
+
+interface SenderInfo {
+  name: string;
+  appName?: string;  // macOS only
+  uuid?: string;     // macOS only
+}
+```
+
+### Worker Protocol Types (from `renderer/worker`)
+
+```typescript
+import type { WorkerMessage } from "@napolab/texture-bridge-renderer/worker";
+
+// In your Worker:
+self.onmessage = (e: MessageEvent<WorkerMessage>) => {
+  switch (e.data.type) {
+    case "init":   /* e.data.canvas: OffscreenCanvas */ break;
+    case "resize": /* e.data.width, e.data.height */   break;
+    case "dispose": break;
+  }
+};
+```
+
+## `@napolab/texture-bridge-core`
+
+### `sendTextureFromPaintEvent(sender, textureInfo)`
+
+Low-level convenience function that handles platform-specific texture handle extraction and forwarding.
+
+- **macOS**: Reads `handle.ioSurface` buffer → calls `sender.sendSurface()`
+- **Windows**: Reads `handle.ntHandle` buffer as BigInt64LE → calls `sender.send()`
+
+Returns `undefined` when the frame was handed to the sender, or a `PaintDefect`
+(`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`;
+the `unsupported-platform` variant also carries the offending `platform`)
+when the frame was dropped. Drops are normal no-ops, not errors — surface them
+in your own paint loop the same way `createTextureBridge` does with its
+`frameDropped` event. Native send failures throw a `TextureSendError`
+(exported from both packages) — the message is preserved and the original
+thrown value is available on `error.cause`. With `createTextureBridge`,
+these surface on the bridge's `error` event, so you can discriminate with
+`instanceof TextureSendError`.
+
+### `forwardSharedTexture(textureInfo, target, extraArgs?)` (from `core/electron`)
+
+```typescript
+import { forwardSharedTexture, type ForwardDefect } from "@napolab/texture-bridge-core/electron";
+
+const defect = await forwardSharedTexture(textureInfo, target, extraArgs);
+```
+
+Forwards one paint frame to a renderer `WebContents` via Electron's shared-texture channel (`sharedTexture.importSharedTexture` → `sharedTexture.sendSharedTexture`). Zero-copy: only a GPU handle crosses the process boundary — no pixels move.
+
+This lives on a **separate subpath**, `@napolab/texture-bridge-core/electron`, not the package's main entry. The main entry must stay importable without Electron installed — the plain-Node `sendRgbaBuffer` sanity check (see "Minimal sanity check (no Electron)" above) depends on that — so the static `import { sharedTexture } from "electron"` this function needs is quarantined to this subpath and enforced at build time by an electron-free guard on the main entry's output.
+
+Returns `undefined` when the frame was handed to Electron for delivery, or a `ForwardDefect` describing why it was not — the same reporting idiom as `sendTextureFromPaintEvent`'s `PaintDefect | undefined`: the low-level tier reports, the caller decides.
+
+```typescript
+type ForwardDefect =
+  | { reason: "target-destroyed" }   // target.isDestroyed(), or its mainFrame is gone
+  | { reason: "import-failed"; cause: Error }
+  | { reason: "send-failed"; cause: Error };
+```
+
+Because it's an `async` function, it can never throw synchronously — a defect always surfaces through the returned promise, never as a thrown exception at the call site. When the import succeeds, the imported texture is released in a `finally` regardless of whether the subsequent send succeeds or fails (release-in-finally).
+
+Low-level callers driving their own paint loop can call it directly, alongside `sendTextureFromPaintEvent`. Release the texture in a `finally` — otherwise a thrown `TextureSendError` from `sendTextureFromPaintEvent` (native send failures throw) skips `texture.release()` and leaks the frame. `forwardSharedTexture` never throws synchronously (see above), so it's safe to fire-and-forget before `sendTextureFromPaintEvent` runs — no `await` needed to guarantee the dispatch already started:
+
+```typescript
+win.webContents.on("paint", (e) => {
+  const texture = e.texture;
+  if (!texture) return;
+  try {
+    void forwardSharedTexture(texture.textureInfo, monitorWC, [slot]); // → renderer (dispatch is synchronous)
+    sendTextureFromPaintEvent(sender, texture.textureInfo);           // → Syphon/Spout (throws on failure)
+  } finally {
+    texture.release();
+  }
+});
+```
+
+### `sendImportedTexture(frame, imported, extraArgs?)` (from `core/electron`)
+
+```typescript
+import { sendImportedTexture } from "@napolab/texture-bridge-core/electron";
+
+await sendImportedTexture(targetFrame, importedSharedTexture, extraArgs);
+```
+
+Delivers an **already-imported** shared texture (the result of
+`sharedTexture.importSharedTexture(...)`) to a target `WebFrameMain`,
+releasing it in a `finally` regardless of whether the send succeeds or
+fails — release-in-finally, same contract as `forwardSharedTexture`'s
+internal delivery step. This is the shared helper both `forwardSharedTexture`
+(above) and the renderer package's shared-texture receiver path
+(`shared-texture-receiver.ts`, `preview-manager.ts`) call into, so there is
+one implementation of "deliver + always release" instead of duplicated
+copies. Most callers want `forwardSharedTexture`, which also does the
+`importSharedTexture` step; reach for `sendImportedTexture` directly only
+when you already hold an imported texture from elsewhere (e.g. a receiver
+polling loop) and just need the send-and-release half.
+
+### `TextureSender`
+
+Native class for sending textures to Syphon/Spout receivers.
+
+```typescript
+class TextureSender {
+  constructor(name: string, width: number, height: number);
+  send(handle: number, width: number, height: number): void;
+  sendSurface(surfaceBuffer: Buffer, width: number, height: number): void;
+  sendRgbaBuffer(data: Buffer, width: number, height: number, bytesPerRow?: number): void;
+  platform(): string;
+  stop(): void;  // Terminal — releases native resources immediately
+}
+```
+
+### `TextureReceiver`
+
+Native class for receiving textures from Syphon/Spout senders.
+
+```typescript
+class TextureReceiver {
+  constructor(senderName: string, appName?: string, serverUuid?: string);
+  hasNewFrame(): boolean;
+  receiveFrame(): ReceivedFrame | null;                  // RGBA readback
+  receiveSharedTexture(): SharedTextureFrame | null;     // zero-copy GPU handle (Windows + macOS)
+  isConnected(): boolean;
+  getWidth(): number;
+  getHeight(): number;
+  platform(): string;
+  stop(): void;  // Terminal — releases native resources immediately
+}
+
+interface SharedTextureFrame {
+  width: number;
+  height: number;
+  pixelFormat: "bgra" | "rgba" | "rgbaf16";
+  ownerPid: number;        // process ID that owns the handle (usually process.pid)
+  handle: Buffer;          // 8-byte LE: NT HANDLE on Windows, IOSurfaceRef pointer on macOS
+}
+```
+
+Each `handle` is a fresh, owning native reference. Either hand it to `sharedTexture.importSharedTexture` (Electron takes ownership) or call `closeNativeHandle(handle)` — otherwise you leak an NT HANDLE / IOSurface per frame.
+
+### `closeNativeHandle(handle)`
+
+```typescript
+function closeNativeHandle(handle: Buffer): void;
+```
+
+Releases a native shared-texture handle (NT HANDLE on Windows, `IOSurfaceRef` on macOS) that was minted by `receiveSharedTexture()` but never consumed by Electron's `importSharedTexture`. Only call this for handles you have **not** forwarded to Electron; Electron releases handles it has taken ownership of on its own.
+
+### Resource Lifecycle
+
+Both `TextureSender` and `TextureReceiver` follow deterministic disposal semantics:
+
+1. **`stop()` releases native resources immediately.** Do not rely on garbage collection for cleanup.
+2. **`stop()` is terminal.** The instance cannot be reused afterward. Any operational method called after `stop()` will throw an error (sender) or return a safe terminal value (receiver).
+3. **`stop()` is idempotent.** Repeated calls are safe and return without error.
+4. **Higher-level `dispose()` methods** (on `TextureBridge`, `TextureReceiverBridge`) forward to native `stop()` and are also terminal.
+
+```typescript
+// Recommended pattern
+const sender = new TextureSender("MyApp", 1920, 1080);
+try {
+  // ... use sender ...
+} finally {
+  sender.stop();
+}
+
+// Also supports Symbol.dispose for use with `using` declarations.
+// Requires Node.js 22+ (or a runtime with Symbol.dispose support) and
+// `"lib": ["ESNext.Disposable"]` in your tsconfig.json.
+// Import from @napolab/texture-bridge-core for runtime Symbol.dispose patching.
+using sender = new TextureSender("MyApp", 1920, 1080);
+```
+
+### `listSenders()`
+
+```typescript
+function listSenders(): Array<{ name: string; appName?: string; uuid?: string }>;
+```
+
+### `getPlatform()`
+
+```typescript
+function getPlatform(): "spout" | "syphon-metal" | "unsupported";
+```
+
+`getPlatform()` and the instance method `sender.platform()` / `receiver.platform()` return the same string set:
+
+| Value | Meaning |
+|-------|---------|
+| `"syphon-metal"` | macOS — Syphon Metal backend active |
+| `"spout"` | Windows — Spout backend active |
+| `"unsupported"` | Platform without a backend (no-op sends/receives) |
+
+### Types
+
+```typescript
+type PixelFormat = "bgra" | "nv12" | "rgba" | "rgbaf16";
+
+interface TextureInfo {
+  pixelFormat: PixelFormat;
+  codedSize: { width: number; height: number };
+  visibleRect: { x: number; y: number; width: number; height: number };
+  handle: {
+    ntHandle?: Buffer;   // Windows (Electron 40+)
+    ioSurface?: Buffer;  // macOS
+  };
+}
+
+interface PaintTexture {
+  textureInfo: TextureInfo;
+  release?: () => void;
+}
+
+type Platform = "spout" | "syphon-metal" | "unsupported";
+```
+

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,65 @@
+# Development
+
+Repository layout and CI for contributors. Build instructions live in [INSTALLATION.md](INSTALLATION.md#building-from-source).
+
+## Project Structure
+
+```
+electron-texture-bridge/
+├── packages/
+│   ├── native/                # @napolab/texture-bridge (napi-rs)
+│   │   ├── src/
+│   │   │   ├── lib.rs         # napi-rs entry point, TextureSender/Receiver API
+│   │   │   ├── types.rs       # RawTextureHandle type alias
+│   │   │   ├── mac/           # macOS: Syphon Metal sender + receiver + FFI
+│   │   │   └── win/           # Windows: Spout sender + receiver + FFI
+│   │   ├── cpp/
+│   │   │   ├── mac/           # ObjC++ Syphon Metal bridge (send + receive + discovery)
+│   │   │   └── win/           # C++ Spout bridge (send + receive + discovery)
+│   │   ├── build.rs           # Platform-specific build configuration
+│   │   └── Cargo.toml
+│   ├── core/                  # @napolab/texture-bridge-core (TypeScript)
+│   │   └── src/
+│   │       ├── index.ts       # sendTextureFromPaintEvent + re-exports (sender + receiver)
+│   │       └── types.ts       # TextureInfo, PaintTexture, SenderInfo, ReceivedFrame
+│   ├── renderer/              # @napolab/texture-bridge-renderer (TypeScript)
+│   │   └── src/
+│   │       ├── index.ts       # createTextureBridge + createTextureReceiver + SenderDiscovery
+│   │       ├── bridge.ts      # Sender factory implementation (EventEmitter)
+│   │       ├── receiver.ts    # Receiver factory (polling + FPS tracking)
+│   │       ├── discovery.ts   # SenderDiscovery (polling + diff events)
+│   │       ├── types.ts       # TextureBridgeOptions, TextureBridge
+│   │       ├── preview-manager.ts  # Preview window lifecycle
+│   │       ├── fps-counter.ts # FPS measurement utility
+│   │       ├── client/        # Renderer-process helpers
+│   │       │   ├── index.ts   # createWorkerRenderer
+│   │       │   └── worker-protocol.ts  # Worker message types
+│   │       └── assets/        # Static files (preview.html, preload)
+│   └── example/               # Electron VJ demo app (private)
+│       └── src/
+│           ├── main/          # Electron main process (~30 LOC)
+│           └── renderer/      # Three.js + GLSL + Web Worker
+├── vendor/                    # Third-party SDKs (gitignored, built locally)
+│   ├── syphon-src/            # Syphon Framework source (git submodule)
+│   ├── Syphon.framework/     # Built framework (macOS)
+│   └── Spout2/               # Spout SDK (Windows) — SpoutDirectX/ + SpoutGL/
+├── specs/
+│   └── ARCHITECTURE.md        # Detailed architecture documentation
+├── Cargo.toml                 # Rust workspace root
+├── pnpm-workspace.yaml        # pnpm monorepo config
+└── package.json               # Root workspace scripts
+```
+
+
+## CI/CD
+
+GitHub Actions builds native binaries for all supported platforms:
+
+| Runner | Target | Output |
+|--------|--------|--------|
+| `macos-14` | `aarch64-apple-darwin` | `texture-bridge.darwin-arm64.node` |
+| `macos-13` | `x86_64-apple-darwin` | `texture-bridge.darwin-x64.node` |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `texture-bridge.win32-x64-msvc.node` |
+
+Publishing to npm is triggered by version tags (`v*`).
+

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,101 @@
+# Migration guides
+
+Breaking changes and how to move across them, newest first.
+
+## Migration: Electron 42 / OSR device scale
+
+Electron 42 changed offscreen rendering's default device scale factor to `1.0`
+([breaking change](https://www.electronjs.org/docs/latest/breaking-changes)).
+From the texture-bridge release that includes this change (see CHANGELOG),
+`createTextureBridge` pins `offscreen.deviceScaleFactor: 1` on Electron ≥ 41,
+making `width`/`height` mean exact pixels on every display.
+
+- **If you used `pixelExact: true`** (e.g. on Electron 40): keep it — it is a
+  no-op on Electron ≥ 41 and still required on 40.
+- **If you worked around scaling yourself** (`force-device-scale-factor=1`,
+  manual DIP math, removing `pixelExact` after a quarter-resolution output on
+  Electron 42): those workarounds are no longer needed once you upgrade.
+- **If you intentionally want a scaled framebuffer**, pass your own
+  `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` —
+  a user-supplied `offscreen` block always wins.
+
+Empirical background: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`.
+
+## Migration: Synchronous dispose (v0.14+)
+
+Starting from v0.14, `dispose()` also `destroy()`s the offscreen
+`renderWindow` synchronously instead of `close()`-ing it — see the
+`dispose()` notes under [`TextureBridge`](API.md#texturebridge) above for the two
+consumer-visible changes this brings (disposed-time window access, missing
+close/beforeunload events).
+
+If you previously worked around the old async `close()` by calling
+`bridge.dispose()` and then your own `bridge.renderWindow.destroy()`,
+**remove that external `destroy()` call** — calling it after `dispose()` now
+targets an already-destroyed window, and Electron does not guarantee a second
+`destroy()` is safe. Guard it or move it before `dispose()` if you can't
+remove it right away
+(`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`, or
+call it **before** `dispose()`, not after).
+
+## Migration: Explicit Disposal (v0.6+)
+
+Starting from v0.6, `stop()` and `dispose()` are **terminal operations** that immediately release native GPU/IPC resources. Previously, resource cleanup depended on JavaScript garbage collection timing.
+
+### What changed
+
+| Behavior | Before (v0.5) | After (v0.6+) |
+|----------|---------------|---------------|
+| `sender.stop()` | No-op (GC handles cleanup) | Drops native resources immediately |
+| `sender.send()` after `stop()` | Silently worked | Throws `"TextureSender has been stopped"` |
+| `receiver.receiveFrame()` after `stop()` | Returned stale/null | Returns `null` |
+| `receiver.hasNewFrame()` after `stop()` | Returned stale value | Returns `false` |
+| `bridge.dispose()` | Stopped timers only | Fully tears down native sender + preview |
+
+### How to migrate
+
+**Sender** — always pair with explicit teardown:
+
+```typescript
+const sender = new TextureSender("MyApp", 1920, 1080);
+try {
+  sender.send(handle, w, h);
+} finally {
+  sender.stop(); // resources released immediately
+}
+```
+
+**Receiver** — same pattern:
+
+```typescript
+const receiver = new TextureReceiver("MySender");
+try {
+  const frame = receiver.receiveFrame();
+} finally {
+  receiver.stop();
+}
+```
+
+**High-level bridge** — no code changes needed if you already call `dispose()`:
+
+```typescript
+const bridge = await createTextureBridge({ ... });
+// ... use bridge ...
+bridge.dispose(); // now deterministic
+```
+
+**`using` declarations** (Node.js 22+, `"lib": ["ESNext.Disposable"]`):
+
+```typescript
+// Import from @napolab/texture-bridge-core for Symbol.dispose support
+using sender = new TextureSender("MyApp", 1920, 1080);
+// resources automatically released at end of scope
+```
+
+### Key rules
+
+1. Once `stop()` or `dispose()` is called, the instance is permanently closed
+2. Repeated `stop()` / `dispose()` calls are safe (idempotent)
+3. Do not reuse stopped instances — create a new one instead
+4. Do not rely on GC to release native resources
+

--- a/docs/RECEIVING.md
+++ b/docs/RECEIVING.md
@@ -1,0 +1,134 @@
+# Receiving textures from Spout/Syphon
+
+There are two receive paths, and they solve different problems:
+
+- **`TextureReceiver.receiveFrame()` / `createTextureReceiver()`** — RGBA readback. The native side performs a GPU→CPU blit (D3D11 staging / Metal blit), then hands you an `ArrayBuffer` via an IPC hop. Roughly ~8 MB per 1080p frame copied through IPC. Use it when you actually want pixel data in JavaScript (analysis, image export, custom color pipelines).
+- **`TextureReceiver.receiveSharedTexture()` / `createSharedTextureReceiver()` / `consumeSharedTexture()`** — zero-copy GPU delivery. The native side mints a platform-native shared handle (DXGI NT handle on Windows, IOSurface pointer on macOS) per frame and passes it through Electron's `sharedTexture.importSharedTexture` + `sendSharedTexture` pair into the renderer as a `VideoFrame`. No CPU readback, no ArrayBuffer IPC copy. `ctx.drawImage(videoFrame, 0, 0)` stays on the GPU and `GPUDevice.importExternalTexture({ source: videoFrame })` exposes the same texture to WebGPU without a copy. Use it when you just want to display or GPU-process the incoming video.
+
+Pick whichever matches what you will do with the frame.
+
+> **Status.** The zero-copy GPU path is verified end-to-end on both Windows (Spout) and macOS (Syphon Metal). On macOS the receiver mints a fresh per-frame `IOSurfaceRef` backed by a per-receiver staging `MTLTexture` and Y-flips it through a tiny render pass so `drawImage(videoFrame)` / `importExternalTexture({ source: videoFrame })` render right-side-up. The same `closeNativeHandle()` ownership contract applies on both platforms.
+
+## Main process: `createSharedTextureReceiver`
+
+```typescript
+// main process
+import { app, BrowserWindow } from "electron";
+import { createSharedTextureReceiver } from "@napolab/texture-bridge-renderer";
+
+app.whenReady().then(() => {
+  const receiverWindow = new BrowserWindow({
+    width: 960,
+    height: 540,
+    webPreferences: {
+      preload: /* path to preload that installs the consumer */ undefined,
+    },
+  });
+
+  const bridge = createSharedTextureReceiver({
+    senderName: "Resolume Arena",   // required
+    target: receiverWindow.webContents,
+    pollIntervalMs: 8,              // optional, defaults to 16
+    appName: undefined,             // optional, macOS filter
+    serverUuid: undefined,          // optional, macOS UUID
+    extraArgs: [],                  // optional, forwarded to sendSharedTexture(..., ...args)
+  });
+
+  bridge.on("fps", (fps) => console.log(`[receiver] ${fps.toFixed(1)} fps`));
+  bridge.on("error", (err) => console.error("[receiver]", err.message));
+  bridge.on("disposed", () => console.log("[receiver] disposed"));
+
+  bridge.start();
+
+  receiverWindow.on("closed", () => {
+    bridge.dispose();   // stops polling, releases the native receiver, emits "disposed"
+  });
+});
+```
+
+The bridge runs with a drop-latest policy: if a previous `sendSharedTexture` is still in flight when the next poll fires, the tick is skipped. This keeps at most one imported-texture reference alive on the main process and prevents frame pile-up when the renderer is slow.
+
+## Renderer process: `installSharedTextureReceiver` + `consumeSharedTexture`
+
+```typescript
+// renderer process (or preload with nodeIntegration: true, contextIsolation: false)
+import {
+  installSharedTextureReceiver,
+  consumeSharedTexture,
+} from "@napolab/texture-bridge-renderer/client";
+
+// Call once at startup. Binds Electron's single
+// sharedTexture.setSharedTextureReceiver slot to an internal pool so multiple
+// consumers can coexist. Idempotent.
+installSharedTextureReceiver();
+
+const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+const ctx = canvas.getContext("2d")!;
+
+const registration = consumeSharedTexture({
+  onFrame: ({ textureId, videoFrame }) => {
+    if (canvas.width !== videoFrame.displayWidth) canvas.width = videoFrame.displayWidth;
+    if (canvas.height !== videoFrame.displayHeight) canvas.height = videoFrame.displayHeight;
+    // Zero-copy GPU blit in Chromium when the source is a shared-texture VideoFrame.
+    ctx.drawImage(videoFrame, 0, 0);
+  },
+  onError: (err) => console.error("[consumer]", err),
+});
+
+// registration.dispose();  // optional — removes this consumer from the pool
+```
+
+`videoFrame` is a standard Web `VideoFrame`. For WebGPU, hand it to `device.importExternalTexture({ source: videoFrame })` instead of `drawImage` — that path is also zero-copy. You do **not** need to call `videoFrame.close()` yourself; the consumer wrapper closes it after your handler's returned promise settles.
+
+## Optional: polling `TextureReceiver.receiveSharedTexture()` directly
+
+If you want to drive the poll loop yourself (e.g. to integrate with a custom scheduler), use the low-level primitive and forward the handle to `sharedTexture.importSharedTexture` by hand:
+
+```typescript
+import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge";
+import { sharedTexture } from "electron";
+
+const receiver = new TextureReceiver("Resolume Arena");
+const frame = receiver.receiveSharedTexture();
+if (frame) {
+  const handle =
+    process.platform === "win32" ? { ntHandle: frame.handle } : { ioSurface: frame.handle };
+  try {
+    const imported = sharedTexture.importSharedTexture({
+      textureInfo: {
+        codedSize: { width: frame.width, height: frame.height },
+        handle,
+        pixelFormat: frame.pixelFormat,   // "bgra" | "rgba" | "rgbaf16"
+      },
+    });
+    // ... deliver `imported` via sendSharedTexture, then imported.release() ...
+  } catch (err) {
+    // importSharedTexture threw before taking ownership — release ourselves.
+    closeNativeHandle(frame.handle);
+    throw err;
+  }
+}
+```
+
+> **Ownership contract.** Every `SharedTextureFrame.handle` returned by `receiveSharedTexture()` is a freshly-minted native handle. On a successful `importSharedTexture` Electron takes ownership and releases it when the imported texture is released. On **any** path that does not feed the handle into `importSharedTexture` (unknown pixel format, target destroyed, `importSharedTexture` threw, you decided to skip the frame), you **must** call `closeNativeHandle(frame.handle)` or you will leak an NT HANDLE (Windows) / `IOSurfaceRef` (macOS) per frame.
+
+## Discovering available senders
+
+```typescript
+import { listSenders } from "@napolab/texture-bridge-renderer";
+
+for (const s of listSenders()) {
+  console.log(s.name, s.appName ?? "", s.uuid ?? "");
+}
+// [{ name: "Resolume Arena", appName: "Resolume Arena", uuid: "..." }, ...]
+```
+
+For continuous change notifications, use `SenderDiscovery` (see [API Reference](API.md#senderdiscovery)).
+
+## Renderer context isolation
+
+Electron's `sharedTexture` module is only accessible from the main and renderer processes that have `electron` resolvable at runtime. Importing `@napolab/texture-bridge-renderer/client` directly from a Vite-driven renderer can fail during dev pre-bundle (`path.join is not a function`), because Vite cannot pre-bundle the `electron` CJS module. Two ways out:
+
+1. **Recommended for simple cases:** put `installSharedTextureReceiver()` and `consumeSharedTexture()` in a **preload script** (bundled by electron-vite / electron-builder with `externalizeDepsPlugin`), and run the receiver window with `nodeIntegration: true, contextIsolation: false`. The example app does this — see [`packages/example/src/preload/receiver.ts`](../packages/example/src/preload/receiver.ts).
+2. **Context-isolated setups:** bind the consumer in the preload, then forward each `VideoFrame` to the isolated renderer world via `window.postMessage(videoFrame, "*", [videoFrame])` (the `VideoFrame` is a transferable). Close it on the renderer side after use.
+

--- a/docs/SENDING.md
+++ b/docs/SENDING.md
@@ -1,0 +1,156 @@
+# Sending textures
+
+Recipes beyond the [README Quick Start](../README.md#quick-start): capturing external pages, transparency, the low-level core API, DPI correctness, and electron-vite integration.
+
+## Capturing an external page (`rendererUrl` + `webPreferences`)
+
+`rendererUrl` is not limited to local HTML — pass any `http(s)://` URL to capture a live web page (e.g. a YouTube watch page) and forward it to Syphon/Spout. `webPreferences` is merged into the offscreen `BrowserWindow`, so you can set a `partition` (for an isolated/logged-in session), relax `autoplayPolicy`, or disable the sandbox as needed.
+
+```typescript
+const bridge = await createTextureBridge({
+  name: "WebCapture",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "https://www.youtube.com/watch?v=...",
+  preview: { enabled: true },            // open a preview window for instant eyeballing
+  webPreferences: {
+    partition: "persist:capture",        // isolated session (cookies/login persist here)
+    autoplayPolicy: "no-user-gesture-required",
+    sandbox: false,
+  },
+});
+```
+
+## Sending with transparency (`includeAlpha`)
+
+Pass `includeAlpha: true` to forward the page's per-pixel alpha into the shared BGRA texture. VJ software (Resolume, VDMX, etc.) will then receive the layer with its transparency mask intact, so it can be composited over other layers.
+
+```typescript
+const bridge = await createTextureBridge({
+  name: "MyApp",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "path/to/index.html",
+  includeAlpha: true,
+});
+```
+
+The flag is opt-in (default `false`). When set, `createTextureBridge` builds the offscreen `BrowserWindow` with `transparent: true` and `backgroundColor: "#00000000"` — both keys are required for Chromium's compositor to emit a transparent backdrop into the shared texture. The page itself must also use a transparent background or the alpha will be overwritten:
+
+```css
+html, body { background: transparent; }
+```
+
+WebGL/Canvas content rendered with non-1.0 alpha (or pre-multiplied alpha disabled appropriately for your pipeline) will then flow through to the shared texture's alpha channel.
+
+
+## Low-Level: Core API
+
+For full control over the pipeline, use `@napolab/texture-bridge-core` directly.
+
+```typescript
+import { BrowserWindow } from "electron";
+import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
+
+const win = new BrowserWindow({
+  width: 1920,
+  height: 1080,
+  show: false,
+  webPreferences: {
+    offscreen: { useSharedTexture: true },
+  },
+});
+
+const sender = new TextureSender("MyApp", 1920, 1080);
+
+win.webContents.on("paint", (event) => {
+  const texture = event.texture;
+  if (!texture) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release?.(); // IMPORTANT: Always release to prevent GPU memory leaks
+  }
+});
+
+win.webContents.setFrameRate(60);
+```
+
+### Electron version note: the `paint` event shape
+
+This library targets **Electron 40+** (the first version with `useSharedTexture` paint events). On current Electron (42+) the listener receives a single event object and the texture release method is **non-optional**:
+
+```typescript
+win.webContents.on("paint", (details) => {
+  const texture = details.texture;
+  if (texture === undefined) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release();   // Electron 42: non-optional. (Older typings exposed `release?`.)
+  }
+});
+```
+
+Older examples that destructure `(event, dirtyRect, image, texture)` are from a pre-40 API and will not type-check against current Electron. If you build against `electron@>=42` types, drop the optional chaining on `release`.
+
+> ### macOS Retina and Windows DPI scaling
+>
+> ⚠️ **This is the #1 cause of a black or garbled output on Electron ≤ 40.** How the offscreen framebuffer relates to your requested `width × height` depends on the Electron version:
+>
+> - **Electron ≥ 41:** `createTextureBridge` pins `webPreferences.offscreen.deviceScaleFactor` to `1`, so the framebuffer is always exactly `width × height` pixels — display scaling does not affect the texture. (`Electron 42` changed the OSR default device scale factor to `1.0`; the bridge sets it explicitly from 41, where the option first appeared.) `pixelExact` is trivially satisfied and effectively a no-op. Verified on macOS; Windows display-scaling verification is pending (the investigation report lists it as an open item) — if you hit clamping on Windows, size down or verify with the [probe script](../packages/renderer/scripts/osr-scale-probe.cjs).
+> - **Electron 40:** Chromium sizes the offscreen surface in **device-independent pixels (DIP)**, so the framebuffer delivered to the shared texture is `width × height × display.scaleFactor`. On a macOS Retina display (scaleFactor 2) a sender declared as `new TextureSender("X", 1280, 720)` ends up producing a **2560×1440** texture. Use `createTextureBridge({ pixelExact: true })` to absorb this, or handle DPR yourself on the low-level core path.
+>
+> **Low-level core** (manual `BrowserWindow` + `paint`) has no absorption on any version — on Electron ≥ 41 pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself; on Electron 40 keep the sender's declared size and the actual framebuffer size in agreement manually.
+
+## Minimal sanity check (no Electron)
+
+`TextureSender.sendRgbaBuffer()` does **not** require Electron — you can stand up a Syphon/Spout server from plain Node (e.g. via `tsx`) and push raw RGBA. This is the fastest way to isolate a problem: if this shows up in your VJ app, the native binding and Syphon/Spout publishing are healthy and the issue is on the Electron OSR side.
+
+```typescript
+// sanity.ts — run with: npx tsx sanity.ts
+import { TextureSender, getPlatform } from "@napolab/texture-bridge-core";
+
+const W = 512;
+const H = 512;
+const sender = new TextureSender("CHECK", W, H);
+console.log(getPlatform(), sender.platform()); // e.g. "syphon-metal" "syphon-metal"
+
+const buf = Buffer.alloc(W * H * 4);
+let t = 0;
+setInterval(() => {
+  t += 1;
+  for (let i = 0; i < W * H; i++) {
+    buf[i * 4 + 0] = (i + t) & 0xff; // R
+    buf[i * 4 + 1] = (i * 2 + t) & 0xff; // G
+    buf[i * 4 + 2] = t & 0xff; // B
+    buf[i * 4 + 3] = 0xff; // A
+  }
+  sender.sendRgbaBuffer(buf, W, H);
+}, 1000 / 30);
+```
+
+Open your VJ app (or any Syphon/Spout monitor) and look for a sender named **CHECK** animating. `sendRgbaBuffer` involves a CPU→GPU copy, so it is a debugging/fallback path — not the zero-copy production path — but it is invaluable for splitting "is it Electron or is it the bridge?".
+
+## Using with electron-vite (ESM)
+
+If your app is ESM (`"type": "module"` in `package.json`) and built with **electron-vite**, a few integration details matter:
+
+- **External-ize the native packages.** Add `externalizeDepsPlugin()` to both `main` and `preload` configs so the `.node` binary is never bundled:
+
+  ```typescript
+  // electron.vite.config.ts
+  import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+
+  export default defineConfig({
+    main: { plugins: [externalizeDepsPlugin()] },
+    preload: { plugins: [externalizeDepsPlugin()] },
+    renderer: {},
+  });
+  ```
+
+- **Preload is emitted as `.mjs` in ESM mode.** electron-vite outputs the preload as `index.mjs` (not `index.js`), so reference it accordingly from main: `path.join(import.meta.dirname, "../preload/index.mjs")`. A stale `../preload/index.js` reference produces a "preload not found" failure.
+- **`import.meta.dirname` is auto-injected** by electron-vite for ESM main, so you don't need a `__dirname` shim in your own main code.
+- **Prebuilt binaries resolve via `optionalDependencies`.** With pnpm 10 you may need to approve the native package's build in `onlyBuiltDependencies` (`pnpm.onlyBuiltDependencies` / `allowBuilds`) the first time.
+- **Preview works in ESM.** `createTextureBridge({ preview: { enabled: true } })`'s asset resolution is ESM-safe (the renderer package ships `__dirname` shims in its ESM build), so the preview window opens under `"type": "module"`.
+

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,56 @@
+# Troubleshooting
+
+## Paint event not firing
+
+- Ensure `win.webContents.setFrameRate(60)` is set
+- Paint events fire even with `show: false`
+- Verify that a `requestAnimationFrame` loop is running in the renderer/worker
+
+## Black texture output
+
+- **DPR / Retina size mismatch (most common).** **Electron ≤ 40:** on a Retina display or under Windows display scaling, the real framebuffer is `width × height × scaleFactor`, so a sender declared at the logical size disagrees with it and the receiver goes black/garbled. Use `createTextureBridge({ pixelExact: true })`, or — on the low-level core path — declare the sender at the true framebuffer size or neutralize DPR yourself. **Electron ≥ 41:** `createTextureBridge` pins the OSR device scale factor to `1`, so this mismatch no longer occurs — see [Migration: Electron 42 / OSR device scale](MIGRATION.md#migration-electron-42--osr-device-scale); on the low-level core path, pass `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` yourself. See the [Retina/DPI warning](SENDING.md#macos-retina-and-windows-dpi-scaling).
+- **Isolate Electron vs. the bridge** with the [no-Electron sanity check](SENDING.md#minimal-sanity-check-no-electron) — if `sendRgbaBuffer` shows up in your VJ app, the native side is fine and the problem is in the Electron OSR path.
+- `preserveDrawingBuffer` is not needed (Chromium compositor reads directly)
+- Check pixel format mismatch: Chromium outputs BGRA, ensure the receiver expects BGRA
+- Subscribe to `bridge.on("frameDropped", ...)` (or check the return value of
+  `sendTextureFromPaintEvent`) — a persistent `no-nt-handle` / `no-io-surface`
+  reason means Chromium is not delivering a shareable GPU handle, which
+  otherwise manifests only as black output.
+
+## Syphon receiver not showing output (macOS)
+
+- Verify `vendor/Syphon.framework` exists and was built correctly
+- Clear Gatekeeper quarantine: `xattr -dr com.apple.quarantine vendor/Syphon.framework`
+- Check Console.app for error logs
+
+## Spout receiver not showing output (Windows)
+
+- Verify Spout2 is installed on the system
+- Ensure GPU drivers are up to date
+- DirectX 11 compatible GPU is required
+
+## Zero-copy shared-texture receiver
+
+- **Requires Electron 40+** — uses the `sharedTexture.importSharedTexture` / `sendSharedTexture` / `setSharedTextureReceiver` module. Older Electron will throw at import time.
+- **`listSenders()` shows `<sender>_1` suffixes.** A previous sender process of the same name was killed uncleanly and its shared-memory directory entry is lingering. Start (or restart) the real sender — it will either reclaim the clean name or the stale suffix will go away on its own on the next publisher cycle.
+- **Handle leak after the target window closes.** If you poll `receiveSharedTexture()` directly, always call `closeNativeHandle(frame.handle)` on any path that does not forward the handle to `sharedTexture.importSharedTexture` — including "target was destroyed", "unknown pixel format", and "I decided to drop this frame". `createSharedTextureReceiver` does this for you.
+- **Windows staging texture.** The receiver creates its staging texture with `MISC_SHARED_NTHANDLE | MISC_SHARED` (no keyed mutex), so consumers do not need to `AcquireSync` per frame — Electron imports it directly.
+
+## Freezing / paint events stop
+
+- **Always call `texture.release()`** after processing. The texture pool is small (a few frames). Failing to release will exhaust the pool and stall the paint event pipeline.
+- When using `createTextureBridge()`, this is handled automatically.
+- When using the low-level core API, use `try/finally`:
+
+```typescript
+win.webContents.on("paint", (event) => {
+  const texture = event.texture;
+  if (!texture) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release?.();
+  }
+});
+```
+

--- a/docs/ja/API.md
+++ b/docs/ja/API.md
@@ -1,0 +1,467 @@
+# API リファレンス
+
+エクスポートされるすべてのシンボルの完全なリファレンスです。ガイド付きの導入は [README](../../lang/ja/README.md)、送信のレシピは [SENDING.md](SENDING.md)、受信経路は [RECEIVING.md](RECEIVING.md) を参照してください。
+
+## `@napolab/texture-bridge-renderer`
+
+### `createTextureBridge(options): Promise<TextureBridge>`
+
+完全に接続されたテクスチャブリッジを作成するファクトリ関数。`app.whenReady()` の後に呼び出す必要があります。
+
+```typescript
+interface TextureBridgeOptions {
+  name: string;            // Syphon/Spout センダー名
+  width: number;           // テクスチャ幅（ピクセル）
+  height: number;          // テクスチャ高さ（ピクセル）
+  frameRate?: number;      // 目標フレームレート（デフォルト: 60）
+  rendererUrl: string;     // 読み込む URL（ファイルパス、file://、http://）
+  preview?: PreviewOptions;
+  webPreferences?: Electron.WebPreferences;
+  includeAlpha?: boolean;  // ページのピクセル単位のアルファを共有テクスチャへ転送する（デフォルト: false）
+  pixelExact?: boolean;    // ディスプレイ DPR に関係なくフレームバッファを正確に width×height に固定する（デフォルト: false）
+}
+
+interface PreviewOptions {
+  enabled?: boolean;       // プレビューウィンドウを開く（デフォルト: false）
+  width?: number;          // プレビューウィンドウ幅
+  height?: number;         // プレビューウィンドウ高さ
+  title?: string;          // プレビューウィンドウタイトル
+}
+```
+
+**`pixelExact`** — `true` のとき、ホストディスプレイの DPR に関係なくオフスクリーンフレームバッファを正確に `width × height` ピクセルに固定します。**Electron ≥ 41:** 自明に満たされ実質的に no-op です — `createTextureBridge` がすでに `offscreen.deviceScaleFactor: 1` を固定しているため、このオプションの有無に関わらずフレームバッファは常に正確です。**Electron 40:** 指定しないと Retina（scaleFactor 2）や Windows スケーリング（150% / 175%）のディスプレイでは宣言したセンダーサイズより大きいフレームバッファが生成され、多くの場合レシーバーで黒画面/崩れになります（[Retina/DPI 警告](SENDING.md#macos-retina-と-windows-dpi-スケーリング-macos-retina-and-windows-dpi-scaling)参照）。センダーは常に要求ピクセルサイズで登録されるため、レシーバーは指定どおりの寸法を受け取ります。注意: 割り切れないスケール比（例: `1920 / 1.75`）では 1 ピクセルの誤差が残ることがあり、構築時のプライマリディスプレイの scaleFactor のみが反映されます — DPI 変更後は `resize()` で再適用してください。
+
+### `createTextureBridgeWith(deps)`（上級者向け）
+
+```typescript
+interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => TextureSender;
+}
+
+function createTextureBridgeWith(
+  deps: TextureBridgeDeps,
+): (options: TextureBridgeOptions) => Promise<TextureBridge>;
+```
+
+注入されたコンストラクタに束縛された `createTextureBridge` を返します —
+テストや組み込み側が `BrowserWindow` の構築や、ネイティブ `TextureSender` の
+構築をテストダブルに差し替えられるようにするためのものです。
+`createTextureBridge` 自体も、実際の `BrowserWindow` / `TextureSender` に束縛した
+`createTextureBridgeWith` にすぎません。ファクトリは Electron の `app` / `screen`
+グローバルを引き続き直接参照し、プレビューウィンドウも自前で構築します
+（`PreviewManager`）— このシームはウィンドウ / センダーの構築のみを注入可能にし、
+ファクトリ全体を Electron 非依存にするものではありません。完全に Electron 無しの
+テスト環境が必要な場合は、`app` / `screen` を別途モックしてください。
+
+### `TextureBridge`
+
+返されるハンドル：
+
+```typescript
+interface TextureBridge {
+  on(event: "fps", listener: (fps: number) => void): this;
+  on(event: "ready", listener: () => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
+  on(event: "resize", listener: (width: number, height: number) => void): this;
+  on(event: "disposed", listener: () => void): this;
+
+  resize(width: number, height: number): void;  // 全レイヤー + Worker にカスケード
+  openPreview(): void;
+  closePreview(): void;
+  forwardFrames(target: WebContents, options?: FrameForwardOptions): FrameForward;
+  dispose(): void;
+
+  readonly renderWindow: BrowserWindow;
+  readonly previewWindow: BrowserWindow | null;
+  readonly isDisposed: boolean;
+  readonly droppedReason: PaintDefect["reason"] | null;
+}
+```
+
+`frameDropped` は、paint フレームがセンダーに届く前にドロップされたときに発火します
+（`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`）。
+エラーではありませんが、継続的に発火する場合はレシーバー側で黒画面になります。
+同じ理由が連続する場合はデデュープされます：イベントは最初の発生時に一度発火し、
+成功した送信または理由の変化があった後に再び発火します。リスナーをアタッチする前に
+ドロップが確定していた場合（例: レンダラーページがまだロード中の場合）は、
+`bridge.droppedReason` を読んでください — 最新のドロップ理由、または成功した送信の後は
+`null` を保持します。
+
+`dispose()` は、オフスクリーンの `renderWindow` を `close()` ではなく
+`destroy()` で同期的に破棄します。これにより、Electron の `before-quit` との
+競合でクラッシュダイアログが出るリスクがなくなります。ここから 2 点が
+帰結します:
+
+- **`disposed` リスナーで `bridge.renderWindow.webContents` に触れてはいけません** —
+  `disposed` が発火する時点で、オフスクリーンウィンドウはすでに破棄済みです。
+- **レンダーウィンドウの `close` イベントと、ページの `beforeunload`/`unload`
+  ハンドラはもう発火しません** — これは `destroy()` の仕様どおりの挙動です。
+  `closed` イベントは引き続き発火します。
+
+プレビューウィンドウは影響を受けません: 実在する可視ウィンドウであり、
+引き続き `close()` により通常のクローズセマンティクスで閉じます。以前、
+旧来の非同期な `close()` を避けるため `bridge.dispose()` の後に自前で
+`bridge.renderWindow.destroy()` を呼ぶワークアラウンドをしていた場合は、
+**その外部からの `destroy()` 呼び出しを削除してください** — `dispose()` が
+今はそれを内部で行うため、`dispose()` の後に呼ぶとすでに破棄済みのウィンドウ
+に対して呼び出すことになり、Electron は二重の `destroy()` が安全であることを
+保証していません（"Object has been destroyed" で例外になり得ます）。ライブラリ
+側のガードは `dispose()` 内部の呼び出しのみを保護するものであり、`dispose()`
+呼び出し後に外部から呼ばれる `destroy()` までは保護しません。すぐに削除できない
+場合は、自分でガードする
+（`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`）か、
+`dispose()` より前に呼び出すようにしてください。
+
+### `TextureBridge.forwardFrames(target, options?)`
+
+```typescript
+const forward = bridge.forwardFrames(monitorWindow.webContents, { extraArgs: [slot] });
+// 後で
+forward.dispose(); // 冪等
+```
+
+`WebContents`（モニター/マルチビューアウィンドウなど）を登録し、以降すべての paint フレームを `forwardSharedTexture` と同じゼロコピーの shared-texture 経路で受け取れるようにします — ピクセル readback はなく、GPU ハンドルの受け渡しのみです。
+
+**ベストエフォート契約** はプレビュー経路と同一です: 転送失敗（core の `forwardSharedTexture` primitive が返す `ForwardDefect`）はこの driver が握り潰し、`"error"` イベントや `frameDropped` / `droppedReason` を汚しません。**ネイティブの Syphon/Spout 送信からは独立** しています — paint ハンドラ内で転送は `sendTextureFromPaintEvent` より先に実行されるため、ネイティブ送信が throw しても登録済みの転送を止められませんし、転送側の失敗がネイティブ送信をブロックすることもありません。両者は互いの結果と無関係に発火します。
+
+`FrameForward.dispose()` はその 1 件の登録だけを解除し、冪等です — 2 回呼んでも、あるいは `bridge.dispose()` が先に全登録を解除した後に呼んでも no-op です。`bridge.dispose()` は登録済みの転送をすべて解除します。
+
+受け取り側は新たに何も必要ありません: 転送先の target は Syphon/Spout レシーバーとまったく同じ方法でフレームを受け取ります — renderer 起動時に一度 `installSharedTextureReceiver()` を呼び、`consumeSharedTexture({ onFrame: (frame, ...extraArgs) => ... })` で受信します。`forwardFrames(target, { extraArgs })` に渡した `extraArgs` はハンドラの末尾引数としてそのまま届くため、1 つの target が複数ソースからの転送を（例えばスロット番号で）判別できます。
+
+現在の実装は、フレームごとに登録済み target の数だけテクスチャを import します。複数 target が同一ソースフレームを共有する場合は「フレームごとに import は 1 回 → 全 target へ send → 全 send の settle 後に release」へ最適化する余地がありますが、現時点でその需要のある呼び出し元がないため（multiviewer は 1 ソース = 1 target）、将来のオプションとして記録するに留め、実装はしていません。
+
+### `createWorkerRenderer(options)`（`renderer/client` から）
+
+キャンバスから Worker へのパイプラインを設定するレンダラープロセス用ヘルパー。ResizeObserver による自動リサイズ伝播付き。
+
+```typescript
+import { createWorkerRenderer } from "@napolab/texture-bridge-renderer/client";
+
+createWorkerRenderer({
+  worker: new MyWorker(),
+  width: 1920,
+  height: 1080,
+});
+```
+
+### `installSharedTextureReceiver()`（`renderer/client` から）
+
+```typescript
+import { installSharedTextureReceiver } from "@napolab/texture-bridge-renderer/client";
+
+installSharedTextureReceiver();
+```
+
+Electron の単一の `sharedTexture.setSharedTextureReceiver` スロットを内部のコンシューマープールに束縛し、複数の `consumeSharedTexture` 呼び出しが共存できるようにします。冪等です — `consumeSharedTexture` を呼ぶ前に、レンダラー起動時に一度だけ呼び出してください。Electron 40+ が必要です。
+
+### `consumeSharedTexture(handlers)`（`renderer/client` から）
+
+```typescript
+import { consumeSharedTexture } from "@napolab/texture-bridge-renderer/client";
+
+const registration = consumeSharedTexture({
+  onFrame: ({ textureId, videoFrame }, ...extraArgs) => {
+    // videoFrame は共有テクスチャに裏付けられた Web VideoFrame です。
+    // drawImage(videoFrame) — ゼロコピー GPU blit
+    // device.importExternalTexture({ source: videoFrame }) — WebGPU 経路
+  },
+  onError: (err) => console.error(err),
+});
+
+registration.dispose();   // このコンシューマーをプールから削除（冪等）
+```
+
+`installSharedTextureReceiver` が束縛したプールにコンシューマーを登録します。アクティブな各コンシューマーは、届いた import 済みテクスチャごとに専用の `VideoFrame` を受け取ります。ラッパーは `onFrame` が完了した後に `VideoFrame` を close し、全コンシューマーの処理が終わった後に一度だけ、元の import 済みテクスチャを release します。
+
+### `createMultiDispatcher(options)`（`renderer/client` から）
+
+低レベルなファンアウト primitive です: 1 回の `handler(...)` 呼び出しが登録済みの全コールバックを呼び出し、その結果をユーザー指定の `combine` 関数で reduce します。`installSharedTextureReceiver` はこの上に構築されていますが、「1 つの上流スロットに対して複数の下流コンシューマー」というアダプター（例: preload→renderer ブリッジ）を自作できるようにエクスポートされています。完全な API は `packages/renderer/src/client/multi-dispatcher.ts` の JSDoc を参照してください。
+
+### `createSharedTextureReceiver(options): SharedTextureReceiverBridge`
+
+**ゼロコピー GPU** レシーバーブリッジを作成するファクトリ関数です。`TextureReceiver.receiveSharedTexture()` をポーリングし、各フレームを Electron の `sharedTexture.importSharedTexture` + `sendSharedTexture` のペア経由で対象の renderer に配送します。Windows（Spout）と macOS（Syphon Metal）の両方でエンドツーエンド検証済みです。
+
+```typescript
+interface SharedTextureReceiverOptions {
+  senderName: string;                 // Syphon サーバー / Spout センダー名
+  target: Electron.WebContents;       // レシーバーウィンドウの webContents
+  pollIntervalMs?: number;            // デフォルト 16（約 60fps）；drop-latest を適用
+  appName?: string;                   // （macOS のみ）アプリケーション名でフィルタ
+  serverUuid?: string;                // （macOS のみ）サーバー UUID で接続
+  extraArgs?: readonly unknown[];     // sendSharedTexture(..., ...args) へ転送される
+}
+
+interface SharedTextureReceiverBridge {
+  on(event: "fps", listener: (fps: number) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "disposed", listener: () => void): this;
+
+  start(): void;                      // ポーリングを開始
+  stop(): void;                       // ポーリングを一時停止（再度 start 可能）
+  dispose(): void;                    // 終端: stop + ネイティブレシーバーの release
+  [Symbol.dispose](): void;           // dispose() と同じ
+
+  readonly isDisposed: boolean;
+}
+```
+
+`dispose()` は終端かつ冪等です。`"error"` イベントが 10 回連続すると、ブリッジは自動的に停止し（サーキットブレーカー）、シャットダウン理由を説明する最終エラーを 1 回発火します。
+
+### `createTextureReceiver(options): TextureReceiverBridge`
+
+ポーリングと FPS 計測を備えたテクスチャレシーバーを作成するファクトリ関数です。
+
+```typescript
+interface TextureReceiverBridgeOptions {
+  senderName: string;      // Syphon サーバー名 / Spout センダー名
+  appName?: string;        // （macOS のみ）アプリケーション名でフィルタ
+  serverUuid?: string;     // （macOS のみ）サーバー UUID で接続
+  pollIntervalMs?: number; // フレームポーリング間隔（ms、デフォルト: 16）
+}
+```
+
+### `TextureReceiverBridge`
+
+```typescript
+interface TextureReceiverBridge {
+  on(event: "frame", listener: (frame: ReceivedFrame) => void): this;
+  on(event: "fps", listener: (fps: number) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "disposed", listener: () => void): this;
+
+  start(): void;   // フレームのポーリングを開始
+  stop(): void;    // ポーリングを一時停止
+  dispose(): void; // 全リソースを解放
+
+  readonly isDisposed: boolean;
+}
+
+interface ReceivedFrame {
+  data: Buffer;    // RGBA ピクセルデータ
+  width: number;
+  height: number;
+}
+```
+
+### `SenderDiscovery`
+
+利用可能な Syphon サーバー / Spout センダーをポーリングし、差分イベントを発行する EventEmitter です。
+
+```typescript
+const discovery = new SenderDiscovery();
+discovery.on("added", (senders: SenderInfo[]) => { /* 新しいセンダーが出現 */ });
+discovery.on("removed", (senders: SenderInfo[]) => { /* センダーが消失 */ });
+discovery.on("updated", (senders: SenderInfo[]) => { /* 現在の全リスト */ });
+discovery.start(1000); // ポーリング間隔（ms）
+discovery.getSenders(); // 現在のセンダーリスト
+discovery.dispose();
+
+interface SenderInfo {
+  name: string;
+  appName?: string;  // macOS のみ
+  uuid?: string;     // macOS のみ
+}
+```
+
+### Worker プロトコル型（`renderer/worker` から）
+
+```typescript
+import type { WorkerMessage } from "@napolab/texture-bridge-renderer/worker";
+
+// Worker 内:
+self.onmessage = (e: MessageEvent<WorkerMessage>) => {
+  switch (e.data.type) {
+    case "init":   /* e.data.canvas: OffscreenCanvas */ break;
+    case "resize": /* e.data.width, e.data.height */   break;
+    case "dispose": break;
+  }
+};
+```
+
+## `@napolab/texture-bridge-core`
+
+### `sendTextureFromPaintEvent(sender, textureInfo)`
+
+プラットフォーム固有のテクスチャハンドルの取得と転送を自動的に処理する低レベル関数です。
+
+- **macOS**: `handle.ioSurface` バッファを読み取り → `sender.sendSurface()` を呼び出し
+- **Windows**: `handle.ntHandle` バッファを BigInt64LE として読み取り → `sender.send()` を呼び出し
+
+フレームがセンダーに渡された場合は `undefined` を返し、フレームがドロップされた場合は
+`PaintDefect`（`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`；
+`unsupported-platform` バリアントには該当する `platform` も含まれます）を返します。
+ドロップは通常のノーオペレーションであり、エラーではありません — `createTextureBridge` が
+`frameDropped` イベントで行っているのと同様に、自前の paint ループでも表面化させてください。
+ネイティブの送信失敗は `TextureSendError`（両パッケージからエクスポートされます）として
+throw されます — メッセージはそのまま保持され、元の throw 値は `error.cause` から参照できます。
+`createTextureBridge` を使っている場合、これらはブリッジの `error` イベントとして表面化するため、
+`instanceof TextureSendError` で判別できます。
+
+### `forwardSharedTexture(textureInfo, target, extraArgs?)`（`core/electron` から）
+
+```typescript
+import { forwardSharedTexture, type ForwardDefect } from "@napolab/texture-bridge-core/electron";
+
+const defect = await forwardSharedTexture(textureInfo, target, extraArgs);
+```
+
+1 フレームの paint を、Electron の shared-texture チャネル（`sharedTexture.importSharedTexture` → `sharedTexture.sendSharedTexture`）経由で renderer の `WebContents` に転送します。ゼロコピー — プロセス境界を越えるのは GPU ハンドルのみで、ピクセルは動きません。
+
+この関数はパッケージのメインエントリではなく、**独立したサブパス** `@napolab/texture-bridge-core/electron` に置かれています。メインエントリは Electron 未インストールでも import できる状態を保つ必要があります（前述の「Electron 無しの最小サニティチェック」の `sendRgbaBuffer` がそれに依存しています）。そのためこの関数が必要とする静的な `import { sharedTexture } from "electron"` はこのサブパスに隔離し、メインエントリの出力に electron-free ガードをビルド時に適用して強制しています。
+
+フレームが Electron への配送に成功した場合は `undefined` を、失敗した理由は `ForwardDefect` で返します — `sendTextureFromPaintEvent` の `PaintDefect | undefined` と同じ報告方式です: 低レベル層は結果を報告するだけで、判断は呼び出し側に委ねます。
+
+```typescript
+type ForwardDefect =
+  | { reason: "target-destroyed" }   // target.isDestroyed()、または mainFrame が存在しない
+  | { reason: "import-failed"; cause: Error }
+  | { reason: "send-failed"; cause: Error };
+```
+
+`async` 関数であるため、同期的に throw することは構造的にありません — 失敗は常に返り値の Promise を通じて表面化し、呼び出し箇所で例外として飛ぶことはありません。import に成功した場合は、後続の send が成功しても失敗しても `finally` で必ず import 済みテクスチャを release します（release-in-finally）。
+
+自前の paint ループを持つ低レベル利用者は、`sendTextureFromPaintEvent` と並べて直接呼び出せます。texture の release は `finally` で行ってください — `sendTextureFromPaintEvent` はネイティブ送信の失敗時に throw するため、`finally` を使わないと `texture.release()` がスキップされてフレームがリークします。`forwardSharedTexture` は同期的に throw しない（前述）ため、`await` せず fire-and-forget しても安全です — ディスパッチ自体は同期的に開始されるため:
+
+```typescript
+win.webContents.on("paint", (e) => {
+  const texture = e.texture;
+  if (!texture) return;
+  try {
+    void forwardSharedTexture(texture.textureInfo, monitorWC, [slot]); // → renderer（ディスパッチは同期）
+    sendTextureFromPaintEvent(sender, texture.textureInfo);           // → Syphon/Spout（失敗時は throw）
+  } finally {
+    texture.release();
+  }
+});
+```
+
+### `sendImportedTexture(frame, imported, extraArgs?)`（`core/electron` から）
+
+```typescript
+import { sendImportedTexture } from "@napolab/texture-bridge-core/electron";
+
+await sendImportedTexture(targetFrame, importedSharedTexture, extraArgs);
+```
+
+**すでに import 済みの** shared texture（`sharedTexture.importSharedTexture(...)` の戻り値）を対象の `WebFrameMain` に配送し、send の成否に関わらず `finally` で必ず release します — release-in-finally は `forwardSharedTexture` 内部の配送ステップと同じ契約です。これは `forwardSharedTexture`（前述）とレンダラーパッケージの shared-texture receiver 経路（`shared-texture-receiver.ts`、`preview-manager.ts`）の両方が内部で呼び出している共有ヘルパーで、「配送して必ず release する」処理の実装が重複せず一本化されています。ほとんどの利用者は `importSharedTexture` のステップも行う `forwardSharedTexture` を使うべきです — `sendImportedTexture` を直接使うのは、すでに他所（例: receiver のポーリングループ）で import 済みのテクスチャを持っていて、send-and-release の半分だけが必要な場合に限ります。
+
+### `TextureSender`
+
+Syphon/Spout レシーバーにテクスチャを送信するネイティブクラスです。
+
+```typescript
+class TextureSender {
+  constructor(name: string, width: number, height: number);
+  send(handle: number, width: number, height: number): void;
+  sendSurface(surfaceBuffer: Buffer, width: number, height: number): void;
+  sendRgbaBuffer(data: Buffer, width: number, height: number, bytesPerRow?: number): void;
+  platform(): string;
+  stop(): void;  // 終端 — ネイティブリソースを即座に解放
+}
+```
+
+### `TextureReceiver`
+
+Syphon/Spout センダーからテクスチャを受信するネイティブクラスです。
+
+```typescript
+class TextureReceiver {
+  constructor(senderName: string, appName?: string, serverUuid?: string);
+  hasNewFrame(): boolean;
+  receiveFrame(): ReceivedFrame | null;                  // RGBA readback
+  receiveSharedTexture(): SharedTextureFrame | null;     // ゼロコピー GPU ハンドル（Windows + macOS）
+  isConnected(): boolean;
+  getWidth(): number;
+  getHeight(): number;
+  platform(): string;
+  stop(): void;  // 終端 — ネイティブリソースを即座に解放
+}
+
+interface SharedTextureFrame {
+  width: number;
+  height: number;
+  pixelFormat: "bgra" | "rgba" | "rgbaf16";
+  ownerPid: number;        // ハンドルを所有するプロセス ID（通常は process.pid）
+  handle: Buffer;          // 8 バイト LE: Windows では NT HANDLE、macOS では IOSurfaceRef ポインタ
+}
+```
+
+各 `handle` は新規に発行された、所有権を持つネイティブ参照です。`sharedTexture.importSharedTexture` に渡す（Electron が所有権を引き継ぐ）か、`closeNativeHandle(handle)` を呼んでください — さもないとフレームごとに NT HANDLE / IOSurface がリークします。
+
+### `closeNativeHandle(handle)`
+
+```typescript
+function closeNativeHandle(handle: Buffer): void;
+```
+
+`receiveSharedTexture()` が発行したものの Electron の `importSharedTexture` に一度も渡されていない、ネイティブの共有テクスチャハンドル（Windows では NT HANDLE、macOS では `IOSurfaceRef`）を解放します。Electron に転送**していない**ハンドルに対してのみ呼び出してください。Electron が所有権を引き継いだハンドルは、Electron 自身が解放します。
+
+### リソースのライフサイクル
+
+`TextureSender` と `TextureReceiver` はどちらも決定的な破棄セマンティクスに従います:
+
+1. **`stop()` はネイティブリソースを即座に解放します。** クリーンアップをガベージコレクションに頼らないでください。
+2. **`stop()` は終端です。** 呼び出し後、インスタンスは再利用できません。`stop()` 以降に操作系メソッドを呼ぶと、エラーを throw する（sender）か、安全な終端値を返します（receiver）。
+3. **`stop()` は冪等です。** 繰り返し呼び出しても安全で、エラーなく返ります。
+4. **上位の `dispose()` メソッド**（`TextureBridge`、`TextureReceiverBridge` 上）はネイティブの `stop()` に転送され、これも終端です。
+
+```typescript
+// 推奨パターン
+const sender = new TextureSender("MyApp", 1920, 1080);
+try {
+  // ...センダーを使用...
+} finally {
+  sender.stop();
+}
+
+// `using` 宣言で使うための Symbol.dispose にも対応しています。
+// Node.js 22+（または Symbol.dispose 対応ランタイム）と、
+// tsconfig.json の `"lib": ["ESNext.Disposable"]` が必要です。
+// ランタイムの Symbol.dispose パッチには @napolab/texture-bridge-core からインポートしてください。
+using sender = new TextureSender("MyApp", 1920, 1080);
+```
+
+### `listSenders()`
+
+```typescript
+function listSenders(): Array<{ name: string; appName?: string; uuid?: string }>;
+```
+
+### `getPlatform()`
+
+```typescript
+function getPlatform(): "spout" | "syphon-metal" | "unsupported";
+```
+
+`getPlatform()` とインスタンスメソッド `sender.platform()` / `receiver.platform()` は同じ文字列集合を返します：
+
+| 値 | 意味 |
+|----|------|
+| `"syphon-metal"` | macOS — Syphon Metal バックエンド有効 |
+| `"spout"` | Windows — Spout バックエンド有効 |
+| `"unsupported"` | バックエンドのないプラットフォーム（送受信は no-op） |
+
+### 型定義
+
+```typescript
+type PixelFormat = "bgra" | "nv12" | "rgba" | "rgbaf16";
+
+interface TextureInfo {
+  pixelFormat: PixelFormat;
+  codedSize: { width: number; height: number };
+  visibleRect: { x: number; y: number; width: number; height: number };
+  handle: {
+    ntHandle?: Buffer;   // Windows (Electron 40+)
+    ioSurface?: Buffer;  // macOS
+  };
+}
+
+interface PaintTexture {
+  textureInfo: TextureInfo;
+  release?: () => void;
+}
+
+type Platform = "spout" | "syphon-metal" | "unsupported";
+```

--- a/docs/ja/DEVELOPMENT.md
+++ b/docs/ja/DEVELOPMENT.md
@@ -1,0 +1,64 @@
+# 開発
+
+コントリビューター向けのリポジトリ構成と CI についてまとめています。ビルド手順は [INSTALLATION.md](INSTALLATION.md#ソースからのビルド) を参照してください。
+
+## プロジェクト構成
+
+```
+electron-texture-bridge/
+├── packages/
+│   ├── native/                # @napolab/texture-bridge (napi-rs)
+│   │   ├── src/
+│   │   │   ├── lib.rs         # napi-rs エントリポイント、TextureSender/Receiver API
+│   │   │   ├── types.rs       # RawTextureHandle 型エイリアス
+│   │   │   ├── mac/           # macOS: Syphon Metal センダー + レシーバー + FFI
+│   │   │   └── win/           # Windows: Spout センダー + レシーバー + FFI
+│   │   ├── cpp/
+│   │   │   ├── mac/           # ObjC++ Syphon Metal ブリッジ（送信 + 受信 + 検出）
+│   │   │   └── win/           # C++ Spout ブリッジ（送信 + 受信 + 検出）
+│   │   ├── build.rs           # プラットフォーム固有のビルド設定
+│   │   └── Cargo.toml
+│   ├── core/                  # @napolab/texture-bridge-core (TypeScript)
+│   │   └── src/
+│   │       ├── index.ts       # sendTextureFromPaintEvent + 再エクスポート（sender + receiver）
+│   │       └── types.ts       # TextureInfo, PaintTexture, SenderInfo, ReceivedFrame
+│   ├── renderer/              # @napolab/texture-bridge-renderer (TypeScript)
+│   │   └── src/
+│   │       ├── index.ts       # createTextureBridge + createTextureReceiver + SenderDiscovery
+│   │       ├── bridge.ts      # ファクトリ実装（EventEmitter）
+│   │       ├── receiver.ts    # レシーバーファクトリ（ポーリング + FPS 計測）
+│   │       ├── discovery.ts   # SenderDiscovery（ポーリング + 差分イベント）
+│   │       ├── types.ts       # TextureBridgeOptions, TextureBridge
+│   │       ├── preview-manager.ts  # プレビューウィンドウのライフサイクル管理
+│   │       ├── fps-counter.ts # FPS 計測ユーティリティ
+│   │       ├── client/        # レンダラープロセス用ヘルパー
+│   │       │   ├── index.ts   # createWorkerRenderer
+│   │       │   └── worker-protocol.ts  # Worker メッセージ型
+│   │       └── assets/        # 静的ファイル（preview.html, preload）
+│   └── example/               # Electron VJ デモアプリ（プライベート）
+│       └── src/
+│           ├── main/          # Electron メインプロセス（約 30 LOC）
+│           └── renderer/      # Three.js + GLSL + Web Worker
+├── vendor/                    # サードパーティ SDK（gitignore、ローカルでビルド）
+│   ├── syphon-src/            # Syphon Framework ソース（git サブモジュール）
+│   ├── Syphon.framework/     # ビルド済みフレームワーク（macOS）
+│   └── Spout2/               # Spout SDK（Windows）— SpoutDirectX/ + SpoutGL/
+├── specs/
+│   └── ARCHITECTURE.md        # 詳細なアーキテクチャドキュメント
+├── Cargo.toml                 # Rust ワークスペースルート
+├── pnpm-workspace.yaml        # pnpm モノレポ設定
+└── package.json               # ルートワークスペーススクリプト
+```
+
+
+## CI/CD
+
+GitHub Actions が全対応プラットフォーム向けにネイティブバイナリをビルドします：
+
+| ランナー | ターゲット | 出力 |
+|--------|--------|--------|
+| `macos-14` | `aarch64-apple-darwin` | `texture-bridge.darwin-arm64.node` |
+| `macos-13` | `x86_64-apple-darwin` | `texture-bridge.darwin-x64.node` |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `texture-bridge.win32-x64-msvc.node` |
+
+npm への公開はバージョンタグ（`v*`）で自動トリガーされます。

--- a/docs/ja/MIGRATION.md
+++ b/docs/ja/MIGRATION.md
@@ -1,0 +1,81 @@
+# 移行ガイド
+
+破壊的変更とその対応方法を、新しいものから順に紹介します。
+
+## 移行ガイド: Electron 42 / OSR デバイススケール
+
+Electron 42 でオフスクリーンレンダリングのデフォルトデバイススケールファクターが `1.0` に変更されました（[breaking change](https://www.electronjs.org/docs/latest/breaking-changes)）。この変更を含む texture-bridge のリリース以降（CHANGELOG 参照）、`createTextureBridge` は Electron ≥ 41 で `offscreen.deviceScaleFactor: 1` を固定するため、`width`/`height` はどのディスプレイでも正確なピクセル数を意味するようになります。
+
+- **`pixelExact: true` を使っていた場合**（Electron 40 など）: そのままで問題ありません — Electron ≥ 41 では no-op であり、40 では引き続き必要です。
+- **自分でスケーリングを回避していた場合**（`force-device-scale-factor=1`、手動の DIP 計算、Electron 42 で 1/4 解像度になった後に `pixelExact` を外す、など）: アップグレード後はこれらの回避策は不要になります。
+- **意図的にスケーリングされたフレームバッファが欲しい場合**は、自分で `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` を渡してください — ユーザー指定の `offscreen` ブロックは常に優先されます。
+
+実測データの背景: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`。
+
+## 移行ガイド: 同期 dispose（v0.14+）
+
+v0.14 以降、`dispose()` はオフスクリーンの `renderWindow` を `close()` するのではなく、同期的に `destroy()` するようになりました。これによって利用者から見える変化が 2 点あります（disposed 後のウィンドウアクセス、close/beforeunload イベントが発火しなくなる点）— 詳細は [`TextureBridge`](API.md#texturebridge) の `dispose()` の説明を参照してください。
+
+以前、非同期だった旧 `close()` の挙動を回避するために `bridge.dispose()` の後で自前の `bridge.renderWindow.destroy()` を呼んでいた場合は、**その外部からの `destroy()` 呼び出しを削除してください**。`dispose()` の後にこれを呼ぶと、すでに破棄済みのウィンドウを対象にすることになり、Electron は 2 回目の `destroy()` が安全であることを保証していません。すぐに削除できない場合は、ガードするか `dispose()` より前に移動してください
+（`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();` とするか、`dispose()` の**前**に呼ぶ、後には呼ばない）。
+
+## 移行ガイド: 明示的な解放（v0.6+）
+
+v0.6 以降、`stop()` と `dispose()` は**終端操作**となり、呼び出すと即座にネイティブの GPU / IPC リソースを解放します。以前はリソースの解放タイミングが JavaScript のガベージコレクションに依存していました。
+
+### 変更点
+
+| 挙動 | 変更前（v0.5） | 変更後（v0.6+） |
+|----------|---------------|---------------|
+| `sender.stop()` | no-op（GC が解放を担当） | native リソースを即座に drop する |
+| `stop()` 後の `sender.send()` | 黙って動いていた | `"TextureSender has been stopped"` を throw する |
+| `stop()` 後の `receiver.receiveFrame()` | 古い値または null を返していた | `null` を返す |
+| `stop()` 後の `receiver.hasNewFrame()` | 古い値を返していた | `false` を返す |
+| `bridge.dispose()` | タイマーの停止のみ | native sender + preview を完全に teardown する |
+
+### 移行方法
+
+**Sender** — 常に明示的な teardown とペアで使う：
+
+```typescript
+const sender = new TextureSender("MyApp", 1920, 1080);
+try {
+  sender.send(handle, w, h);
+} finally {
+  sender.stop(); // resources released immediately
+}
+```
+
+**Receiver** — 同じパターン：
+
+```typescript
+const receiver = new TextureReceiver("MySender");
+try {
+  const frame = receiver.receiveFrame();
+} finally {
+  receiver.stop();
+}
+```
+
+**高レベルの bridge** — すでに `dispose()` を呼んでいるならコード変更は不要：
+
+```typescript
+const bridge = await createTextureBridge({ ... });
+// ... use bridge ...
+bridge.dispose(); // now deterministic
+```
+
+**`using` 宣言**（Node.js 22+、`"lib": ["ESNext.Disposable"]`）：
+
+```typescript
+// Import from @napolab/texture-bridge-core for Symbol.dispose support
+using sender = new TextureSender("MyApp", 1920, 1080);
+// resources automatically released at end of scope
+```
+
+### 主なルール
+
+1. `stop()` または `dispose()` を呼んだら、そのインスタンスは永続的に closed 状態になる
+2. `stop()` / `dispose()` の複数回呼び出しは安全（idempotent）
+3. 停止済みインスタンスを再利用せず、新しく作り直す
+4. native リソースの解放を GC に依存しない

--- a/docs/ja/RECEIVING.md
+++ b/docs/ja/RECEIVING.md
@@ -1,0 +1,133 @@
+# Spout/Syphon からのテクスチャ受信
+
+受信経路は 2 つあり、それぞれ解決する問題が異なります。
+
+- **`TextureReceiver.receiveFrame()` / `createTextureReceiver()`** — RGBA リードバック。ネイティブ側が GPU→CPU ブリット（D3D11 ステージング / Metal ブリット）を実行し、IPC を 1 回経由して `ArrayBuffer` を渡します。1080p 1 フレームあたり約 8 MB が IPC 経由でコピーされます。JavaScript 側で実際にピクセルデータが欲しい場合（解析、画像エクスポート、独自のカラーパイプラインなど）に使ってください。
+- **`TextureReceiver.receiveSharedTexture()` / `createSharedTextureReceiver()` / `consumeSharedTexture()`** — ゼロコピー GPU 配信。ネイティブ側がフレームごとにプラットフォームネイティブな共有ハンドル（Windows では DXGI NT ハンドル、macOS では IOSurface ポインタ）を発行し、Electron の `sharedTexture.importSharedTexture` + `sendSharedTexture` のペアを介してレンダラーへ `VideoFrame` として渡します。CPU リードバックも `ArrayBuffer` の IPC コピーもありません。`ctx.drawImage(videoFrame, 0, 0)` は GPU 上で完結し、`GPUDevice.importExternalTexture({ source: videoFrame })` も同じテクスチャをコピーなしで WebGPU に渡します。受信した映像を表示するだけ、あるいは GPU 上で処理したいだけの場合に使ってください。
+
+そのフレームで何をしたいかに応じて、どちらか一方を選んでください。
+
+> **ステータス。** ゼロコピー GPU 経路は Windows（Spout）と macOS（Syphon Metal）の両方でエンドツーエンドの動作を確認済みです。macOS ではレシーバーがフレームごとに新しい `IOSurfaceRef` を発行し、レシーバーごとのステージング用 `MTLTexture` を経由して小さなレンダーパスで Y 反転を行うため、`drawImage(videoFrame)` / `importExternalTexture({ source: videoFrame })` の結果が正しい向きで表示されます。同じ `closeNativeHandle()` の所有権契約が両プラットフォームに適用されます。
+
+## メインプロセス: `createSharedTextureReceiver`
+
+```typescript
+// main process
+import { app, BrowserWindow } from "electron";
+import { createSharedTextureReceiver } from "@napolab/texture-bridge-renderer";
+
+app.whenReady().then(() => {
+  const receiverWindow = new BrowserWindow({
+    width: 960,
+    height: 540,
+    webPreferences: {
+      preload: /* path to preload that installs the consumer */ undefined,
+    },
+  });
+
+  const bridge = createSharedTextureReceiver({
+    senderName: "Resolume Arena",   // required
+    target: receiverWindow.webContents,
+    pollIntervalMs: 8,              // optional, defaults to 16
+    appName: undefined,             // optional, macOS filter
+    serverUuid: undefined,          // optional, macOS UUID
+    extraArgs: [],                  // optional, forwarded to sendSharedTexture(..., ...args)
+  });
+
+  bridge.on("fps", (fps) => console.log(`[receiver] ${fps.toFixed(1)} fps`));
+  bridge.on("error", (err) => console.error("[receiver]", err.message));
+  bridge.on("disposed", () => console.log("[receiver] disposed"));
+
+  bridge.start();
+
+  receiverWindow.on("closed", () => {
+    bridge.dispose();   // stops polling, releases the native receiver, emits "disposed"
+  });
+});
+```
+
+このブリッジは drop-latest ポリシーで動作します。前回の `sendSharedTexture` がまだ処理中の状態で次のポーリングが発火した場合、そのティックはスキップされます。これにより main プロセス側で保持される import 済みテクスチャ参照は常に最大 1 個に抑えられ、レンダラーの処理が遅い場合でもフレームが積み上がるのを防ぎます。
+
+## レンダラープロセス: `installSharedTextureReceiver` + `consumeSharedTexture`
+
+```typescript
+// renderer process (or preload with nodeIntegration: true, contextIsolation: false)
+import {
+  installSharedTextureReceiver,
+  consumeSharedTexture,
+} from "@napolab/texture-bridge-renderer/client";
+
+// Call once at startup. Binds Electron's single
+// sharedTexture.setSharedTextureReceiver slot to an internal pool so multiple
+// consumers can coexist. Idempotent.
+installSharedTextureReceiver();
+
+const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+const ctx = canvas.getContext("2d")!;
+
+const registration = consumeSharedTexture({
+  onFrame: ({ textureId, videoFrame }) => {
+    if (canvas.width !== videoFrame.displayWidth) canvas.width = videoFrame.displayWidth;
+    if (canvas.height !== videoFrame.displayHeight) canvas.height = videoFrame.displayHeight;
+    // Zero-copy GPU blit in Chromium when the source is a shared-texture VideoFrame.
+    ctx.drawImage(videoFrame, 0, 0);
+  },
+  onError: (err) => console.error("[consumer]", err),
+});
+
+// registration.dispose();  // optional — removes this consumer from the pool
+```
+
+`videoFrame` は標準の Web `VideoFrame` です。WebGPU で使う場合は `drawImage` の代わりに `device.importExternalTexture({ source: videoFrame })` に渡してください — こちらの経路もゼロコピーです。`videoFrame.close()` を自分で呼ぶ**必要はありません**。ハンドラーが返す Promise が解決した後、consumer 側のラッパーが close します。
+
+## オプション: `TextureReceiver.receiveSharedTexture()` を直接ポーリングする
+
+自前のスケジューラと統合するなど、ポーリングループ自体を自分で駆動したい場合は、低レベルのプリミティブを使い、ハンドルを手動で `sharedTexture.importSharedTexture` に渡してください。
+
+```typescript
+import { TextureReceiver, closeNativeHandle } from "@napolab/texture-bridge";
+import { sharedTexture } from "electron";
+
+const receiver = new TextureReceiver("Resolume Arena");
+const frame = receiver.receiveSharedTexture();
+if (frame) {
+  const handle =
+    process.platform === "win32" ? { ntHandle: frame.handle } : { ioSurface: frame.handle };
+  try {
+    const imported = sharedTexture.importSharedTexture({
+      textureInfo: {
+        codedSize: { width: frame.width, height: frame.height },
+        handle,
+        pixelFormat: frame.pixelFormat,   // "bgra" | "rgba" | "rgbaf16"
+      },
+    });
+    // ... deliver `imported` via sendSharedTexture, then imported.release() ...
+  } catch (err) {
+    // importSharedTexture threw before taking ownership — release ourselves.
+    closeNativeHandle(frame.handle);
+    throw err;
+  }
+}
+```
+
+> **所有権契約。** `receiveSharedTexture()` が返す `SharedTextureFrame.handle` は、そのつど新しく発行されたネイティブハンドルです。`importSharedTexture` が成功すると、Electron がそのハンドルの所有権を引き受け、import 済みテクスチャが release されたタイミングで解放します。ハンドルが `importSharedTexture` に渡らない経路（未知のピクセルフォーマット、ターゲットが破棄済み、`importSharedTexture` が例外を投げた、フレームをスキップすると決めた、など）を通った場合は**必ず** `closeNativeHandle(frame.handle)` を呼んでください。呼ばないと、フレームごとに NT HANDLE（Windows）/ `IOSurfaceRef`（macOS）がリークします。
+
+## 利用可能なセンダーの検出
+
+```typescript
+import { listSenders } from "@napolab/texture-bridge-renderer";
+
+for (const s of listSenders()) {
+  console.log(s.name, s.appName ?? "", s.uuid ?? "");
+}
+// [{ name: "Resolume Arena", appName: "Resolume Arena", uuid: "..." }, ...]
+```
+
+継続的な変更通知が必要な場合は `SenderDiscovery` を使ってください（[API リファレンス](API.md#senderdiscovery)を参照）。
+
+## レンダラーのコンテキスト分離
+
+Electron の `sharedTexture` モジュールは、`electron` を実行時に解決できる main / renderer プロセスからのみアクセスできます。`@napolab/texture-bridge-renderer/client` を Vite 駆動のレンダラーから直接 import すると、dev のプリバンドル時に失敗することがあります（`path.join is not a function`）。これは Vite が `electron` の CJS モジュールをプリバンドルできないためです。回避方法は 2 つあります。
+
+1. **単純なケースでの推奨方法:** `installSharedTextureReceiver()` と `consumeSharedTexture()` を **preload スクリプト**（electron-vite / electron-builder が `externalizeDepsPlugin` でバンドルする）に置き、レシーバーウィンドウを `nodeIntegration: true, contextIsolation: false` で実行します。サンプルアプリはこの方式を採っています — [`packages/example/src/preload/receiver.ts`](../../packages/example/src/preload/receiver.ts) を参照してください。
+2. **コンテキスト分離を維持する場合:** consumer を preload 側でバインドし、各 `VideoFrame` を `window.postMessage(videoFrame, "*", [videoFrame])`（`VideoFrame` は transferable です）で分離された renderer world へ転送します。使用後は renderer 側で close してください。

--- a/docs/ja/SENDING.md
+++ b/docs/ja/SENDING.md
@@ -1,0 +1,155 @@
+# テクスチャの送信
+
+[README のクイックスタート](../../lang/ja/README.md#クイックスタート)の先にあるレシピ集です: 外部ページのキャプチャ、透過、低レベル Core API、DPI の正しさ、electron-vite との統合を扱います。
+
+## 外部ページのキャプチャ（`rendererUrl` + `webPreferences`）
+
+`rendererUrl` はローカル HTML に限りません。`http(s)://` の URL を渡せば、稼働中の Web ページ（例: YouTube の視聴ページ）をキャプチャして Syphon/Spout へ流せます。`webPreferences` はオフスクリーン `BrowserWindow` にマージされるので、`partition`（隔離済み/ログイン済みセッション）の指定、`autoplayPolicy` の緩和、サンドボックスの無効化などが可能です。
+
+```typescript
+const bridge = await createTextureBridge({
+  name: "WebCapture",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "https://www.youtube.com/watch?v=...",
+  preview: { enabled: true },            // プレビューウィンドウで即座に目視確認
+  webPreferences: {
+    partition: "persist:capture",        // 隔離セッション（Cookie/ログインがここに永続化）
+    autoplayPolicy: "no-user-gesture-required",
+    sandbox: false,
+  },
+});
+```
+
+## 透過での送信（`includeAlpha`）
+
+`includeAlpha: true` を渡すと、ページのピクセル単位のアルファが共有 BGRA テクスチャへ転送されます。VJ ソフトウェア（Resolume、VDMX など）はそのレイヤーを透過マスク付きのまま受け取れるため、他のレイヤーに重ねて合成できます。
+
+```typescript
+const bridge = await createTextureBridge({
+  name: "MyApp",
+  width: 1920,
+  height: 1080,
+  rendererUrl: "path/to/index.html",
+  includeAlpha: true,
+});
+```
+
+このフラグはオプトイン（デフォルト `false`）です。設定すると、`createTextureBridge` はオフスクリーン `BrowserWindow` を `transparent: true` と `backgroundColor: "#00000000"` 付きで構築します — Chromium のコンポジターが共有テクスチャへ透明な背景を出力するには、この 2 つのキーの両方が必要です。ページ自体も背景を透明にする必要があります。そうしないとアルファが上書きされます:
+
+```css
+html, body { background: transparent; }
+```
+
+1.0 以外のアルファで描画された WebGL/Canvas コンテンツ（あるいはパイプラインに応じて適切に無効化された premultiplied alpha）は、そのまま共有テクスチャのアルファチャンネルへ反映されます。
+
+
+## 低レベル: Core API
+
+パイプラインを完全に制御する場合は `@napolab/texture-bridge-core` を直接使用します。
+
+```typescript
+import { BrowserWindow } from "electron";
+import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
+
+const win = new BrowserWindow({
+  width: 1920,
+  height: 1080,
+  show: false,
+  webPreferences: {
+    offscreen: { useSharedTexture: true },
+  },
+});
+
+const sender = new TextureSender("MyApp", 1920, 1080);
+
+win.webContents.on("paint", (event) => {
+  const texture = event.texture;
+  if (!texture) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release?.(); // 重要: GPU メモリリークを防ぐため必ず release を呼ぶ
+  }
+});
+
+win.webContents.setFrameRate(60);
+```
+
+### Electron バージョン別の `paint` イベント形
+
+本ライブラリは **Electron 40+**（`useSharedTexture` paint イベントが入った最初のバージョン）を対象とします。現行 Electron（42+）ではリスナの引数は単一のイベントオブジェクトで、テクスチャの release メソッドは **非 optional** です：
+
+```typescript
+win.webContents.on("paint", (details) => {
+  const texture = details.texture;
+  if (texture === undefined) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release();   // Electron 42: 非 optional（古い型定義では `release?` だった）
+  }
+});
+```
+
+古い例にある `(event, dirtyRect, image, texture)` の分割代入は 40 以前の API で、現行 Electron の型に対しては型エラーになります。`electron@>=42` の型でビルドする場合は `release` のオプショナルチェーンを外してください。
+
+> ### macOS Retina と Windows DPI スケーリング (macOS Retina and Windows DPI scaling)
+>
+> ⚠️ **Electron 40 以下では黒画面・崩れた出力の最大の原因です。** オフスクリーンフレームバッファが要求した `width × height` とどう対応するかは Electron のバージョンによって変わります:
+>
+> - **Electron ≥ 41:** `createTextureBridge` が `webPreferences.offscreen.deviceScaleFactor` を `1` に固定するため、フレームバッファは常に厳密に `width × height` ピクセルになります — ディスプレイのスケーリングはテクスチャに影響しません。（`Electron 42` は OSR のデフォルトデバイススケールファクターを `1.0` に変更しました。このオプションが初めて存在する 41 から、ブリッジが明示的に設定しています。）`pixelExact` は自明に満たされ、実質的に no-op になります。macOS では検証済みですが、Windows のディスプレイスケーリングでの検証は未実施です（調査レポートに未解決項目として記載）— Windows でクランプが発生した場合はサイズを小さくするか、[プローブスクリプト](../../packages/renderer/scripts/osr-scale-probe.cjs)で検証してください。
+> - **Electron 40:** Chromium はオフスクリーン面を **DIP（デバイス非依存ピクセル）** でサイズ指定するため、共有テクスチャに渡されるフレームバッファは `width × height × display.scaleFactor` になります。macOS Retina ディスプレイ（scaleFactor 2）では `new TextureSender("X", 1280, 720)` と宣言したつもりが **2560×1440** のテクスチャを生成してしまいます。これを吸収するには `createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路で自分で DPR を処理してください。
+>
+> **低レベル core**（手動 `BrowserWindow` + `paint`）はどのバージョンでも吸収機構がありません — Electron ≥ 41 では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡し、Electron 40 ではセンダーの宣言サイズと実フレームバッファサイズの整合を自分で取ってください。
+
+## Electron 無しの最小サニティチェック
+
+`TextureSender.sendRgbaBuffer()` は Electron を**必要としません** — plain Node（例: `tsx`）から Syphon/Spout サーバを立てて生 RGBA を流せます。問題の切り分けに最速です。これが VJ アプリに映れば、ネイティブバインディングと Syphon/Spout の発行は健全で、問題は Electron OSR 側に確定できます。
+
+```typescript
+// sanity.ts — run with: npx tsx sanity.ts
+import { TextureSender, getPlatform } from "@napolab/texture-bridge-core";
+
+const W = 512;
+const H = 512;
+const sender = new TextureSender("CHECK", W, H);
+console.log(getPlatform(), sender.platform()); // e.g. "syphon-metal" "syphon-metal"
+
+const buf = Buffer.alloc(W * H * 4);
+let t = 0;
+setInterval(() => {
+  t += 1;
+  for (let i = 0; i < W * H; i++) {
+    buf[i * 4 + 0] = (i + t) & 0xff; // R
+    buf[i * 4 + 1] = (i * 2 + t) & 0xff; // G
+    buf[i * 4 + 2] = t & 0xff; // B
+    buf[i * 4 + 3] = 0xff; // A
+  }
+  sender.sendRgbaBuffer(buf, W, H);
+}, 1000 / 30);
+```
+
+VJ アプリ（または任意の Syphon/Spout モニタ）を開き、**CHECK** という名前のセンダーがアニメーションしているか確認します。`sendRgbaBuffer` は CPU→GPU コピーを伴うのでデバッグ/フォールバック用途であり、ゼロコピーの本番経路ではありませんが、「Electron が悪いのかブリッジが悪いのか」の切り分けに非常に有効です。
+
+## electron-vite（ESM）との統合
+
+アプリが ESM（`package.json` の `"type": "module"`）で **electron-vite** ビルドの場合、いくつかの統合上の注意点があります：
+
+- **ネイティブパッケージを external 化する。** `main` と `preload` の両方に `externalizeDepsPlugin()` を入れ、`.node` バイナリが bundle されないようにします：
+
+  ```typescript
+  // electron.vite.config.ts
+  import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+
+  export default defineConfig({
+    main: { plugins: [externalizeDepsPlugin()] },
+    preload: { plugins: [externalizeDepsPlugin()] },
+    renderer: {},
+  });
+  ```
+
+- **ESM モードでは preload は `.mjs` で排出される。** electron-vite は preload を `index.mjs`（`index.js` ではない）として出力するため、main からは `path.join(import.meta.dirname, "../preload/index.mjs")` のように参照します。古い `../preload/index.js` 参照は「preload not found」系の失敗になります。
+- **`import.meta.dirname` は electron-vite が自動注入**するので、自分の main コードに `__dirname` シムは不要です。
+- **プリビルドバイナリは `optionalDependencies` で解決される。** pnpm 10 では初回にネイティブパッケージのビルドを `onlyBuiltDependencies`（`pnpm.onlyBuiltDependencies` / `allowBuilds`）で承認する必要がある場合があります。
+- **プレビューは ESM でも動作する。** `createTextureBridge({ preview: { enabled: true } })` のアセット解決は ESM セーフです（renderer パッケージは ESM ビルドに `__dirname` シムを同梱）。`"type": "module"` 下でもプレビューウィンドウが開きます。

--- a/docs/ja/TROUBLESHOOTING.md
+++ b/docs/ja/TROUBLESHOOTING.md
@@ -1,0 +1,55 @@
+# トラブルシューティング
+
+## paint イベントが発火しない
+
+- `win.webContents.setFrameRate(60)` を設定しているか確認
+- `show: false` でも paint イベントは発火する
+- レンダラー/ワーカー内で `requestAnimationFrame` ループが動いているか確認
+
+## テクスチャが真っ黒
+
+- **DPR / Retina のサイズ不一致（最も多い）。** **Electron ≤ 40:** Retina ディスプレイや Windows のディスプレイスケーリング下では実フレームバッファが `width × height × scaleFactor` になり、論理サイズで宣言したセンダーと食い違ってレシーバーが黒/崩れになります。`createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路ではセンダーを実フレームバッファサイズで宣言するか自分で DPR を打ち消してください。**Electron ≥ 41:** `createTextureBridge` が OSR のデバイススケールファクターを `1` に固定するため、この不一致は発生しません — [移行ガイド: Electron 42 / OSR デバイススケール](MIGRATION.md#移行ガイド-electron-42--osr-デバイススケール)を参照してください。低レベル core 経路では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡してください。（[Retina/DPI の警告](SENDING.md)参照）。
+- **Electron とブリッジの切り分け**には[Electron 無しのサニティチェック](SENDING.md)を使ってください — `sendRgbaBuffer` が VJ アプリに映ればネイティブ側は健全で、問題は Electron OSR 経路にあります。
+- `preserveDrawingBuffer` は不要（Chromium のコンポジターが直接読み取る）
+- ピクセルフォーマットの不一致を確認：Chromium は BGRA を出力するので、レシーバー側も BGRA を期待しているか確認
+- `bridge.on("frameDropped", ...)` を購読する（または `sendTextureFromPaintEvent` の
+  戻り値を確認する）— `no-nt-handle` / `no-io-surface` の理由が継続する場合、
+  Chromium が共有可能な GPU ハンドルを配信していないことを意味し、
+  それ以外では黒画面としてのみ現れます。
+
+## Syphon レシーバーに表示されない（macOS）
+
+- `vendor/Syphon.framework` が正しい場所にあるか確認
+- Gatekeeper の隔離属性をクリア：`xattr -dr com.apple.quarantine vendor/Syphon.framework`
+- Console.app でエラーログを確認
+
+## Spout レシーバーに表示されない（Windows）
+
+- Spout2 がシステムにインストールされているか確認
+- GPU ドライバが最新か確認
+- DirectX 11 対応 GPU が必要
+
+## ゼロコピー共有テクスチャレシーバー
+
+- **Electron 40 以上が必要です** — `sharedTexture.importSharedTexture` / `sendSharedTexture` / `setSharedTextureReceiver` モジュールを使用します。それより古い Electron では import 時点で例外を投げます。
+- **`listSenders()` に `<sender>_1` のような接尾辞が付く。** 同名の前回のセンダープロセスが正常終了せず、その共有メモリのディレクトリエントリが残っている状態です。実際のセンダーを起動（または再起動）してください — きれいな名前を再取得するか、次回の publisher サイクルで接尾辞付きのエントリが自然に消えます。
+- **対象ウィンドウが閉じた後のハンドルリーク。** `receiveSharedTexture()` を直接ポーリングする場合は、ハンドルを `sharedTexture.importSharedTexture` に渡さない全ての経路——「ターゲットが破棄済み」「未知のピクセルフォーマット」「このフレームを破棄すると決めた」を含む——で必ず `closeNativeHandle(frame.handle)` を呼んでください。`createSharedTextureReceiver` はこれを自動的に行います。
+- **Windows のステージングテクスチャ。** レシーバーはステージングテクスチャを `MISC_SHARED_NTHANDLE | MISC_SHARED`（キーミューテックスなし）で作成するため、consumer 側はフレームごとに `AcquireSync` を呼ぶ必要がありません — Electron が直接 import します。
+
+## フリーズ / paint イベントが停止する
+
+- **テクスチャ処理後は必ず `texture.release()` を呼ぶこと。** テクスチャプールは数フレーム分しかありません。release を呼ばないとプールが枯渇し、paint イベントパイプラインが停止します。
+- `createTextureBridge()` 使用時は自動的に処理されます。
+- 低レベルの core API 使用時は `try/finally` で確実に release を呼ぶ：
+
+```typescript
+win.webContents.on("paint", (event) => {
+  const texture = event.texture;
+  if (!texture) return;
+  try {
+    sendTextureFromPaintEvent(sender, texture.textureInfo);
+  } finally {
+    texture.release?.();
+  }
+});
+```

--- a/lang/ja/README.md
+++ b/lang/ja/README.md
@@ -3,19 +3,21 @@
 [![CI](https://github.com/naporin0624/electron-texture-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/naporin0624/electron-texture-bridge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 
-**Electron から VJ ソフトウェアへ GPU ゼロコピーでテクスチャを共有する Spout / Syphon Metal ブリッジ**
+**Electron と VJ ソフトウェア間で Spout / Syphon Metal を介して双方向に GPU テクスチャを共有する。**
 
 [English](../../README.md)
 
-Electron のオフスクリーンレンダリング（`useSharedTexture`）から GPU テクスチャをキャプチャし、Resolume Arena、VDMX、OBS、TouchDesigner などの Syphon/Spout 対応アプリケーションへ CPU リードバックなしで共有する napi-rs ネイティブアドオンです。
+Electron との双方向 GPU テクスチャ共有のための napi-rs ネイティブアドオンです。Electron のオフスクリーンレンダリング（`useSharedTexture`）からテクスチャを**送信**して VJ ソフトウェアへ渡す、あるいは外部の Syphon/Spout サーバーからテクスチャを**受信**して Electron アプリに取り込む、どちらにも対応します。Resolume Arena、VDMX、OBS、TouchDesigner など、Syphon/Spout 対応のアプリケーションと連携できます。
 
 ## インストール
 
 ```bash
 npm i @napolab/texture-bridge-renderer
+# または
+pnpm add @napolab/texture-bridge-renderer
 ```
 
-実体は複数の `@napolab/*` パッケージとして公開されています：
+このパッケージ 1 つで依存チェーン全体（プリビルド済みネイティブバイナリを含む）が入ります。通常はこれだけに依存すれば十分です。
 
 | 用途 | パッケージ | 提供するもの |
 |------|-----------|-------------|
@@ -24,154 +26,60 @@ npm i @napolab/texture-bridge-renderer
 | ネイティブバインディング | [`@napolab/texture-bridge`](https://www.npmjs.com/package/@napolab/texture-bridge) | napi-rs の生クラス（`TextureSender`, `TextureReceiver`） |
 | プリビルドバイナリ | `@napolab/texture-bridge-darwin-arm64` 他 | プラットフォーム別 `.node`。`optionalDependencies` で自動解決 |
 
-依存方向: `texture-bridge-renderer` → `texture-bridge-core` → `texture-bridge` → `texture-bridge-<platform>`。`-renderer` を入れれば連鎖がすべて入るので、通常は1パッケージに依存するだけで済みます。
+依存方向: `texture-bridge-renderer` → `texture-bridge-core` → `texture-bridge` → `texture-bridge-<platform>`。
 
-## どの API を使うべきか
+> ソースからのビルド、前提条件の詳細、パッケージング、統合の手順は **[docs/ja/INSTALLATION.md](../../docs/ja/INSTALLATION.md)** を参照してください。
 
-```
-OSR(useSharedTexture) を Syphon/Spout に出したいだけで、ウィンドウ管理もライブラリに任せたい？
-  YES → createTextureBridge()  (@napolab/texture-bridge-renderer)
-        BrowserWindow・paint 配線・DPR/pixelExact・プレビュー・FPS まで面倒を見る。まずここから。
+## AI Agent Skills
 
-自前の BrowserWindow / paint ループに後付けで送信だけ足したい？
-  YES → TextureSender + sendTextureFromPaintEvent()  (@napolab/texture-bridge-core)
-        DPR の整合は自分で担保する（後述の「macOS Retina / Windows DPI」警告を参照）。
+このリポジトリには、コーディングエージェントにこのライブラリの実際の API 表面を教える **エージェントスキル** が同梱されています。
 
-Electron 無しで生 RGBA を流したい（テスト / CI / サニティチェック）？
-  YES → new TextureSender(...).sendRgbaBuffer()  (@napolab/texture-bridge-core)
-        後述の「Electron 無しの最小サニティチェック」を参照。
-```
+これらが存在する理由は、texture-bridge をこれらのスキルなしで統合しようとしたモデルが、一貫して実在しない「もっともらしい」API（`publishSharedTexture`、`subscribeFrames`、定義されたことのないオプションオブジェクトなど）をでっち上げるからです。各スキルはこうした実観測された失敗に対してテストファーストで書かれ、エージェントが実際の API を出力するようになることを検証済みです。
 
-### パッケージの役割と依存方向
+### Claude Code（プラグイン）
 
 ```
-@napolab/texture-bridge-renderer   高レベルファクトリ API（推奨）: createTextureBridge、
-        │                          レシーバー、ディスカバリ、プレビュー
-        ▼
-@napolab/texture-bridge-core       低レベルプリミティブ: TextureSender / TextureReceiver、
-        │                          sendTextureFromPaintEvent — Electron はオプション
-        ▼
-@napolab/texture-bridge            ネイティブアドオン（napi-rs バインディング）
-        │
-        ▼
-@napolab/texture-bridge-darwin-arm64 / -darwin-x64 / -win32-x64-msvc
-                                   プリビルド済みプラットフォームバイナリ（自動インストール）
+/plugin marketplace add naporin0624/electron-texture-bridge
+/plugin install texture-bridge
 ```
 
-## アーキテクチャ
+### その他のエージェント（Skills CLI）
 
-```
-[Web Worker]              [Chromium GPU Process]         [Native Addon]         [外部アプリ]
- Three.js / WebGL  ──→   Compositor (Metal / D3D11) ──→  texture-bridge  ──→   Resolume Arena
- OffscreenCanvas          Shared Texture (GPU)            Spout / Syphon        VDMX, OBS 等
-```
-
-全パイプラインが GPU 上で完結。CPU リードバックなし。サブフレームレイテンシ。
-
-## 特徴
-
-- **GPU ゼロコピー**: IOSurface（macOS）または DXGI Shared Handle（Windows）を介して GPU 上で直接テクスチャを共有
-- **クロスプラットフォーム**: macOS は Syphon Metal、Windows は Spout
-- **Electron ネイティブ対応**: Electron 40+ の `useSharedTexture` paint イベント API 向けに設計
-- **WebGPU プレビュー**: `importExternalTexture` を使用したゼロコピープレビューウィンドウ（オプション）
-- **ファクトリ API**: `createTextureBridge()` がオフスクリーンウィンドウ・paint イベント・プレビュー・FPS 計測をすべて自動化
-- **低レベル API**: `sendTextureFromPaintEvent()` でパイプラインの完全な制御も可能
-- **napi-rs**: 型安全な Rust → Node.js バインディング（プリビルドバイナリ付き）
-
-## 対応プラットフォーム
-
-| プラットフォーム | プロトコル | GPU API | ターゲット |
-|----------|----------|---------|--------|
-| macOS (Apple Silicon) | Syphon Metal | IOSurface + Metal | `aarch64-apple-darwin` |
-| macOS (Intel) | Syphon Metal | IOSurface + Metal | `x86_64-apple-darwin` |
-| Windows x64 | Spout | DXGI Shared Handle + D3D11 | `x86_64-pc-windows-msvc` |
-
-## 必要要件
-
-- **Node.js** 20+
-- **pnpm** 10+
-- **Rust** ツールチェーン（[rustup](https://rustup.rs/) 経由）
-- **Electron** 40.0.0+
-
-### macOS
-
-- Xcode Command Line Tools
-- macOS 11.0+（Metal サポート）
-
-### Windows
-
-- Visual Studio Build Tools 2019+（「C++ によるデスクトップ開発」ワークロード）
-- Windows SDK 10.0.19041.0+
-- DirectX 11 対応 GPU
-
-## インストール
-
-> **詳細ガイド:** 前提条件、ソースからのビルド、プロジェクト統合、パッケージング、トラブルシューティングの詳細は [docs/ja/INSTALLATION.md](../../docs/ja/INSTALLATION.md) を参照してください。
-
-### ライブラリとして使用（推奨）
+Codex、GitHub Copilot、Amp、Cursor、Antigravity など、[skills.sh](https://skills.sh/naporin0624/electron-texture-bridge) 経由で動作します。**1 コマンドにつき 1 スキルをインストールしてください** — 複数を一度に渡しても最初の 1 つしかインストールされません:
 
 ```bash
-npm install @napolab/texture-bridge-renderer
-# または
-pnpm add @napolab/texture-bridge-renderer
+npx skills add naporin0624/electron-texture-bridge@setting-up-texture-bridge
+npx skills add naporin0624/electron-texture-bridge@choosing-texture-bridge-api
+npx skills add naporin0624/electron-texture-bridge@migrating-to-forward-frames
+npx skills add naporin0624/electron-texture-bridge@receiving-shared-textures
+npx skills add naporin0624/electron-texture-bridge@managing-frame-forward-lifecycle
+npx skills add naporin0624/electron-texture-bridge@delivering-imported-textures
+npx skills add naporin0624/electron-texture-bridge@handling-texture-bridge-failures
 ```
 
-`@napolab/texture-bridge-renderer` がほとんどのユーザー向けの高レベルパッケージです。`@napolab/texture-bridge-core` と `@napolab/texture-bridge` を依存関係として含みます。
+グローバルにインストールする場合は `-g` を付けてください。
 
-パイプラインを直接制御したい場合：
+> `@skill-name` サフィックスを省略すると、texture-bridge とは無関係なこのリポジトリ自身の内部開発ルール用スキル（`ci`、`smart-commit` など）を含む、リポジトリ内の **すべての** スキルがインストールされます。目的のスキル名を明示してください。
 
-```bash
-npm install @napolab/texture-bridge-core
-```
+### 各スキルが担う範囲
 
-### ソースからビルド
+スキルは会話の文脈から自動的に発火します — 覚えるべきコマンドはありません。
 
-```bash
-# サブモジュール（Syphon ソース）を含めてクローン
-git clone --recursive https://github.com/naporin0624/electron-texture-bridge.git
-cd electron-texture-bridge
-```
-
-#### macOS: Syphon Framework のビルド
-
-```bash
-cd vendor/syphon-src
-xcodebuild -project Syphon.xcodeproj \
-  -scheme Syphon \
-  -configuration Release \
-  -derivedDataPath build \
-  ONLY_ACTIVE_ARCH=NO \
-  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-cp -R build/Build/Products/Release/Syphon.framework ../Syphon.framework
-cd ../..
-```
-
-#### Windows: Spout2 SDK の取得
-
-ネイティブアドオンは `SpoutDX/`（C++ ラッパー）と `SpoutGL/`（`SpoutDX.h` が相対
-include する共有メモリ/D3D ヘルパー）の両方をビルドするため、Spout2 のサブディレクトリ
-構造を `vendor/Spout2/` 配下にそのまま保持してください：
-
-```powershell
-git clone --depth 1 https://github.com/leadedge/Spout2.git _spout2_tmp
-New-Item -ItemType Directory -Force vendor/Spout2 | Out-Null
-Copy-Item -Recurse _spout2_tmp/SPOUTSDK/SpoutDirectX vendor/Spout2/SpoutDirectX
-Copy-Item -Recurse _spout2_tmp/SPOUTSDK/SpoutGL vendor/Spout2/SpoutGL
-Remove-Item -Recurse -Force _spout2_tmp
-```
-
-#### ビルド
-
-```bash
-pnpm install
-pnpm build          # ネイティブアドオン + core + renderer パッケージをビルド
-```
+| スキル | 発火する場面 |
+|-------|--------------------------|
+| `setting-up-texture-bridge` | ライブラリのインストール、Electron アプリへの Syphon/Spout 出力の追加、electron-vite 設定、セットアップ直後の黒画面/崩れた出力 |
+| `choosing-texture-bridge-api` | どの API 階層を使うか — simple vs core、`forwardSharedTexture` vs `forwardFrames`、送信経路 vs 受信経路 — および統合計画のレビュー |
+| `migrating-to-forward-frames` | `capturePage` ポーリング / bitmap-IPC プレビュー / Syphon ループバックをゼロコピー転送に置き換える |
+| `receiving-shared-textures` | 受信側: 転送されたフレームの消費、マルチビューアグリッド、`VideoFrame` のライフサイクル、切断後にフレームが再表示される問題 |
+| `managing-frame-forward-lifecycle` | `forwardFrames` ターゲットの登録・解除: 開閉を繰り返すモニターウィンドウ、繰り返される接続/切断、`MaxListenersExceededWarning`、転送まわりのリーク |
+| `delivering-imported-textures` | main からレンダラーへのテクスチャ配送: `importSharedTexture` / `sendSharedTexture` / `release()` を手動で扱う、`release()` をどこに置くべきか、`sendImportedTexture` vs `forwardSharedTexture` |
+| `handling-texture-bridge-failures` | エラーハンドリングとテレメトリ: どの呼び出しが throw/reject するか、defect としてモデル化されるか、emit されるか — `Result.fromThrowable` で何を包むべきか、無音の黒画面、ブリッジ呼び出しによる main プロセスのクラッシュ |
 
 ## クイックスタート
 
-### 高レベル: ファクトリ API（推奨）
+### 送信: Electron → VJ ソフトウェア
 
-electron-texture-bridge を最も簡単に使う方法です。ファクトリがオフスクリーンウィンドウの作成、paint イベントの接続、Syphon/Spout センダー、オプションのプレビューウィンドウをすべて1回の呼び出しで処理します。
+ファクトリがオフスクリーンウィンドウの作成、paint イベントの接続、Syphon/Spout センダー、オプションのプレビューウィンドウをすべて 1 回の呼び出しで処理します。
 
 ```typescript
 // メインプロセス
@@ -206,421 +114,173 @@ app.whenReady().then(async () => {
 </script>
 ```
 
-### 外部ページのキャプチャ（`rendererUrl` + `webPreferences`）
+外部ページのライブキャプチャ、透過（`includeAlpha`）、低レベル core の paint ループ、DPI の正確な扱い、electron-vite（ESM）統合など、送信に関するさらなるレシピは **[docs/ja/SENDING.md](../../docs/ja/SENDING.md)** にあります。
 
-`rendererUrl` はローカル HTML に限りません。`http(s)://` の URL を渡せば、稼働中の Web ページ（例: YouTube の視聴ページ）をキャプチャして Syphon/Spout へ流せます。`webPreferences` はオフスクリーン `BrowserWindow` にマージされるので、`partition`（隔離済み/ログイン済みセッション）の指定、`autoplayPolicy` の緩和、サンドボックスの無効化などが可能です。
+### 受信: VJ ソフトウェア → Electron
 
-```typescript
-const bridge = await createTextureBridge({
-  name: "WebCapture",
-  width: 1920,
-  height: 1080,
-  rendererUrl: "https://www.youtube.com/watch?v=...",
-  preview: { enabled: true },            // プレビューウィンドウで即座に目視確認
-  webPreferences: {
-    partition: "persist:capture",        // 隔離セッション（Cookie/ログインがここに永続化）
-    autoplayPolicy: "no-user-gesture-required",
-    sandbox: false,
-  },
-});
-```
-
-### 低レベル: Core API
-
-パイプラインを完全に制御する場合は `@napolab/texture-bridge-core` を直接使用します。
+外部の Syphon/Spout サーバーからテクスチャを取得して Electron アプリに取り込みます。
 
 ```typescript
-import { BrowserWindow } from "electron";
-import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
+// メインプロセス
+import { app } from "electron";
+import { createTextureReceiver, SenderDiscovery } from "@napolab/texture-bridge-renderer";
 
-const win = new BrowserWindow({
-  width: 1920,
-  height: 1080,
-  show: false,
-  webPreferences: {
-    offscreen: { useSharedTexture: true },
-  },
-});
-
-const sender = new TextureSender("MyApp", 1920, 1080);
-
-win.webContents.on("paint", (event) => {
-  const texture = event.texture;
-  if (!texture) return;
-  try {
-    sendTextureFromPaintEvent(sender, texture.textureInfo);
-  } finally {
-    texture.release?.(); // 重要: GPU メモリリークを防ぐため必ず release を呼ぶ
-  }
-});
-
-win.webContents.setFrameRate(60);
-```
-
-#### Electron バージョン別の `paint` イベント形
-
-本ライブラリは **Electron 40+**（`useSharedTexture` paint イベントが入った最初のバージョン）を対象とします。現行 Electron（42+）ではリスナの引数は単一のイベントオブジェクトで、テクスチャの release メソッドは **非 optional** です：
-
-```typescript
-win.webContents.on("paint", (details) => {
-  const texture = details.texture;
-  if (texture === undefined) return;
-  try {
-    sendTextureFromPaintEvent(sender, texture.textureInfo);
-  } finally {
-    texture.release();   // Electron 42: 非 optional（古い型定義では `release?` だった）
-  }
-});
-```
-
-古い例にある `(event, dirtyRect, image, texture)` の分割代入は 40 以前の API で、現行 Electron の型に対しては型エラーになります。`electron@>=42` の型でビルドする場合は `release` のオプショナルチェーンを外してください。
-
-> ### macOS Retina と Windows DPI スケーリング
->
-> ⚠️ **Electron 40 以下では黒画面・崩れた出力の最大の原因です。** オフスクリーンフレームバッファが要求した `width × height` とどう対応するかは Electron のバージョンによって変わります:
->
-> - **Electron ≥ 41:** `createTextureBridge` が `webPreferences.offscreen.deviceScaleFactor` を `1` に固定するため、フレームバッファは常に厳密に `width × height` ピクセルになります — ディスプレイのスケーリングはテクスチャに影響しません。（`Electron 42` は OSR のデフォルトデバイススケールファクターを `1.0` に変更しました。このオプションが初めて存在する 41 から、ブリッジが明示的に設定しています。）`pixelExact` は自明に満たされ、実質的に no-op になります。macOS では検証済みですが、Windows のディスプレイスケーリングでの検証は未実施です（調査レポートに未解決項目として記載）— Windows でクランプが発生した場合はサイズを小さくするか、[プローブスクリプト](../../packages/renderer/scripts/osr-scale-probe.cjs)で検証してください。
-> - **Electron 40:** Chromium はオフスクリーン面を **DIP（デバイス非依存ピクセル）** でサイズ指定するため、共有テクスチャに渡されるフレームバッファは `width × height × display.scaleFactor` になります。macOS Retina ディスプレイ（scaleFactor 2）では `new TextureSender("X", 1280, 720)` と宣言したつもりが **2560×1440** のテクスチャを生成してしまいます。これを吸収するには `createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路で自分で DPR を処理してください。
->
-> **低レベル core**（手動 `BrowserWindow` + `paint`）はどのバージョンでも吸収機構がありません — Electron ≥ 41 では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡し、Electron 40 ではセンダーの宣言サイズと実フレームバッファサイズの整合を自分で取ってください。
-
-### Electron 無しの最小サニティチェック
-
-`TextureSender.sendRgbaBuffer()` は Electron を**必要としません** — plain Node（例: `tsx`）から Syphon/Spout サーバを立てて生 RGBA を流せます。問題の切り分けに最速です。これが VJ アプリに映れば、ネイティブバインディングと Syphon/Spout の発行は健全で、問題は Electron OSR 側に確定できます。
-
-```typescript
-// sanity.ts — 実行: npx tsx sanity.ts
-import { TextureSender, getPlatform } from "@napolab/texture-bridge-core";
-
-const W = 512;
-const H = 512;
-const sender = new TextureSender("CHECK", W, H);
-console.log(getPlatform(), sender.platform()); // 例: "syphon-metal" "syphon-metal"
-
-const buf = Buffer.alloc(W * H * 4);
-let t = 0;
-setInterval(() => {
-  t += 1;
-  for (let i = 0; i < W * H; i++) {
-    buf[i * 4 + 0] = (i + t) & 0xff; // R
-    buf[i * 4 + 1] = (i * 2 + t) & 0xff; // G
-    buf[i * 4 + 2] = t & 0xff; // B
-    buf[i * 4 + 3] = 0xff; // A
-  }
-  sender.sendRgbaBuffer(buf, W, H);
-}, 1000 / 30);
-```
-
-VJ アプリ（または任意の Syphon/Spout モニタ）を開き、**CHECK** という名前のセンダーがアニメーションしているか確認します。`sendRgbaBuffer` は CPU→GPU コピーを伴うのでデバッグ/フォールバック用途であり、ゼロコピーの本番経路ではありませんが、「Electron が悪いのかブリッジが悪いのか」の切り分けに非常に有効です。
-
-## electron-vite（ESM）との統合
-
-アプリが ESM（`package.json` の `"type": "module"`）で **electron-vite** ビルドの場合、いくつかの統合上の注意点があります：
-
-- **ネイティブパッケージを external 化する。** `main` と `preload` の両方に `externalizeDepsPlugin()` を入れ、`.node` バイナリが bundle されないようにします：
-
-  ```typescript
-  // electron.vite.config.ts
-  import { defineConfig, externalizeDepsPlugin } from "electron-vite";
-
-  export default defineConfig({
-    main: { plugins: [externalizeDepsPlugin()] },
-    preload: { plugins: [externalizeDepsPlugin()] },
-    renderer: {},
+app.whenReady().then(() => {
+  // 利用可能なサーバーを検出
+  const discovery = new SenderDiscovery();
+  discovery.on("added", (senders) => {
+    console.log("New senders:", senders);
   });
-  ```
+  discovery.start(1000); // 1 秒ごとにポーリング
 
-- **ESM モードでは preload は `.mjs` で排出される。** electron-vite は preload を `index.mjs`（`index.js` ではない）として出力するため、main からは `path.join(import.meta.dirname, "../preload/index.mjs")` のように参照します。古い `../preload/index.js` 参照は「preload not found」系の失敗になります。
-- **`import.meta.dirname` は electron-vite が自動注入**するので、自分の main コードに `__dirname` シムは不要です。
-- **プリビルドバイナリは `optionalDependencies` で解決される。** pnpm 10 では初回にネイティブパッケージのビルドを `onlyBuiltDependencies`（`pnpm.onlyBuiltDependencies` / `allowBuilds`）で承認する必要がある場合があります。
-- **プレビューは ESM でも動作する。** `createTextureBridge({ preview: { enabled: true } })` のアセット解決は ESM セーフです（renderer パッケージは ESM ビルドに `__dirname` シムを同梱）。`"type": "module"` 下でもプレビューウィンドウが開きます。
+  // 特定のサーバーから受信
+  const receiver = createTextureReceiver({
+    senderName: "Resolume Arena",
+  });
 
-## API リファレンス
+  receiver.on("frame", (frame) => {
+    // frame: { data: Buffer, width: number, height: number }
+    console.log(`Received ${frame.width}x${frame.height} frame`);
+  });
 
-### `@napolab/texture-bridge-renderer`
+  receiver.on("fps", (fps) => console.log(`Receive FPS: ${fps.toFixed(1)}`));
+  receiver.start();
 
-#### `createTextureBridge(options): Promise<TextureBridge>`
-
-完全に接続されたテクスチャブリッジを作成するファクトリ関数。`app.whenReady()` の後に呼び出す必要があります。
-
-```typescript
-interface TextureBridgeOptions {
-  name: string;            // Syphon/Spout センダー名
-  width: number;           // テクスチャ幅（ピクセル）
-  height: number;          // テクスチャ高さ（ピクセル）
-  frameRate?: number;      // 目標フレームレート（デフォルト: 60）
-  rendererUrl: string;     // 読み込む URL（ファイルパス、file://、http://）
-  preview?: PreviewOptions;
-  webPreferences?: Electron.WebPreferences;
-  pixelExact?: boolean;    // ディスプレイ DPR に関係なくフレームバッファを正確に width×height に固定（デフォルト: false）
-}
-
-interface PreviewOptions {
-  enabled?: boolean;       // プレビューウィンドウを開く（デフォルト: false）
-  width?: number;          // プレビューウィンドウ幅
-  height?: number;         // プレビューウィンドウ高さ
-  title?: string;          // プレビューウィンドウタイトル
-}
-```
-
-**`pixelExact`** — `true` のとき、ホストディスプレイの DPR に関係なくオフスクリーンフレームバッファを正確に `width × height` ピクセルに固定します。**Electron ≥ 41:** 自明に満たされ実質的に no-op です — `createTextureBridge` がすでに `offscreen.deviceScaleFactor: 1` を固定しているため、このオプションの有無に関わらずフレームバッファは常に正確です。**Electron 40:** 指定しないと Retina（scaleFactor 2）や Windows スケーリング（150% / 175%）のディスプレイでは宣言したセンダーサイズより大きいフレームバッファが生成され、多くの場合レシーバーで黒画面/崩れになります（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。センダーは常に要求ピクセルサイズで登録されるため、レシーバーは指定どおりの寸法を受け取ります。注意: 割り切れないスケール比（例: `1920 / 1.75`）では 1 ピクセルの誤差が残ることがあり、構築時のプライマリディスプレイの scaleFactor のみが反映されます — DPI 変更後は `resize()` で再適用してください。
-
-#### `createTextureBridgeWith(deps)`（上級者向け）
-
-```typescript
-interface TextureBridgeDeps {
-  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
-  createSender: (name: string, width: number, height: number) => TextureSender;
-}
-
-function createTextureBridgeWith(
-  deps: TextureBridgeDeps,
-): (options: TextureBridgeOptions) => Promise<TextureBridge>;
-```
-
-注入されたコンストラクタに束縛された `createTextureBridge` を返します —
-テストや組み込み側が `BrowserWindow` の構築や、ネイティブ `TextureSender` の
-構築をテストダブルに差し替えられるようにするためのものです。
-`createTextureBridge` 自体も、実際の `BrowserWindow` / `TextureSender` に束縛した
-`createTextureBridgeWith` にすぎません。ファクトリは Electron の `app` / `screen`
-グローバルを引き続き直接参照し、プレビューウィンドウも自前で構築します
-（`PreviewManager`）— このシームはウィンドウ / センダーの構築のみを注入可能にし、
-ファクトリ全体を Electron 非依存にするものではありません。完全に Electron 無しの
-テスト環境が必要な場合は、`app` / `screen` を別途モックしてください。
-
-#### `TextureBridge`
-
-返されるハンドル：
-
-```typescript
-interface TextureBridge {
-  on(event: "fps", listener: (fps: number) => void): this;
-  on(event: "ready", listener: () => void): this;
-  on(event: "error", listener: (error: Error) => void): this;
-  on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
-  on(event: "resize", listener: (width: number, height: number) => void): this;
-  on(event: "disposed", listener: () => void): this;
-
-  resize(width: number, height: number): void;  // 全レイヤー + Worker にカスケード
-  openPreview(): void;
-  closePreview(): void;
-  forwardFrames(target: WebContents, options?: FrameForwardOptions): FrameForward;
-  dispose(): void;
-
-  readonly renderWindow: BrowserWindow;
-  readonly previewWindow: BrowserWindow | null;
-  readonly isDisposed: boolean;
-  readonly droppedReason: PaintDefect["reason"] | null;
-}
-```
-
-`frameDropped` は、paint フレームがセンダーに届く前にドロップされたときに発火します
-（`reason`: `"no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform"`）。
-エラーではありませんが、継続的に発火する場合はレシーバー側で黒画面になります。
-同じ理由が連続する場合はデデュープされます：イベントは最初の発生時に一度発火し、
-成功した送信または理由の変化があった後に再び発火します。リスナーをアタッチする前に
-ドロップが確定していた場合（例: レンダラーページがまだロード中の場合）は、
-`bridge.droppedReason` を読んでください — 最新のドロップ理由、または成功した送信の後は
-`null` を保持します。
-
-`dispose()` は、オフスクリーンの `renderWindow` を `close()` ではなく
-`destroy()` で同期的に破棄します。これにより、Electron の `before-quit` との
-競合でクラッシュダイアログが出るリスクがなくなります。ここから 2 点が
-帰結します:
-
-- **`disposed` リスナーで `bridge.renderWindow.webContents` に触れてはいけません** —
-  `disposed` が発火する時点で、オフスクリーンウィンドウはすでに破棄済みです。
-- **レンダーウィンドウの `close` イベントと、ページの `beforeunload`/`unload`
-  ハンドラはもう発火しません** — これは `destroy()` の仕様どおりの挙動です。
-  `closed` イベントは引き続き発火します。
-
-プレビューウィンドウは影響を受けません: 実在する可視ウィンドウであり、
-引き続き `close()` により通常のクローズセマンティクスで閉じます。以前、
-旧来の非同期な `close()` を避けるため `bridge.dispose()` の後に自前で
-`bridge.renderWindow.destroy()` を呼ぶワークアラウンドをしていた場合は、
-**その外部からの `destroy()` 呼び出しを削除してください** — `dispose()` が
-今はそれを内部で行うため、`dispose()` の後に呼ぶとすでに破棄済みのウィンドウ
-に対して呼び出すことになり、Electron は二重の `destroy()` が安全であることを
-保証していません（"Object has been destroyed" で例外になり得ます）。ライブラリ
-側のガードは `dispose()` 内部の呼び出しのみを保護するものであり、`dispose()`
-呼び出し後に外部から呼ばれる `destroy()` までは保護しません。すぐに削除できない
-場合は、自分でガードする
-（`if (!bridge.renderWindow.isDestroyed()) bridge.renderWindow.destroy();`）か、
-`dispose()` より前に呼び出すようにしてください。
-
-#### `TextureBridge.forwardFrames(target, options?)`
-
-```typescript
-const forward = bridge.forwardFrames(monitorWindow.webContents, { extraArgs: [slot] });
-// 後で
-forward.dispose(); // 冪等
-```
-
-`WebContents`（モニター/マルチビューアウィンドウなど）を登録し、以降すべての paint フレームを `forwardSharedTexture` と同じゼロコピーの shared-texture 経路で受け取れるようにします — ピクセル readback はなく、GPU ハンドルの受け渡しのみです。
-
-**ベストエフォート契約** はプレビュー経路と同一です: 転送失敗（core の `forwardSharedTexture` primitive が返す `ForwardDefect`）はこの driver が握り潰し、`"error"` イベントや `frameDropped` / `droppedReason` を汚しません。**ネイティブの Syphon/Spout 送信からは独立** しています — paint ハンドラ内で転送は `sendTextureFromPaintEvent` より先に実行されるため、ネイティブ送信が throw しても登録済みの転送を止められませんし、転送側の失敗がネイティブ送信をブロックすることもありません。両者は互いの結果と無関係に発火します。
-
-`FrameForward.dispose()` はその 1 件の登録だけを解除し、冪等です — 2 回呼んでも、あるいは `bridge.dispose()` が先に全登録を解除した後に呼んでも no-op です。`bridge.dispose()` は登録済みの転送をすべて解除します。
-
-受け取り側は新たに何も必要ありません: 転送先の target は Syphon/Spout レシーバーとまったく同じ方法でフレームを受け取ります — renderer 起動時に一度 `installSharedTextureReceiver()` を呼び、`consumeSharedTexture({ onFrame: (frame, ...extraArgs) => ... })` で受信します。`forwardFrames(target, { extraArgs })` に渡した `extraArgs` はハンドラの末尾引数としてそのまま届くため、1 つの target が複数ソースからの転送を（例えばスロット番号で）判別できます。
-
-現在の実装は、フレームごとに登録済み target の数だけテクスチャを import します。複数 target が同一ソースフレームを共有する場合は「フレームごとに import は 1 回 → 全 target へ send → 全 send の settle 後に release」へ最適化する余地がありますが、現時点でその需要のある呼び出し元がないため（multiviewer は 1 ソース = 1 target）、将来のオプションとして記録するに留め、実装はしていません。
-
-#### `createWorkerRenderer(options)`（`renderer/client` から）
-
-キャンバスから Worker へのパイプラインを設定するレンダラープロセス用ヘルパー。ResizeObserver による自動リサイズ伝播付き。
-
-```typescript
-import { createWorkerRenderer } from "@napolab/texture-bridge-renderer/client";
-
-createWorkerRenderer({
-  worker: new MyWorker(),
-  width: 1920,
-  height: 1080,
+  // クリーンアップ
+  // receiver.dispose();
+  // discovery.dispose();
 });
 ```
 
-#### Worker プロトコル型（`renderer/worker` から）
+この例は **RGBA readback** 経路を使用しています。**ゼロコピー GPU** 経路（`createSharedTextureReceiver`、`consumeSharedTexture`、レンダラーのコンテキスト分離）については **[docs/ja/RECEIVING.md](../../docs/ja/RECEIVING.md)** を参照してください。
 
-```typescript
-import type { WorkerMessage } from "@napolab/texture-bridge-renderer/worker";
+## どの API を使うべきか
 
-// Worker 内:
-self.onmessage = (e: MessageEvent<WorkerMessage>) => {
-  switch (e.data.type) {
-    case "init":   /* e.data.canvas: OffscreenCanvas */ break;
-    case "resize": /* e.data.width, e.data.height */   break;
-    case "dispose": break;
-  }
-};
+```
+OSR(useSharedTexture) を Syphon/Spout に出したいだけで、ウィンドウ管理もライブラリに任せたい？
+  YES → createTextureBridge()  (@napolab/texture-bridge-renderer)
+        BrowserWindow・paint 配線・DPR/pixelExact・プレビュー・FPS まで面倒を見る。まずここから。
+
+自前の BrowserWindow / paint ループに後付けで送信だけ足したい？
+  YES → TextureSender + sendTextureFromPaintEvent()  (@napolab/texture-bridge-core)
+        DPR の整合は自分で担保する — docs/ja/SENDING.md の「macOS Retina / Windows DPI」を参照。
+
+Electron 無しで生 RGBA を流したい（テスト / CI / サニティチェック）？
+  YES → new TextureSender(...).sendRgbaBuffer()  (@napolab/texture-bridge-core)
+        docs/ja/SENDING.md の「Electron 無しの最小サニティチェック」を参照。
 ```
 
-### `@napolab/texture-bridge-core`
+### パッケージの役割と依存方向
 
-#### `sendTextureFromPaintEvent(sender, textureInfo)`
-
-プラットフォーム固有のテクスチャハンドルの取得と転送を自動的に処理する低レベル関数です。
-
-- **macOS**: `handle.ioSurface` バッファを読み取り → `sender.sendSurface()` を呼び出し
-- **Windows**: `handle.ntHandle` バッファを BigInt64LE として読み取り → `sender.send()` を呼び出し
-
-フレームがセンダーに渡された場合は `undefined` を返し、フレームがドロップされた場合は
-`PaintDefect`（`{ reason: "no-texture" | "no-nt-handle" | "no-io-surface" | "unsupported-platform" }`；
-`unsupported-platform` バリアントには該当する `platform` も含まれます）を返します。
-ドロップは通常のノーオペレーションであり、エラーではありません — `createTextureBridge` が
-`frameDropped` イベントで行っているのと同様に、自前の paint ループでも表面化させてください。
-ネイティブの送信失敗は `TextureSendError`（両パッケージからエクスポートされます）として
-throw されます — メッセージはそのまま保持され、元の throw 値は `error.cause` から参照できます。
-`createTextureBridge` を使っている場合、これらはブリッジの `error` イベントとして表面化するため、
-`instanceof TextureSendError` で判別できます。
-
-#### `forwardSharedTexture(textureInfo, target, extraArgs?)`（`core/electron` から）
-
-```typescript
-import { forwardSharedTexture, type ForwardDefect } from "@napolab/texture-bridge-core/electron";
-
-const defect = await forwardSharedTexture(textureInfo, target, extraArgs);
+```
+@napolab/texture-bridge-renderer   高レベルファクトリ API（推奨）: createTextureBridge、
+        │                          レシーバー、ディスカバリ、プレビュー
+        ▼
+@napolab/texture-bridge-core       低レベルプリミティブ: TextureSender / TextureReceiver、
+        │                          sendTextureFromPaintEvent — Electron はオプション
+        ▼
+@napolab/texture-bridge            ネイティブアドオン（napi-rs バインディング）
+        │
+        ▼
+@napolab/texture-bridge-darwin-arm64 / -darwin-x64 / -win32-x64-msvc
+                                   プリビルド済みプラットフォームバイナリ（自動インストール）
 ```
 
-1 フレームの paint を、Electron の shared-texture チャネル（`sharedTexture.importSharedTexture` → `sharedTexture.sendSharedTexture`）経由で renderer の `WebContents` に転送します。ゼロコピー — プロセス境界を越えるのは GPU ハンドルのみで、ピクセルは動きません。
+## アーキテクチャ
 
-この関数はパッケージのメインエントリではなく、**独立したサブパス** `@napolab/texture-bridge-core/electron` に置かれています。メインエントリは Electron 未インストールでも import できる状態を保つ必要があります（前述の「Electron 無しの最小サニティチェック」の `sendRgbaBuffer` がそれに依存しています）。そのためこの関数が必要とする静的な `import { sharedTexture } from "electron"` はこのサブパスに隔離し、メインエントリの出力に electron-free ガードをビルド時に適用して強制しています。
+### 送信 (Electron → VJ ソフトウェア)
 
-フレームが Electron への配送に成功した場合は `undefined` を、失敗した理由は `ForwardDefect` で返します — `sendTextureFromPaintEvent` の `PaintDefect | undefined` と同じ報告方式です: 低レベル層は結果を報告するだけで、判断は呼び出し側に委ねます。
-
-```typescript
-type ForwardDefect =
-  | { reason: "target-destroyed" }   // target.isDestroyed()、または mainFrame が存在しない
-  | { reason: "import-failed"; cause: Error }
-  | { reason: "send-failed"; cause: Error };
+```
+[Web Worker]              [Chromium GPU Process]         [Native Addon]         [外部アプリ]
+ Three.js / WebGL  ──→   Compositor (Metal / D3D11) ──→  texture-bridge  ──→   Resolume Arena
+ OffscreenCanvas          Shared Texture (GPU)            Spout / Syphon        VDMX, OBS 等
 ```
 
-`async` 関数であるため、同期的に throw することは構造的にありません — 失敗は常に返り値の Promise を通じて表面化し、呼び出し箇所で例外として飛ぶことはありません。import に成功した場合は、後続の send が成功しても失敗しても `finally` で必ず import 済みテクスチャを release します（release-in-finally）。
+全パイプラインが GPU 上で完結。CPU リードバックなし。サブフレームレイテンシ。
 
-自前の paint ループを持つ低レベル利用者は、`sendTextureFromPaintEvent` と並べて直接呼び出せます。texture の release は `finally` で行ってください — `sendTextureFromPaintEvent` はネイティブ送信の失敗時に throw するため、`finally` を使わないと `texture.release()` がスキップされてフレームがリークします。`forwardSharedTexture` は同期的に throw しない（前述）ため、`await` せず fire-and-forget しても安全です — ディスパッチ自体は同期的に開始されるため:
+### 受信 (VJ ソフトウェア → Electron)
 
-```typescript
-win.webContents.on("paint", (e) => {
-  const texture = e.texture;
-  if (!texture) return;
-  try {
-    void forwardSharedTexture(texture.textureInfo, monitorWC, [slot]); // → renderer（ディスパッチは同期）
-    sendTextureFromPaintEvent(sender, texture.textureInfo);           // → Syphon/Spout（失敗時は throw）
-  } finally {
-    texture.release();
-  }
-});
+フレームをどう扱いたいかによって、2 つの経路が選べます:
+
+**RGBA readback（両プラットフォームで動作）:**
+
+```
+[External Apps]          [Native Addon]                  [Electron App]
+ Resolume Arena   ──→    texture-bridge   ──→ RGBA buf ──→  Process frames
+ VDMX, OBS, etc.         Syphon Client / Spout Receiver     Display, analyze, etc.
 ```
 
-#### `sendImportedTexture(frame, imported, extraArgs?)`（`core/electron` から）
+GPU→CPU リードバック（Metal blit / D3D11 staging）に加え、ArrayBuffer の IPC ホップを伴います。JS 側でピクセルを検査する必要がある場合（解析、ディスクへの保存、独自のカラーパイプラインなど）に使用します。
 
-```typescript
-import { sendImportedTexture } from "@napolab/texture-bridge-core/electron";
+**ゼロコピー GPU 共有テクスチャ（Windows + macOS）:**
 
-await sendImportedTexture(targetFrame, importedSharedTexture, extraArgs);
+```
+[External Apps]          [Native Addon]        [Electron main]         [Electron renderer]
+ Resolume Arena   ──→   texture-bridge   ──→  importSharedTexture ──→  VideoFrame
+ VDMX, OBS, etc.        Shared Handle /       + sendSharedTexture       drawImage / WebGPU
+                        IOSurface             (zero-copy GPU)           importExternalTexture
 ```
 
-**すでに import 済みの** shared texture（`sharedTexture.importSharedTexture(...)` の戻り値）を対象の `WebFrameMain` に配送し、send の成否に関わらず `finally` で必ず release します — release-in-finally は `forwardSharedTexture` 内部の配送ステップと同じ契約です。これは `forwardSharedTexture`（前述）とレンダラーパッケージの shared-texture receiver 経路（`shared-texture-receiver.ts`、`preview-manager.ts`）の両方が内部で呼び出している共有ヘルパーで、「配送して必ず release する」処理の実装が重複せず一本化されています。ほとんどの利用者は `importSharedTexture` のステップも行う `forwardSharedTexture` を使うべきです — `sendImportedTexture` を直接使うのは、すでに他所（例: receiver のポーリングループ）で import 済みのテクスチャを持っていて、send-and-release の半分だけが必要な場合に限ります。
+テクスチャは送信元から最終的に消費先の canvas や WebGPU デバイスまで、一貫して GPU 上に置かれたまま渡されます。CPU リードバックも IPC でのピクセルコピーもありません — ソースが shared-texture を裏付けとする `VideoFrame` の場合、`drawImage(videoFrame, 0, 0)` は Chromium 内で GPU blit になります。
 
-#### `TextureSender`
+## 特徴
 
-Syphon/Spout レシーバーにテクスチャを送信するネイティブクラスです。
+- **GPU ゼロコピー送信**: IOSurface（macOS）または DXGI Shared Handle（Windows）を介して GPU 上で直接テクスチャを共有
+- **GPU ゼロコピー受信**（Windows + macOS）: Electron の `importSharedTexture` を介して、Syphon/Spout サーバーからのテクスチャをレンダラーの `VideoFrame` へ直接取り込み — CPU リードバックも IPC でのピクセルコピーもなし
+- **透過キャプチャ**: `includeAlpha: true` によりオフスクリーンウィンドウがピクセル単位のアルファを共有テクスチャへ転送するため、VJ ソフトウェアはオーバーレイ / ロワーサード合成に適した正しい透過を持つレイヤーとして受け取れる
+- **RGBA readback 受信**: `TextureReceiver.receiveFrame()` が両プラットフォームでピクセルを `Buffer` として返す
+- **センダーディスカバリ**: 利用可能な Syphon サーバー / Spout センダーをリアルタイムの変更イベント付きで列挙
+- **クロスプラットフォーム**: macOS は Syphon Metal、Windows は Spout
+- **Electron ネイティブ対応**: Electron 40+ の `useSharedTexture` paint イベントと `sharedTexture` モジュール向けに構築
+- **WebGPU プレビュー**: `importExternalTexture` を使用したゼロコピープレビューウィンドウ（オプション）
+- **ファクトリ API**: 送信用の `createTextureBridge()`、RGBA readback 用の `createTextureReceiver()`、ゼロコピー GPU 配送用の `createSharedTextureReceiver()` — 定型処理をすべて肩代わり
+- **低レベル API**: `sendTextureFromPaintEvent()`、`TextureReceiver`、`closeNativeHandle()` による完全な制御
+- **napi-rs**: 型安全な Rust → Node.js バインディング（プリビルドバイナリ付き）
 
-```typescript
-class TextureSender {
-  constructor(name: string, width: number, height: number);
-  send(handle: number, width: number, height: number): void;
-  sendSurface(surfaceBuffer: Buffer, width: number, height: number): void;
-  sendRgbaBuffer(data: Buffer, width: number, height: number, bytesPerRow?: number): void;
-  platform(): string;
-  stop(): void;
-}
-```
+## 対応プラットフォーム
 
-#### `getPlatform()`
+| プラットフォーム | プロトコル | GPU API | ターゲット |
+|----------|----------|---------|--------|
+| macOS (Apple Silicon) | Syphon Metal | IOSurface + Metal | `aarch64-apple-darwin` |
+| macOS (Intel) | Syphon Metal | IOSurface + Metal | `x86_64-apple-darwin` |
+| Windows x64 | Spout | DXGI Shared Handle + D3D11 | `x86_64-pc-windows-msvc` |
 
-```typescript
-function getPlatform(): "spout" | "syphon-metal" | "unsupported";
-```
+### プラットフォーム別の機能対応
 
-`getPlatform()` とインスタンスメソッド `sender.platform()` / `receiver.platform()` は同じ文字列集合を返します：
+| 機能 | Windows (Spout) | macOS (Syphon Metal) |
+|---------|:---------------:|:--------------------:|
+| センダー（Electron の paint → 外部アプリ） | 対応 | 対応 |
+| レシーバー、RGBA readback（`receiveFrame()`） | 対応 | 対応 |
+| レシーバー、ゼロコピー GPU（`receiveSharedTexture()` + `createSharedTextureReceiver`） | 対応 | 対応 |
+| センダーディスカバリ（`listSenders()` / `SenderDiscovery`） | 対応 | 対応 |
+| 透過キャプチャ（`createTextureBridge({ includeAlpha: true })`） | 対応 | 対応 |
 
-| 値 | 意味 |
-|----|------|
-| `"syphon-metal"` | macOS — Syphon Metal バックエンド有効 |
-| `"spout"` | Windows — Spout バックエンド有効 |
-| `"unsupported"` | バックエンドのないプラットフォーム（送受信は no-op） |
+## 必要要件
 
-#### 型定義
+- **Node.js** 20+
+- **Electron** 40.0.0+
+- **macOS** 11.0+（Metal）、または DirectX 11 対応 GPU を搭載した **Windows**
 
-```typescript
-type PixelFormat = "bgra" | "nv12" | "rgba" | "rgbaf16";
-
-interface TextureInfo {
-  pixelFormat: PixelFormat;
-  codedSize: { width: number; height: number };
-  visibleRect: { x: number; y: number; width: number; height: number };
-  handle: {
-    ntHandle?: Buffer;   // Windows (Electron 40+)
-    ioSurface?: Buffer;  // macOS
-  };
-}
-
-interface PaintTexture {
-  textureInfo: TextureInfo;
-  release?: () => void;
-}
-
-type Platform = "spout" | "syphon-metal" | "unsupported";
-```
+ソースからビルドする場合はさらに Rust ツールチェーン、pnpm 10+、各プラットフォームのビルドツールが必要です — [docs/ja/INSTALLATION.md § 前提条件](../../docs/ja/INSTALLATION.md#前提条件) を参照してください。
 
 ## パフォーマンス
+
+### 送信
 
 | パス | GPU コピー | レイテンシ | メモリ |
 |------|-----------|---------|--------|
 | Syphon / Spout | 0（ゼロコピー） | 1 フレーム未満 | 共有 GPU メモリ |
 | WebGPU プレビュー | 0（ゼロコピー） | 1 フレーム未満 | 共有 GPU メモリ |
 | RGBA バッファ（フォールバック） | 1（CPU → GPU） | 2-3 フレーム | CPU + GPU |
+
+### 受信
+
+| パス | GPU コピー | IPC コピー | レイテンシ | 備考 |
+|------|-----------|----------|---------|-------|
+| Shared Texture（`createSharedTextureReceiver` / `receiveSharedTexture`） | 0（ゼロコピー） | なし（ハンドルのみ） | 1 フレーム未満 | Windows + macOS。フレームは `VideoFrame` として届く — `drawImage` または WebGPU の `importExternalTexture` を使用 |
+| RGBA Readback（`createTextureReceiver` / `receiveFrame`） | 1（GPU → CPU staging） | 1080p 1 フレームあたり約 8 MB | 2–3 フレーム | JS 側で実際にピクセルデータが必要な場合に使用 |
+
+60fps でのおおよその readback 帯域: 1080p で約 500 MB/s、4K で約 2 GB/s — 表示のみのワークロードでは、ポーリング頻度を下げるか shared-texture 経路への切り替えを検討してください。
 
 ## サンプルアプリケーション
 
@@ -663,122 +323,18 @@ pnpm --filter @napolab/texture-bridge-example run build:win
 
 > **自分のアプリのパッケージング。** ネイティブ `.node` アドオンは ASAR アーカイブ内からロードできないため、electron-builder 設定に `asarUnpack: "node_modules/@napolab/texture-bridge*"` を追加し、macOS では `Syphon.framework` を `Frameworks/` に同梱して codesign してください。コピペできる electron-builder / electron-forge のスニペットは [docs/ja/INSTALLATION.md](../../docs/ja/INSTALLATION.md) にあります。
 
-## プロジェクト構成
+## ドキュメント
 
-```
-electron-texture-bridge/
-├── packages/
-│   ├── native/                # @napolab/texture-bridge (napi-rs)
-│   │   ├── src/
-│   │   │   ├── lib.rs         # napi-rs エントリポイント、TextureSender API
-│   │   │   ├── types.rs       # RawTextureHandle 型エイリアス
-│   │   │   ├── mac/           # macOS: Syphon Metal センダー + FFI
-│   │   │   └── win/           # Windows: Spout センダー + FFI
-│   │   ├── cpp/
-│   │   │   ├── mac/           # ObjC++ Syphon Metal ブリッジ
-│   │   │   └── win/           # C++ Spout ブリッジ
-│   │   ├── build.rs           # プラットフォーム固有のビルド設定
-│   │   └── Cargo.toml
-│   ├── core/                  # @napolab/texture-bridge-core (TypeScript)
-│   │   └── src/
-│   │       ├── index.ts       # sendTextureFromPaintEvent + 再エクスポート
-│   │       └── types.ts       # TextureInfo, PaintTexture 型定義
-│   ├── renderer/              # @napolab/texture-bridge-renderer (TypeScript)
-│   │   └── src/
-│   │       ├── index.ts       # createTextureBridge ファクトリ
-│   │       ├── bridge.ts      # ファクトリ実装（EventEmitter）
-│   │       ├── types.ts       # TextureBridgeOptions, TextureBridge
-│   │       ├── preview-manager.ts  # プレビューウィンドウのライフサイクル管理
-│   │       ├── fps-counter.ts # FPS 計測ユーティリティ
-│   │       ├── client/        # レンダラープロセス用ヘルパー
-│   │       │   ├── index.ts   # createWorkerRenderer
-│   │       │   └── worker-protocol.ts  # Worker メッセージ型
-│   │       └── assets/        # 静的ファイル（preview.html, preload）
-│   └── example/               # Electron VJ デモアプリ（プライベート）
-│       └── src/
-│           ├── main/          # Electron メインプロセス（約 30 LOC）
-│           └── renderer/      # Three.js + GLSL + Web Worker
-├── vendor/                    # サードパーティ SDK（gitignore、ローカルでビルド）
-│   ├── syphon-src/            # Syphon Framework ソース（git サブモジュール）
-│   ├── Syphon.framework/     # ビルド済みフレームワーク（macOS）
-│   └── Spout2/               # Spout SDK（Windows）— SpoutDirectX/ + SpoutGL/
-├── specs/
-│   └── ARCHITECTURE.md        # 詳細なアーキテクチャドキュメント
-├── Cargo.toml                 # Rust ワークスペースルート
-├── pnpm-workspace.yaml        # pnpm モノレポ設定
-└── package.json               # ルートワークスペーススクリプト
-```
-
-## トラブルシューティング
-
-### paint イベントが発火しない
-
-- `win.webContents.setFrameRate(60)` を設定しているか確認
-- `show: false` でも paint イベントは発火する
-- レンダラー/ワーカー内で `requestAnimationFrame` ループが動いているか確認
-
-### テクスチャが真っ黒
-
-- **DPR / Retina のサイズ不一致（最も多い）。** **Electron ≤ 40:** Retina ディスプレイや Windows のディスプレイスケーリング下では実フレームバッファが `width × height × scaleFactor` になり、論理サイズで宣言したセンダーと食い違ってレシーバーが黒/崩れになります。`createTextureBridge({ pixelExact: true })` を使うか、低レベル core 経路ではセンダーを実フレームバッファサイズで宣言するか自分で DPR を打ち消してください。**Electron ≥ 41:** `createTextureBridge` が OSR のデバイススケールファクターを `1` に固定するため、この不一致は発生しません — [移行ガイド: Electron 42 / OSR デバイススケール](#移行ガイド-electron-42--osr-デバイススケール)を参照してください。低レベル core 経路では自分で `offscreen: { useSharedTexture: true, deviceScaleFactor: 1 }` を渡してください。（[Retina/DPI 警告](#macos-retina-と-windows-dpi-スケーリング)参照）。
-- **Electron とブリッジの切り分け**には[Electron 無しの最小サニティチェック](#electron-無しの最小サニティチェック)を使ってください — `sendRgbaBuffer` が VJ アプリに映ればネイティブ側は健全で、問題は Electron OSR 経路にあります。
-- `preserveDrawingBuffer` は不要（Chromium のコンポジターが直接読み取る）
-- ピクセルフォーマットの不一致を確認：Chromium は BGRA を出力するので、レシーバー側も BGRA を期待しているか確認
-- `bridge.on("frameDropped", ...)` を購読する（または `sendTextureFromPaintEvent` の
-  戻り値を確認する）— `no-nt-handle` / `no-io-surface` の理由が継続する場合、
-  Chromium が共有可能な GPU ハンドルを配信していないことを意味し、
-  それ以外では黒画面としてのみ現れます。
-
-### Syphon レシーバーに表示されない（macOS）
-
-- `vendor/Syphon.framework` が正しい場所にあるか確認
-- Gatekeeper の隔離属性をクリア：`xattr -dr com.apple.quarantine vendor/Syphon.framework`
-- Console.app でエラーログを確認
-
-### Spout レシーバーに表示されない（Windows）
-
-- Spout2 がシステムにインストールされているか確認
-- GPU ドライバが最新か確認
-- DirectX 11 対応 GPU が必要
-
-### フリーズ / paint イベントが停止する
-
-- **テクスチャ処理後は必ず `texture.release()` を呼ぶこと。** テクスチャプールは数フレーム分しかありません。release を呼ばないとプールが枯渇し、paint イベントパイプラインが停止します。
-- `createTextureBridge()` 使用時は自動的に処理されます。
-- 低レベルの core API 使用時は `try/finally` で確実に release を呼ぶ：
-
-```typescript
-win.webContents.on("paint", (event) => {
-  const texture = event.texture;
-  if (!texture) return;
-  try {
-    sendTextureFromPaintEvent(sender, texture.textureInfo);
-  } finally {
-    texture.release?.();
-  }
-});
-```
-
-## 移行ガイド: Electron 42 / OSR デバイススケール
-
-Electron 42 でオフスクリーンレンダリングのデフォルトデバイススケールファクターが `1.0` に変更されました（[breaking change](https://www.electronjs.org/docs/latest/breaking-changes)）。この変更を含む texture-bridge のリリース以降（CHANGELOG 参照）、`createTextureBridge` は Electron ≥ 41 で `offscreen.deviceScaleFactor: 1` を固定するため、`width`/`height` はどのディスプレイでも正確なピクセル数を意味するようになります。
-
-- **`pixelExact: true` を使っていた場合**（Electron 40 など）: そのままで問題ありません — Electron ≥ 41 では no-op であり、40 では引き続き必要です。
-- **自分でスケーリングを回避していた場合**（`force-device-scale-factor=1`、手動の DIP 計算、Electron 42 で 1/4 解像度になった後に `pixelExact` を外す、など）: アップグレード後はこれらの回避策は不要になります。
-- **意図的にスケーリングされたフレームバッファが欲しい場合**は、自分で `webPreferences: { offscreen: { useSharedTexture: true, deviceScaleFactor: <n> } }` を渡してください — ユーザー指定の `offscreen` ブロックは常に優先されます。
-
-実測データの背景: `reports/2026-08-11-pixelexact-osr-scale-investigation.md`。
-
-## CI/CD
-
-GitHub Actions が全対応プラットフォーム向けにネイティブバイナリをビルドします：
-
-| ランナー | ターゲット | 出力 |
-|--------|--------|--------|
-| `macos-14` | `aarch64-apple-darwin` | `texture-bridge.darwin-arm64.node` |
-| `macos-13` | `x86_64-apple-darwin` | `texture-bridge.darwin-x64.node` |
-| `windows-latest` | `x86_64-pc-windows-msvc` | `texture-bridge.win32-x64-msvc.node` |
-
-npm への公開はバージョンタグ（`v*`）で自動トリガーされます。
+| ドキュメント | 内容 |
+|----------|--------------|
+| [docs/ja/INSTALLATION.md](../../docs/ja/INSTALLATION.md) | 前提条件、ソースからのビルド、アプリへの統合、パッケージング、検証 |
+| [docs/ja/SENDING.md](../../docs/ja/SENDING.md) | 外部ページのキャプチャ、`includeAlpha` による透過、低レベル core の paint ループ、Retina/DPI の正確な扱い、Electron 無しのサニティチェック、electron-vite（ESM） |
+| [docs/ja/RECEIVING.md](../../docs/ja/RECEIVING.md) | 2 つの受信経路、`createSharedTextureReceiver`、`installSharedTextureReceiver` / `consumeSharedTexture`、ハンドルの所有権、レンダラーのコンテキスト分離 |
+| [docs/ja/API.md](../../docs/ja/API.md) | 3 パッケージすべてのエクスポートシンボルの完全な API リファレンス |
+| [docs/ja/TROUBLESHOOTING.md](../../docs/ja/TROUBLESHOOTING.md) | 黒画面、paint イベントが発火しない、フリーズ、プラットフォームごとのレシーバー問題 |
+| [docs/ja/MIGRATION.md](../../docs/ja/MIGRATION.md) | Electron 42 / OSR デバイススケール、同期的な dispose（v0.14+）、明示的な破棄（v0.6+） |
+| [docs/ja/DEVELOPMENT.md](../../docs/ja/DEVELOPMENT.md) | リポジトリ構成と CI |
+| [specs/ARCHITECTURE.md](../../specs/ARCHITECTURE.md) | 詳細な内部アーキテクチャ |
 
 ## ライセンス
 

--- a/plugins/texture-bridge/README.md
+++ b/plugins/texture-bridge/README.md
@@ -4,10 +4,35 @@ Claude Code skills for using [`@napolab/texture-bridge`](https://github.com/napo
 
 ## Install
 
+### Claude Code (plugin)
+
 ```
 /plugin marketplace add naporin0624/electron-texture-bridge
 /plugin install texture-bridge
 ```
+
+### Any other agent (Skills CLI)
+
+Works with Codex, GitHub Copilot, Amp, Cursor, Antigravity, and others via
+[skills.sh](https://skills.sh/naporin0624/electron-texture-bridge). **Install one
+skill per command** — passing several at once only installs the first:
+
+```bash
+npx skills add naporin0624/electron-texture-bridge@setting-up-texture-bridge
+npx skills add naporin0624/electron-texture-bridge@choosing-texture-bridge-api
+npx skills add naporin0624/electron-texture-bridge@migrating-to-forward-frames
+npx skills add naporin0624/electron-texture-bridge@receiving-shared-textures
+npx skills add naporin0624/electron-texture-bridge@managing-frame-forward-lifecycle
+npx skills add naporin0624/electron-texture-bridge@delivering-imported-textures
+npx skills add naporin0624/electron-texture-bridge@handling-texture-bridge-failures
+```
+
+Add `-g` to install globally instead of into the current project.
+
+> Omitting the `@skill-name` suffix installs **every** skill in the repository,
+> including this project's own internal development-rule skills (`ci`,
+> `smart-commit`, and others) that are not about texture-bridge at all. Name the
+> skills you want.
 
 ## Skills
 


### PR DESCRIPTION
## What

README was 1323 lines with install instructions duplicated across three places and the API reference taking up 36% of the file. This cuts it to **341 lines** and moves the reference material into `docs/`.

| File | Lines | Contents |
|---|---|---|
| `README.md` | 1323 → **341** | Overview, install, agent skills, quick start, API decision flow, architecture, platforms, example, doc index |
| `docs/API.md` | +478 | Full API reference for all three packages |
| `docs/SENDING.md` | +156 | External-page capture, `includeAlpha`, low-level core paint loop, Retina/DPI, no-Electron sanity check, electron-vite ESM |
| `docs/RECEIVING.md` | +134 | Both receive paths, zero-copy shared texture, handle ownership, context isolation |
| `docs/MIGRATION.md` | +101 | Electron 42 / OSR device scale, synchronous dispose (v0.14+), explicit disposal (v0.6+) |
| `docs/DEVELOPMENT.md` | +65 | Repository layout, CI |
| `docs/TROUBLESHOOTING.md` | +56 | Black output, paint stalls, per-platform receiver issues |

Content was **moved verbatim, not rewritten** — the split was done by line-range extraction so every one of the original 1322 lines lands somewhere.

## Agent skills are now documented

The repo has shipped 7 agent skills for a while, but the README never mentioned them. There is now an `## AI Agent Skills` section directly after Install, documenting both install paths:

- **Claude Code** — `/plugin marketplace add` + `/plugin install`
- **Any other agent** — `npx skills add naporin0624/electron-texture-bridge@<skill>` (works with Codex, Copilot, Amp, Cursor, Antigravity, …)

Two things were verified by actually running the CLI and are called out explicitly, because both are easy to get wrong:

1. **One command installs one skill.** Passing several `repo@skill` arguments at once silently installs only the first.
2. **Omitting the `@skill-name` suffix installs all 11 skills in the repo** — including this project's internal development-rule skills (`ci`, `smart-commit`, `chaining-neverthrow-results`, `consuming-results-at-api-boundaries`), which have nothing to do with texture-bridge.

`plugins/texture-bridge/README.md` gained the same Skills CLI instructions.

## Japanese docs

`lang/ja/README.md` is restructured to the same shape (341 lines, identical heading counts), and `docs/ja/` gains the six matching translations.

The Japanese docs had drifted behind English. This fills in material that previously existed **only** in English: `forwardFrames`, `sendImportedTexture`, `forwardSharedTexture`, `createMultiDispatcher`, `installSharedTextureReceiver` / `consumeSharedTexture`, the whole zero-copy shared-texture receive path, the multiviewer section, and the synchronous-dispose migration guide.

## Verification

- **No content lost** — arithmetic coverage check confirms all 1322 original lines are accounted for; 15 identifiers that appear only in relocated sections (`createTextureBridgeWith`, `createMultiDispatcher`, `MISC_SHARED_NTHANDLE`, …) all verified reachable.
- **Links** — every relative link resolves in both languages.
- **Anchors** — all 7 English and 5 Japanese cross-file heading anchors resolve.
- **Structural parity** — EN/JA match exactly on `##` (12/12), `###` (13/13) and code-fence counts (26/26) for the README, and on all heading/fence counts for the six doc pairs.
- **Code blocks** — Japanese code blocks are MD5-identical to English once comments are stripped.
- `pnpm lint` and `pnpm typecheck` pass.

Docs-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vmgd8MZM2CPCvEiRz6tpJ7