### PR TITLE
docs: add AGENTS.md, superpowers plans, and core API abstraction report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+<claude-mem-context>
+# Memory Context
+
+# [electron-texture-bridge] recent context, 2026-08-10 5:56pm GMT+9
+
+Legend: 🎯session 🔴bugfix 🟣feature 🔄refactor ✅change 🔵discovery ⚖️decision 🚨security_alert 🔐security_note
+Format: ID TIME TYPE TITLE
+Fetch details: get_observations([IDs]) | Search: mem-search skill
+
+Stats: 50 obs (17,743t read) | 1,092,553t work | 98% savings
+
+### Jul 15, 2026
+S4020 Push branch and create PR for coding-rules compliance + neverthrow refactor in electron-texture-bridge (Jul 15 at 4:17 PM)
+S4021 Post-PR review fix: revert `receiverSlot` const-object workaround to plain `let activeReceiver` in example main process (Jul 15 at 4:22 PM)
+S4026 Revert uiSlot and installState from mutable-slot const objects back to plain let declarations in electron-texture-bridge (Jul 15 at 4:25 PM)
+S4029 PR分割: refactor/coding-rules-complianceブランチをフェーズ1・2の2つのPRに分割 (Jul 15 at 4:55 PM)
+S4030 Refactor electron-texture-bridge by loading skills first, then splitting a large refactor into fine-grained stacked PRs (Jul 15 at 5:22 PM)
+S4033 sender.send / sender.sendSurface を fromThrowable でラップして match できる Result 型 API を提供する (Jul 15 at 5:32 PM)
+34870 6:06p 🔵 既存テストは sendTextureFromPaintEvent のみをカバー — Result API のテストが未存在
+34871 6:07p 🟣 TextureSendError のラップ検証テストを追加
+34873 " 🟣 sendTextureFromPaintEventResult の vitest テストスイートを追加
+34874 " 🟣 neverthrow Result ラップ実装が全 CI チェックを通過 — 14 テスト全パス
+34876 " 🟣 refactor/core-send-result ブランチを commit &amp; push して完了
+34878 6:08p 🟣 PR #64 作成 — feat(core): Result-returning send API
+S4034 sender.send / sender.sendSurface を fromThrowable でラップして match できる形で提供 → 設計レビューにより Result を公開 API から撤去して内部消費に変更 (Jul 15 at 6:08 PM)
+34881 6:09p 🔄 neverthrow import から ok を削除 — ok(undefined) 早期リターンの置き換えが必要
+34883 6:10p 🔄 sendTextureFromPaintEventResult を廃止 — Result を公開 API から取り除き内部実装に留めた
+34884 " 🔄 sendTextureFromPaintEventResult の vitest テストスイートを削除
+34885 " 🟣 非 Error throw のラップ検証テストを sendTextureFromPaintEvent describe に移動・追加
+34886 " 🟣 設計変更後の全 CI チェック通過 — 11 テスト全パス
+34889 " 🟣 PR #64 を設計変更後の内容で更新・push 完了
+34890 6:11p ⚖️ neverthrow-api-boundary ルールをプロジェクトメモリに永続化
+34891 " ✅ MEMORY.md インデックスに neverthrow-api-boundary エントリを追加
+S4035 consuming-results-at-api-boundaries スキルの作成と TDD 検証 — neverthrow の Result を公開 API に露出しない設計規範をスキルとして永続化 (Jul 15 at 6:11 PM)
+34899 6:13p 🔵 ベースラインテスト A: 別エージェントは同問題に対して Result を公開 API として返す設計を提案
+34901 6:14p 🔵 ベースラインテスト B: 別エージェントも Result を公開 API として返す設計を提案 — neverthrow を peerDependency にすべきと指摘
+34902 " 🟣 consuming-results-at-api-boundaries スキルを新規作成
+34903 6:15p 🔴 consuming-results-at-api-boundaries スキルの内容確認完了
+34904 " 🔵 スキル適用テスト: consuming-results-at-api-boundaries スキルが別エージェントの設計を正しく誘導することを確認
+34906 " 🔵 スキル適用テスト A: 元のユーザーリクエストと同一プロンプトでもスキルが正しく void + throw 設計に誘導することを確認
+34911 6:17p 🔵 .claude/skills/ は .gitignore で除外されており、スキルはリポジトリに追跡されない
+S4039 add -f して #65 に含めて — force-add gitignored skill file and include in PR #65, then apply the named fromThrowable binding style across core and renderer (Jul 15 at 6:17 PM)
+35012 6:48p ✅ Force-add files to PR #65 with `git add -f`
+### Aug 10, 2026
+55177 5:34p 🔵 API Structure Abstraction: genovese & cannelloni — prefix-match-processor and precise-type-modeling
+55178 " 🔵 electron-texture-bridge Repository Structure and Task History
+55179 5:35p 🔵 electron-texture-bridge Package Structure: Four Packages, Two API Tiers
+55180 " 🔵 Factory API (Simple Usage): createTextureBridge and createTextureReceiver Signatures
+55181 " 🔵 electron-texture-bridge README: Explicit Two-Tier API Documentation Structure
+55182 " 🔵 Async Subagent Launched to Deeply Explore Genovese VJ System API
+55183 5:36p 🔵 Genovese is "vizion" v2.2.0 — Professional VJ Software with Rich Dependency Stack
+55184 " 🔵 Cannelloni v1.2.1 — Electron VJ App with Patched texture-bridge and Python Shazam Subproject
+55185 " 🔵 electron-texture-bridge Core API: Three-Way Decision Tree for API Tier Selection
+55186 5:37p 🔵 Genovese Compositor: prefix-match-processor Pattern in plugin-kernel
+55187 " 🔵 Cannelloni command-bus: CQRS Prefix-Namespaced Route Dispatch in src/main
+55188 " 🔵 Genovese: Factory API Usage Pattern — setupTextureBridge with pixelExact, includeAlpha, Port Distribution
+55189 " 🔵 Cannelloni deck.ts: Factory API + neverthrow ResultAsync + Testability Seam
+55190 " 🔵 Confirmed ESM Bug in texture-bridge-renderer: __dirname Undefined in ESM Scope
+55191 " 🔵 texture-bridge-core Complete Type Surface: Platform, SenderInfo, ReceivedFrame, TextureSender, TextureReceiver
+55192 " 🔵 Genovese TextureReceiverServiceImpl: Mixed High-Level and Core API Usage with RxJS Observable Pipeline
+55193 5:39p 🔵 Genovese commandPrefixes: Real Plugin Prefix Declarations for compositor.worker.ts
+55194 " 🔵 Shared precise-type-modeling Pattern: IntentNamespace Exhaustiveness via Phantom Type Parameter
+55195 " 🔵 Chain-of-Responsibility Plugin Pattern Used Across Three Independent Systems
+55196 " 🔵 Genovese Effect System: Four-Pattern EffectDefinition Discriminated Union with Registry
+55197 " 🔵 Cannelloni DPI Strategy: force-device-scale-factor=1 Instead of pixelExact
+55198 " 🔵 Cannelloni BroadcastChannels: Namespaced Typed IPC Channel Map (prefix-based addressing)
+55199 " 🔵 Genovese CompositionManager: Facade over Store + Three Orchestrators with Port DI
+55200 5:45p 🔵 API Abstraction Task: genovese & cannelloni Local Projects
+55201 5:47p 🔵 4-Layer API Abstraction: Simple/Core Usage Model for electron-texture-bridge
+S6106 Abstract simple/core API structure from Genovese and Cannelloni repos, focusing on prefix-match-processor and precise-type-modeling patterns — for electron-texture-bridge redesign (Aug 10 at 5:48 PM)
+55202 5:54p 🟣 HTML Artifact with Codex Diagram Illustrations Requested
+55210 5:55p 🟣 Codex imagegen Used to Generate Hero Illustration for electron-texture-bridge
+55212 5:56p 🟣 Second Codex imagegen Call Generates Layered Architecture Diagram (layers.png)
+
+Access 1093k tokens of past work via get_observations([IDs]) or mem-search skill.
+</claude-mem-context>

--- a/docs/superpowers/plans/2026-08-12-di-seam-sync-dispose-docs.md
+++ b/docs/superpowers/plans/2026-08-12-di-seam-sync-dispose-docs.md
@@ -1,0 +1,373 @@
+# DI Seam + Sync Dispose + Package Docs（backlog #5/#6/#7）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (#6) `dispose()` の teardown を `close()`（async）→ `destroy()`（sync）に変更して before-quit の SIGKILL 競合を根治、(#5) `createTextureBridgeWith(deps)` のテスト用注入 seam を公開、(#7) core の package description 修正 + README に依存方向図を追加。
+
+**Architecture:** #6 はオーナー決定済み — offscreen の hidden window に `close()` のライフサイクル配慮は不要で、Genovese / Cannelloni が独立に同じ `destroy()` workaround を実装した事実がデフォルトの誤りの証拠。#5 は Cannelloni の `createDeckWith(createBridge)` パターンの texture-bridge 版: `TextureBridgeDeps = { createWindow, createSender }` を curried factory で注入し、`resize()` の sender 再構築も同じ `createSender` を通す（`TextureBridgeImpl` ctor 第 6 引数・デフォルト付きで既存呼び出し無変更）。#7 は Cannelloni doc-feedback §1 への対応。
+
+**Tech Stack:** pnpm / vitest / tsgo / oxlint+oxfmt。electron mock は既存 bridge.test.ts のものを拡張。
+
+## Global Constraints
+
+- ベースは **main**（#69 マージ済み、04dfe8a 以降）。`git fetch origin main && git pull --ff-only origin main` してから分岐
+- ブランチ名: `feat/di-seam-sync-dispose`
+- 各タスク完了時 `pnpm lint && pnpm typecheck`（tsc 直接実行禁止）
+- コミットは本計画のステップでのみ。CLAUDE.md / tasks.md / AGENTS.md（untracked）を含めない。push は指示待ち
+- 既存の `function` 宣言スタイルは触らない（未マージ PR #58–#64 との衝突最小化）。ただし #5 で `createTextureBridge` は `createTextureBridgeWith` から導出する const arrow に**置き換える**（これは機能変更であり style 変更ではない。シグネチャ・JSDoc は維持）
+- `dispose()` の `destroy()` 化は**挙動変更**: fix(renderer) として conventional commit。README / JSDoc の説明も同期
+- 実装完了後 difit でレビュー依頼（Task 4）
+
+## File Structure
+
+| ファイル | 役割 |
+|---|---|
+| `packages/renderer/src/bridge.ts` | #6 dispose の destroy 化、#5 `TextureBridgeDeps` + `createTextureBridgeWith` + ctor 第 6 引数 + resize の注入 sender |
+| `packages/renderer/src/types.ts` | #6 `dispose()` JSDoc 更新 |
+| `packages/renderer/src/index.ts` | #5 `createTextureBridgeWith` / `TextureBridgeDeps` の公開 |
+| `packages/renderer/src/__tests__/bridge.test.ts` | mock 拡張（destroy）+ #6/#5 テスト |
+| `packages/core/package.json` | #7 description 修正 |
+| `README.md` / `lang/ja/README.md` | #6 dispose 記述更新、#7 依存方向図 + 役割テーブル |
+
+---
+
+### Task 1: #6 — dispose() を destroy() に変更
+
+**Files:**
+- Modify: `packages/renderer/src/bridge.ts`（`dispose()`、186–189 行付近）
+- Modify: `packages/renderer/src/types.ts`（`dispose()` JSDoc）
+- Test: `packages/renderer/src/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Produces: `dispose()` が `renderWindow.close()` の代わりに `renderWindow.destroy()` を呼ぶ（同期・キャンセル不可）。他の teardown 順序（sender.stop → previewManager.dispose → emit "disposed" → removeAllListeners）は不変
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+(a) electron mock の `MockBrowserWindow` を拡張 — `close` を assert 可能な `vi.fn()` プロパティにし、`destroy` を追加:
+
+```typescript
+    close = vi.fn();
+    destroy = vi.fn();
+```
+
+（既存の `close(): void {}` method shorthand は削除して property に置き換える。`isDestroyed()` はそのまま）
+
+(b) ファイル末尾に describe を追加:
+
+```typescript
+describe("TextureBridgeImpl.dispose — synchronous teardown", () => {
+  it("destroys the render window synchronously instead of close()", () => {
+    const win = new BrowserWindow();
+    const bridge = new TextureBridgeImpl(win, new TextureSender("t", 16, 9), null, baseOpts);
+
+    bridge.dispose();
+
+    expect(win.destroy).toHaveBeenCalledTimes(1);
+    expect(win.close).not.toHaveBeenCalled();
+    expect(bridge.isDisposed).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    const win = new BrowserWindow();
+    const bridge = new TextureBridgeImpl(win, new TextureSender("t", 16, 9), null, baseOpts);
+
+    bridge.dispose();
+    bridge.dispose();
+
+    expect(win.destroy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: FAIL — `destroy` が呼ばれず `close` が呼ばれる
+
+- [ ] **Step 3: 実装**
+
+`dispose()` 内（bridge.ts）:
+
+```typescript
+    // Destroy the offscreen window synchronously. `close()` is async and
+    // cancellable — it loses the race against `before-quit`, letting Chromium
+    // SIGKILL the OSR renderer and pop a crash dialog. Both known consumers
+    // independently worked around this by forcing `destroy()`; a hidden
+    // offscreen window has no user-facing close semantics to honor.
+    if (!this._renderWindow.isDestroyed()) {
+      this._renderWindow.destroy();
+    }
+```
+
+`packages/renderer/src/types.ts` の `dispose()` JSDoc を更新:
+
+```typescript
+  /**
+   * Tear down all resources synchronously. The offscreen window is
+   * `destroy()`ed (not `close()`d) so teardown cannot lose the race against
+   * `before-quit` — no separate `renderWindow.destroy()` workaround is needed.
+   * Terminal operation — the bridge cannot be reused afterward.
+   */
+  dispose(): void;
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: PASS（全件 — 既存の disposed 系テストも destroy mock で通る）
+
+- [ ] **Step 5: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/bridge.ts packages/renderer/src/types.ts packages/renderer/src/__tests__/bridge.test.ts
+git commit -m "fix(renderer): destroy the offscreen window synchronously in dispose()"
+```
+
+---
+
+### Task 2: #5 — createTextureBridgeWith(deps) seam
+
+**Files:**
+- Modify: `packages/renderer/src/bridge.ts`
+- Modify: `packages/renderer/src/index.ts`
+- Test: `packages/renderer/src/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 完了後の bridge.ts
+- Produces:
+  - `interface TextureBridgeDeps { createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow; createSender: (name: string, width: number, height: number) => InstanceType<typeof TextureSender>; }`（export）
+  - `createTextureBridgeWith(deps: TextureBridgeDeps): (options: TextureBridgeOptions) => Promise<TextureBridge>`（export、公開 index からも）
+  - `createTextureBridge` は `createTextureBridgeWith({ 実デフォルト })` から導出（シグネチャ・JSDoc 維持）
+  - `TextureBridgeImpl` ctor 第 6 引数 `createSender: TextureBridgeDeps["createSender"] = (name, width, height) => new TextureSender(name, width, height)` — `resize()` の 2 箇所の `new TextureSender(...)` を `this.createSender(...)` に置き換え
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```typescript
+describe("createTextureBridgeWith — dependency injection seam", () => {
+  it("routes window and sender construction through the injected deps", async () => {
+    const createWindow = vi.fn(
+      (options: Electron.BrowserWindowConstructorOptions) => new BrowserWindow(options),
+    );
+    const createSender = vi.fn(
+      (name: string, width: number, height: number) => new TextureSender(name, width, height),
+    );
+
+    const bridge = await createTextureBridgeWith({ createWindow, createSender })(baseOpts);
+
+    expect(createWindow).toHaveBeenCalledTimes(1);
+    expect(createWindow.mock.calls[0]?.[0]?.webPreferences?.offscreen).toBeDefined();
+    expect(createSender).toHaveBeenCalledWith("test", 1920, 1080);
+
+    bridge.resize(1280, 720);
+    expect(createSender).toHaveBeenCalledWith("test", 1280, 720);
+  });
+});
+```
+
+import 行に `createTextureBridgeWith` を追加。
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test -- bridge
+```
+
+Expected: FAIL — `createTextureBridgeWith` 未 export
+
+- [ ] **Step 3: 実装**
+
+(a) `TextureBridgeDeps` を定義（`buildBrowserWindowOptions` の近く）:
+
+```typescript
+/**
+ * Injectable constructors for {@link createTextureBridgeWith}. Lets tests and
+ * embedders swap the BrowserWindow / native sender without faking Electron
+ * globals (the pattern consumers previously built themselves as
+ * `createDeckWith(createBridge)`).
+ */
+export interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => InstanceType<typeof TextureSender>;
+}
+```
+
+(b) `TextureBridgeImpl` に第 6 引数を追加:
+
+```typescript
+  private readonly createSender: TextureBridgeDeps["createSender"];
+
+  constructor(
+    renderWindow: BrowserWindow,
+    sender: InstanceType<typeof TextureSender>,
+    previewManager: PreviewManager | null,
+    options: TextureBridgeOptions,
+    policy: OsrScalePolicy = resolveOsrScalePolicy(resolveElectronMajor(process.versions)),
+    createSender: TextureBridgeDeps["createSender"] = (name, width, height) =>
+      new TextureSender(name, width, height),
+  ) {
+```
+
+`resize()` の 2 箇所（forward / rollback）の `new TextureSender(...)` を `this.createSender(...)` に置き換える。
+
+(c) 既存 `createTextureBridge`（async function 宣言）を次の 2 export に置き換える。**既存の JSDoc は `createTextureBridgeWith` 側へ移し、`createTextureBridge` には「デフォルト deps 束縛版」の 1 行 JSDoc を付ける**:
+
+```typescript
+export const createTextureBridgeWith =
+  (deps: TextureBridgeDeps) =>
+  async (options: TextureBridgeOptions): Promise<TextureBridge> => {
+    // …既存 createTextureBridge の本体をそのまま移植し、
+    //   new BrowserWindow(...) → deps.createWindow(...)
+    //   new TextureSender(name, width, height) → deps.createSender(name, width, height)
+    //   new TextureBridgeImpl(renderWindow, sender, previewManager, options, policy)
+    //     → new TextureBridgeImpl(renderWindow, sender, previewManager, options, policy, deps.createSender)
+  };
+
+/** {@link createTextureBridgeWith} bound to the real BrowserWindow / TextureSender. */
+export const createTextureBridge = createTextureBridgeWith({
+  createWindow: (options) => new BrowserWindow(options),
+  createSender: (name, width, height) => new TextureSender(name, width, height),
+});
+```
+
+(d) `packages/renderer/src/index.ts` に追加:
+
+```typescript
+export { createTextureBridgeWith } from "./bridge";
+export type { TextureBridgeDeps } from "./bridge";
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+Expected: PASS（既存の createTextureBridge 系テストも同一挙動で通る）
+
+- [ ] **Step 5: lint / typecheck**
+
+```bash
+pnpm lint && pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/renderer/src/bridge.ts packages/renderer/src/index.ts packages/renderer/src/__tests__/bridge.test.ts
+git commit -m "feat(renderer): expose createTextureBridgeWith dependency-injection seam"
+```
+
+---
+
+### Task 3: #7 — core description 修正 + README 依存方向図
+
+**Files:**
+- Modify: `packages/core/package.json`（description）
+- Modify: `README.md`（「Which API should I use?」直後に依存方向図、`dispose` 記述の整合）
+- Modify: `lang/ja/README.md`（ミラー）
+
+**Interfaces:**
+- Consumes: Task 1（dispose 挙動）/ Task 2（新 export）
+
+- [ ] **Step 1: core package.json の description 修正**
+
+```diff
+-  "description": "High-level GPU texture sharing for Electron (Spout + Syphon Metal)",
++  "description": "Low-level GPU texture sharing primitives for Electron (Spout + Syphon Metal): TextureSender/TextureReceiver + paint-event helpers",
+```
+
+- [ ] **Step 2: README EN — 依存方向図 + 役割テーブル**
+
+`## Which API should I use?` セクションの直後に追加:
+
+```markdown
+### Package roles and dependency direction
+
+```
+@napolab/texture-bridge-renderer   High-level factory API (recommended): createTextureBridge,
+        │                          receivers, discovery, preview
+        ▼
+@napolab/texture-bridge-core       Low-level primitives: TextureSender / TextureReceiver,
+        │                          sendTextureFromPaintEvent — Electron optional
+        ▼
+@napolab/texture-bridge            Native addon (napi-rs binding)
+        │
+        ▼
+@napolab/texture-bridge-darwin-arm64 / -darwin-x64 / -win32-x64-msvc
+                                   Prebuilt platform binaries (installed automatically)
+```
+```
+
+- [ ] **Step 3: README EN — dispose 記述の整合**
+
+`TextureBridge` API ref の `dispose()` 行、および Migration: Explicit Disposal 節に古い「`renderWindow.close()`（async, cancellable）」前提の記述があれば、Task 1 の新挙動（同期 `destroy()`、before-quit workaround 不要）に合わせて更新する。`createTextureBridgeWith` を API Reference の `createTextureBridge` 直後に 1 エントリ追加:
+
+```markdown
+#### `createTextureBridgeWith(deps)` (advanced)
+
+Returns `createTextureBridge` bound to injected constructors
+(`{ createWindow, createSender }`) — for tests and embedders that need to swap
+the `BrowserWindow` or native sender without faking Electron globals.
+```
+
+- [ ] **Step 4: lang/ja/README.md に対応 3 箇所をミラー**
+
+EN の挿入（依存方向図・dispose 更新・createTextureBridgeWith エントリ）を対応位置に自然な日本語で反映。
+
+- [ ] **Step 5: 検証**
+
+```bash
+pnpm lint && pnpm typecheck && pnpm --filter @napolab/texture-bridge-core test && pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/package.json README.md lang/ja/README.md
+git commit -m "docs: correct core package role and add dependency-direction diagram"
+```
+
+（package.json の description は docs 扱いだが release-please のパス検知対象。`docs:` は release をトリガーしないため、リリースには Task 1 の `fix(renderer):` / Task 2 の `feat(renderer):` が乗る — 問題なし）
+
+---
+
+### Task 4: 検証 + 最終レビュー + difit
+
+- [ ] **Step 1: フルビルド + 全テスト**
+
+```bash
+pnpm --filter @napolab/texture-bridge-core build && pnpm --filter @napolab/texture-bridge-renderer build
+pnpm lint && pnpm typecheck && pnpm --filter @napolab/texture-bridge-core test && pnpm --filter @napolab/texture-bridge-renderer test
+```
+
+- [ ] **Step 2: 実機スモーク（dispose 変更の確認）**
+
+example を起動 → fps 確認 → **終了させて**クラッシュダイアログが出ないこと（destroy 経路）を確認 → 必ず process kill。
+
+- [ ] **Step 3: difit でレビュー依頼**
+
+```bash
+npx difit HEAD main
+```
+
+**push / PR 作成は指示を待つ。**
+
+---
+
+## 実装しないこと（スコープ外）
+
+- `PreviewManager` の注入（YAGNI — 消費者需要の実績がない）
+- backlog #8（内部 seam の event union 化）/ #9（processor chain）
+- Windows 実機検証（#3 の残課題として別トラック）

--- a/docs/superpowers/plans/2026-08-12-refactor-stack-revival.md
+++ b/docs/superpowers/plans/2026-08-12-refactor-stack-revival.md
@@ -1,0 +1,108 @@
+# Refactor Stack Revival（旧 #58–#64 の再スコープ 5 PR）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 2026-07-15 の stacked refactor PR #58–#64（unmerged で close 済み）のうち現 main（cca64cd 以降）でも有効な内容を、監査（2026-08-12）の適応指示に従って 5 本の新 PR として順に再実装する。
+
+**Architecture:** 各タスク = 1 ブランチ = 1 PR。**旧 PR の diff（`gh pr diff <n>`）が一次ソース**で、各タスクの「適応リスト」が現 main との差分を埋める。旧ブランチの rebase は禁止（#67/#69/#70 のシグネチャ変更を跨げない）。タスクは直列（2→3→4 は同一ファイル依存）。
+
+**Tech Stack:** pnpm / vitest / tsgo / oxlint+oxfmt / neverthrow（Task 1・4 で各パッケージに導入）
+
+## Global Constraints
+
+- 各タスク開始時: `git fetch origin main && git checkout main && git pull --ff-only origin main` → タスク記載のブランチ名で分岐
+- 一次ソース: `gh pr view <n> --json title,body` と `gh pr diff <n>`（closed でも取得可能）。**そのまま適用せず、必ず適応リストを通す**
+- 確立済みの決定（違反したら差し戻し）:
+  - **neverthrow の Result を公開 API から返さない**。内部のみ、`.match` で edge 消費。`Result.fromThrowable` は **module-scope の named const** に束縛（inline IIFE 禁止）
+  - **slot-object パターン禁止**: module/関数レベルの単純な再代入は plain `let` を維持（let-ban-pragmatism）。`lastW/lastH`・`render-worker` の `worker` オブジェクト化は**採用しない**
+  - error class は throw 境界を跨ぐものだけ
+  - top-level は arrow、class メソッドは shorthand
+- `sendTextureFromPaintEvent` の現シグネチャは `(sender, textureInfo) => PaintDefect | undefined`（#67）。`dispose()` は同期 `destroy()`（#70）。`createTextureBridge` は `createTextureBridgeWith` の束縛 const（#70）
+- 各タスク完了時 `pnpm lint && pnpm typecheck` + 対象パッケージの test。コミットに CLAUDE.md / tasks.md / AGENTS.md を含めない
+- 各タスクの最後: difit でユーザーレビュー → **OK をもらってから** push + PR 作成 → ユーザーの merge を待って次タスクへ
+
+---
+
+### Task 1: refactor(core) — rules compliance + TextureSendError（旧 #58 + #64 統合）
+
+**Branch:** `refactor/core-rules-send-error` / **PR title:** `refactor(core): rules compliance + TextureSendError via fromThrowable`
+
+**Source:** `gh pr diff 58`, `gh pr diff 64`
+
+**適応リスト（監査より）:**
+- [ ] `packages/core/src/index.ts` の `(TextureSender.prototype as any)[Symbol.dispose] = function () {...}` ×2 を型付きで置換（`function(this: InstanceType<typeof TextureSender>)` — prototype 代入は `this` が必要なので arrow 不可。func-style ルールの sanctioned exception としてコメントを付す）
+- [ ] platform dispatch を if-chain → `switch (process.platform)`（exhaustive ではない — default が `unsupported-platform` defect）
+- [ ] `sendTextureFromPaintEvent` を arrow const 化（旧 #58 の変換を新シグネチャに適用）。**各 guard 分岐は `PaintDefect` を返す**（void 時代の bare return にしない）
+- [ ] `packages/core/src/errors.ts` を新規作成: `TextureSendError extends Error`（message 保持 + `cause` 保持。旧 #64 の実装を踏襲）
+- [ ] native throw 点（`sender.send` / `sender.sendSurface`）**のみ** module-scope named `Result.fromThrowable` 経由にし、`.match` の err 側で `TextureSendError` を throw。ok 側は `undefined` を返す。**Result は export しない**
+- [ ] `packages/core/package.json` に `neverthrow` 追加、`tsconfig.json` lib に `ES2022.Error`（旧 #64 と同じ）
+- [ ] `Number(ntHandle.readBigInt64LE(0))` は **BigInt→number 変換であり type-coercion ルール（文字列変換）の対象外** — 旧 #58 が別形に変えていても現行行を維持する
+- [ ] テスト: 既存 14 件維持 + `TextureSendError` ラップ検証（非 Error throw の cause 保持含む）。旧 #64 のテストを新シグネチャに適応
+- [ ] core build → `pnpm lint && pnpm typecheck` → core/renderer 両 test（renderer は dist 型依存）
+
+---
+
+### Task 2: refactor(renderer) — toError + arrow cleanup（旧 #59 + #61 有効分）
+
+**Branch:** `refactor/renderer-toerror-arrows` / **PR title:** `refactor(renderer): shared toError helper + arrow-style cleanup`
+
+**Source:** `gh pr diff 59`, `gh pr diff 61`
+
+**適応リスト:**
+- [ ] `packages/renderer/src/to-error.ts` 新規（旧 #59 のものを流用）
+- [ ] `err instanceof Error ? err : new Error(String(err))` の生パターン全 8+ 箇所を `toError(err)` に置換: `bridge.ts`（handlePaint catch）、`discovery.ts`、`receiver.ts` ×2、`shared-texture-receiver.ts` ×3、`client/shared-texture-consumer.ts`
+- [ ] arrow const 化: `computeDipSize` / `buildBrowserWindowOptions` / `createTextureReceiver` / `createSharedTextureReceiver` / `createWorkerRenderer`（export 名・シグネチャ不変）
+- [ ] `createTextureBridgeWith` 内の `let previewManager` → const ternary（旧 #59 の変換を現在の関数位置に適用）
+- [ ] URL スキーム if/else チェーン（http/https/file → loadURL、else → loadFile）を収束（http・https・file は同じ `loadURL` 呼びなので条件を 1 つに）
+- [ ] **`client/index.ts` の `lastW`/`lastH` は plain `let` のまま触らない**（slot-object 化 DROP）
+- [ ] テスト: 挙動不変なので既存 162 件が green のまま。toError の単体テストを追加（Error 素通し / 非 Error ラップ + cause）
+
+---
+
+### Task 3: refactor(renderer) — SendResult switch + PreviewManager 準拠（旧 #60）
+
+**Branch:** `refactor/renderer-receiver-preview` / **PR title:** `refactor(renderer): exhaustive SendResult switch + rule-compliant PreviewManager`
+
+**Source:** `gh pr diff 60`（監査で現 main にほぼ verbatim 適用可と確認済み）。Task 2 マージ後に分岐（toError 依存）。
+
+**適応リスト:**
+- [ ] `shared-texture-receiver.ts`: `let frame`/`let result`/`let imported` の解消、`SendResult` の if-chain → exhaustive `switch`（inline `never` default）、`_receiveFrame`/`_sendTracked`/`_importFrame` 抽出、`(VALID_PIXEL_FORMATS as readonly string[]).includes(...)` → cast-free `isValidPixelFormat` ガード
+- [ ] `preview-manager.ts`: `onPreviewReady =` arrow property → method shorthand + stored listener 参照、`this.win!` → narrowed local、`String(this.width)` → template literal、`sendFrame` の `as Electron.SharedTextureImportTextureInfo` cast 除去（`TextureInfo` 型受け）
+- [ ] テスト: 既存 green 維持 + 旧 #60 が持っていたテストがあれば新構造に適応
+
+---
+
+### Task 4: refactor(renderer) — 内部 neverthrow 採用（旧 #62）
+
+**Branch:** `refactor/renderer-neverthrow` / **PR title:** `refactor(renderer): internal neverthrow adoption with typed error classes`
+
+**Source:** `gh pr diff 62`（named fromThrowable binding 済みで現行スキル準拠と監査確認済み）。Task 2・3 マージ後に分岐。
+
+**適応リスト:**
+- [ ] `packages/renderer/src/errors.ts`: `FrameReceiveError` / `TextureImportError` / `TextureDeliveryError` / `UnsupportedPixelFormatError` / `ReceiverStoppedError`（error class は throw/イベント境界を跨ぐもののみ）
+- [ ] `packages/renderer/package.json` に `neverthrow`、tsconfig lib に `ES2022.Error`
+- [ ] `shared-texture-receiver.ts` の `_validate` → `_prepare` → `_deliver` Result chain、`discovery.ts` の `safeListSenders`、`preview-manager.ts` の import→send chain — すべて module-scope named binding、`.match` で edge 消費
+- [ ] **公開 API 不変**（Result を export しない。新規 export は error class のみ）
+- [ ] テスト: 既存 green 維持 + error class 変換パスのテスト
+
+---
+
+### Task 5: refactor(example) — demo app 準拠（旧 #63、slot-object 置換）
+
+**Branch:** `refactor/example-rules` / **PR title:** `refactor(example): coding-rules compliance for the demo app`
+
+**Source:** `gh pr diff 63`。他タスクと独立（main から分岐、Task 1–4 のマージを待たなくてよいが、順序どおりなら最後）。
+
+**適応リスト:**
+- [ ] `main/index.ts`: `getRendererUrl` / `bootstrap` の arrow 化。`let activeReceiver` / `let activeBridge` は **plain let のまま**
+- [ ] `preload/receiver.ts`: `getElement<T>`（instanceof ガード）で 6 箇所の `as HTMLXElement | null` cast を置換、`(err as Error)` → `instanceof Error` ガード
+- [ ] `render-worker.ts`: **旧 diff の `worker = { context: null as ..., ... }` slot-object は採用しない** — `let context: RenderContext | null = null;` の単一 plain let に置き換えて他の let を統合。`WorkerEvent` の exhaustive `switch` と arrow 化は採用
+- [ ] example は test なし → `pnpm lint && pnpm typecheck` + example 起動スモーク（起動 → fps → 必ず kill）
+
+---
+
+## 実装しないこと
+
+- 旧ブランチ（origin の refactor/*）の rebase・再 open
+- slot-object パターンの復活（監査 DROP 2 件）
+- 公開 API への Result 露出

--- a/reports/2026-08-10-simple-core-api-abstraction.md
+++ b/reports/2026-08-10-simple-core-api-abstraction.md
@@ -1,0 +1,314 @@
+# Simple Usage / Core Usage API の抽象化 — Genovese / Cannelloni 調査に基づく再設計レポート
+
+- 日付: 2026-08-10
+- 調査対象:
+  - `~/ghq/github.com/naporin0624/Genovese`（VJ システム。texture-bridge 0.13.1 消費者）
+  - `~/ghq/github.com/naporin0624/Cannelloni`（Electron アプリ。texture-bridge 0.13.0 消費者、patch 適用中）
+  - 本リポジトリ `electron-texture-bridge`（packages/core, packages/renderer）
+- 目的: 両アプリの API 層構造を抽象化し、texture-bridge の **simple usage（高レベル）/ core usage（低レベル）二層 API 再設計**の土台にする
+- 重点スキル: `prefix-match-processor`（dispatch 構造）, `precise-type-modeling`（型モデリング）
+
+---
+
+## 1. 三リポジトリの現状マップ
+
+| | simple usage（推奨経路） | core usage（合成可能な primitive） | 境界（seam） |
+|---|---|---|---|
+| **texture-bridge** | `createTextureBridge(options)` — 窓・paint 配線・DPR・preview を**所有** | `TextureSender` / `TextureReceiver` / `sendTextureFromPaintEvent` — Electron 任意、`sendRgbaBuffer` は素の Node で動く | package 境界（`-renderer` → `-core`）+ README の decision tree |
+| **Genovese** | `composition-singleton` / `compositorBridge` singleton → `createCompositionSession(deps)` | `createCompositorKernel(plugins)` + 17 個の `createXxxPlugin(deps)` + pure 関数群（`compositor-core`） | `CompositorPlugin` interface + `commandPrefixes` prefix dispatch + type-only `ports/*.ts` |
+| **Cannelloni** | `createDeck` — `createTextureBridge` をさらに包む facade（`ResultAsync<Deck, Error>`） | texture-bridge core は**診断ツール専用**（`scripts/syphon-check.ts` の `sendRgbaBuffer`） | `createDeckWith(createBridge: typeof createTextureBridge)` — factory 注入 seam |
+
+**観察 1: 三者とも「二層 + seam」の同型構造。** 差は seam の表現（package 境界 / path alias + port 型 / factory 注入）だけ。
+
+**観察 2: 実アプリは本番経路で simple tier しか使わない。** Cannelloni の本番 `deck.ts` は `createTextureBridge` のみ。core（`sendRgbaBuffer`）は「Electron 無しの切り分けツール」として使われる。Genovese も本番送出は `createTextureBridge`（`texture-bridge-setup.ts`）、core の `TextureReceiver` は受信サービス内部でのみ直接使用。→ **simple tier が製品、core tier は escape hatch + 診断**という役割分担が消費者側の実態。
+
+---
+
+## 2. 抽象モデル: 二層 API の構造
+
+3 リポジトリに共通する構造を抽象化すると次の 4 層になる。
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ L1: Recommended Entry（simple usage）                       │
+│   createTextureBridge / createDeck / composition-singleton  │
+│   ・リソース（窓・worker・native handle）を「所有」する      │
+│   ・プラットフォーム差（DPR, ESM, paint 形状）を「吸収」する │
+│   ・返すのは Handle: commands + events + readonly state      │
+│     + dispose / Symbol.dispose                               │
+├────────────────────────────────────────────────────────────┤
+│ L2: Facade Assembly（配線のみの層）                          │
+│   assembleDeck / createCompositionSession / bridge.ts 内部   │
+│   ・primitive を組み立てるだけ。ロジックは持たない            │
+│   ・Deps 注入 seam（createXxxWith）はこの層に置く            │
+├────────────────────────────────────────────────────────────┤
+│ L3: Primitives（core usage）                                 │
+│   TextureSender / CompositorPlugin / orchestrator / pure fn  │
+│   ・単一責任。呼び出し側のリソースを所有しない                │
+│   ・単体でテスト可能。Electron 非依存が理想                   │
+├────────────────────────────────────────────────────────────┤
+│ L4: Platform Boundary（外部境界）                            │
+│   native addon / Electron paint event / Worker / Vendor SDK  │
+│   ・unknown が到着する唯一の場所。即座に concrete 型へ parse │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 各層の契約
+
+**L1（simple）の契約 — 「所有と吸収」**
+- リソースのライフサイクルを factory が全所有する（Genovese `.claude/rules/headless-app-pattern.md` の言い方では factory → closure state → subscribe → getters → commands → dispose）
+- プラットフォーム quirk はここで吸収する（texture-bridge の `pixelExact`、Cannelloni の `force-device-scale-factor` 判断はこの層の責務）
+- Handle の形: `{ コマンド(void/Promise); on/subscribe; readonly 状態; dispose(); [Symbol.dispose]() }`
+
+**L2（assembly）の契約 — 「配線のみ」**
+- Genovese の `createCompositionSession` header comment が最も明瞭: *"Creates … Builds … NOT responsible for: subscriptions / event routing"*。**自分の入力を自分で subscribe しない**。配線は使用地点（singleton / アプリ側）で明示的に行う
+- テスト用 seam はここ。Cannelloni の `createDeckWith(createBridge: typeof createTextureBridge)` は texture-bridge がそのまま採用できるパターン:
+
+```ts
+// L2 に置く注入 seam。テストは fake bridge を注入できる
+export const createTextureBridgeWith =
+  (deps: TextureBridgeDeps) =>
+  async (options: TextureBridgeOptions): Promise<TextureBridge> => { /* 配線のみ */ };
+
+export const createTextureBridge = createTextureBridgeWith({
+  createWindow: (o) => new BrowserWindow(o),
+  createSender: (name, w, h) => new TextureSender(name, w, h),
+});
+```
+
+**L3（core）の契約 — 「所有しない・吸収しない」**
+- README の DPR 警告が示す通り、core は DPR を吸収**しない**。これはバグではなく契約 — ただし契約は型とドキュメントで明示する（§4 参照）
+- Electron 非依存で動く部分（`sendRgbaBuffer`）は最強の切り分けツールとして両アプリで実証済み。この性質は保護すべき公開契約
+
+**L4（boundary）の契約 — 「unknown は通過点」**
+- `precise-type-modeling` rule 2: 外部から来る値（Electron の paint event、native の返り値）は到着直後に concrete 型へ分類し、失敗は**モデル化された defect** にする（§4.2）
+
+### Options / Deps の分離（Genovese house style の一般化）
+
+| | 中身 | 例 |
+|---|---|---|
+| `XxxOptions` | **値**（設定・寸法・名前） | `{ name, width, height, frameRate?, pixelExact? }` |
+| `XxxDeps` | **協力者**（注入可能な実装） | `{ createWindow, createSender, discovery? }` |
+
+texture-bridge の現行 `TextureBridgeOptions` は値のみでこの規約に適合済み。欠けているのは Deps 側（factory がすべて内部 import）で、Cannelloni がテストのために `createDeckWith` を自作した事実が需要の証拠。
+
+---
+
+## 3. Dispatch 構造の抽象化（prefix-match-processor 観点）
+
+両アプリには **`Result<Match, PassThrough>` を契約とする first-match chain が計 5 実装**あり、すべて同じ形に収束している。
+
+### 3.1 観測された 3 variant
+
+**Variant A: Result 契約の first-match chain（skill の canonical 形）**
+Cannelloni の toast / MIDI decode、Genovese・Cannelloni 両方の intent router。
+
+```ts
+// 契約: ok = 自分が処理した（short-circuit）/ err(入力そのまま) = 次へ
+type Processor<In, Out> = {
+  readonly id: string;
+  readonly run: (input: In) => Result<Out, In>;
+};
+// runner は再帰 first-match。registry は配列順 = 優先度（specific first）
+```
+
+**Variant B: 宣言的 prefix map + 最長一致 + 構築時衝突検査**
+Genovese の compositor kernel。plugin が `commandPrefixes: readonly string[]` を宣言し、kernel が:
+1. 構築時に prefix 衝突を throw（`"effect/" claimed by both X and Y`）
+2. `sort((a, b) => b.length - a.length)` で**最長 prefix 優先**を機械化（skill の「specific first」を並び順の人為ミスから解放）
+3. dispatch は `startsWith` 一致した plugin の `onCommand` に委譲、suffix の `switch` は plugin 内部
+
+**Variant C: phantom rest parameter による registry 網羅性のコンパイル時検査**
+両アプリの intent router が同一実装:
+
+```ts
+export const createIntentRouter = <const Routes extends readonly IntentRoute[]>(
+  routes: Routes,
+  ..._exhaustive: Exclude<IntentNamespace, Routes[number]['id']> extends never
+    ? []
+    : [missingRoutesFor: Exclude<IntentNamespace, Routes[number]['id']>]
+): ((intent: Intent) => Result<IntentWork, Intent>) => ...
+```
+
+route を 1 個消すと**呼び出し側が型エラーになり、欠けた namespace 名がエラーメッセージに現れる**。
+
+### 3.2 使い分けの抽象規則
+
+| 条件 | 選ぶ形 |
+|---|---|
+| ≤ ~5 家族 & 各分岐 1 行 | inline `switch`（抽出は premature — skill の閾値） |
+| 家族集合が**閉じた union**（`Intent['type']` から導出可能） | Variant A + C: Result chain + phantom param で網羅性検査 |
+| 家族集合が**開いている**（plugin が後から追加され、union を中央で持てない） | Variant B: 宣言的 prefix + 最長一致 + 衝突検査 |
+
+### 3.3 texture-bridge への適用
+
+- 現行の worker protocol（`{ type: "init" | "resize" | "dispose" }` の 3 variant）は**閾値未満。inline switch のままが正しい**
+- ただし今後 command 家族が増える場合（例: `sender/`, `receiver/`, `preview/`, `worker/` の名前空間で bridge 制御コマンドを拡張する場合）は Variant A+C を採用する。texture-bridge の command 集合はライブラリが中央で定義する閉じた union なので、Genovese kernel 型（開集合向け）より **intent router 型（閉集合向け）が適合**
+- `createMultiDispatcher`（現行 renderer/client）は「1 upstream → 全 consumer に fan-out」であり、first-match chain とは**直交する別パターン**。統合しないこと。両者の区別を型名で明示する価値がある: `MultiDispatcher`（fan-out, 全員に配る）vs `ProcessorChain`（first-match, 1 人が引き取る）
+
+---
+
+## 4. 型モデリングの抽象化（precise-type-modeling 観点）
+
+### 4.1 現行 texture-bridge の型で rule 違反になっている箇所
+
+**`TextureInfo.handle` — optional 2 連は collapsed union（rule 4 違反）**
+
+```ts
+// 現行: どちらも optional。両方 undefined / 両方 Buffer が型上表現可能
+handle: {
+  ntHandle?: Buffer;   // Windows
+  ioSurface?: Buffer;  // macOS
+};
+```
+
+これは Electron の paint event をそのまま写した boundary 型なので、**入口はこの形で受けてよいが、rule 2 に従い到着直後に分類する**:
+
+```ts
+/** L4 → L3 の入口で分類した結果。impossible state を排除する */
+type ClassifiedHandle =
+  | { readonly platform: "win32"; readonly ntHandle: Buffer }
+  | { readonly platform: "darwin"; readonly ioSurface: Buffer };
+
+/** 分類失敗も throw ではなくモデル化された defect にする */
+type PaintDefect =
+  | { readonly reason: "no-texture" }
+  | { readonly reason: "no-nt-handle" }
+  | { readonly reason: "no-io-surface" };
+
+const classifyPaintTexture = (
+  texture: PaintTexture | undefined,
+  platform: NodeJS.Platform,
+): Result<ClassifiedHandle, PaintDefect> => { ... };
+```
+
+これは Cannelloni が worktree `fix-win-spout-diagnostics` で**ライブラリの外側に自作した** `paintTextureDefect()`（`'no-texture' | 'no-nt-handle' | 'no-io-surface'` 分類）の取り込みに相当する。消費者が診断のために逆向きに実装した = ライブラリ側にあるべき型だった、という強い証拠。
+
+**Silent drop の廃止（defect union の出口）**
+
+Cannelloni の Win10 調査レポートが名指しした 2 箇所 — renderer `handlePaint()` の `if (!texture?.textureInfo) return;` と core win32 の `if (!ntHandle || ...) return;` — は無言 return で、受信側には「黒画面」としてしか観測できない。上の `PaintDefect` union をそのまま event に流す:
+
+```ts
+interface BridgeEvents {
+  // 既存: fps, ready, error, disposed, resize
+  frameDropped: [defect: PaintDefect];  // 追加。error とは別チャンネル（正常系の no-op も含むため）
+}
+```
+
+Cannelloni の `MidiSkipReason`（「これは失敗ではなく正常な no-op」を tagged 型で表す）と同じ設計判断。**drop は error ではないが観測可能でなければならない。**
+
+**`SenderInfo` の optional（`appName?`, `uuid?`）**
+プラットフォーム依存の optional。頻度・実害が低いので優先度は下がるが、platform tag 付き union 化が筋。
+
+**`PaintTexture.release?`**
+Electron 40–41（optional）と 42+（必須）のバージョン差を optional で表している。型 1 本で全バージョンを覆うのは不可能なので、これは現状維持が妥当（README の version note で契約明示済み）。
+
+### 4.2 エラーチャンネルの層別規約
+
+Genovese / Cannelloni と既存メモリ（neverthrow-api-boundary: **Result は internal-only、edge で `.match`**）から、層ごとのエラー表現規約を抽象化できる:
+
+| 層 | エラー表現 | 根拠 |
+|---|---|---|
+| L1 公開 API | `void` + throw（error class）+ `error` / `frameDropped` event | Result を公開 API に出さない（neverthrow-api-boundary）。PR #64 で確立済み |
+| L2 / L3 内部 | `Result` / `ResultAsync`（module-scope named `fromThrowable` binding） | PR #65/#66 で確立済み。chain 契約は `Result<Match, PassThrough>` |
+| 正常系 no-op | error にせず tagged union（`PaintDefect`, `MidiSkipReason` 型） | 「失敗」と「処理対象外」の混同を防ぐ |
+| throw 境界を跨ぐもののみ | `class extends Error` | Genovese は React error boundary を跨ぐ 1 箇所だけ class（`CompositorFailureError`）。texture-bridge の `TextureSendError` も同判断 |
+
+### 4.3 イベントの型モデル: tuple map vs event union
+
+- texture-bridge（現行）: `BridgeEvents = { fps: [number]; ready: []; ... }` + generic `on<K>` — EventEmitter idiom
+- Genovese: `subscribe(cb: (event: EventUnion) => void)` — union + `switch` で網羅性検査が効く
+
+**推奨: 公開 L1 は現行 tuple map を維持**（Electron エコシステムの idiom、既存消費者互換）。**内部 seam（L2↔L3、worker protocol）は event union + subscribe** に寄せる。discriminated union なら受信側の `switch` に variant 追加漏れがコンパイルエラーとして現れる — tuple map ではイベント名追加が消費者側で静かに無視される。
+
+### 4.4 型の導出規約
+
+- 公開 Handle 型（`TextureBridge`）: 明示 interface を維持（ドキュメント性、JSDoc の付着点）
+- 内部 assembly の型: `export type Xxx = ReturnType<typeof createXxx>`（Genovese house style）で導出し、二重定義を避ける
+- 派生 surface は演算で導出: Genovese の `CompositionProxy = Omit<CompositionManager, ...> & {...}`、port 型（コマンド union の最小 subset を type-only で切り出し、L2 が L3 の全体ではなく必要面だけに依存する）は texture-bridge の `/client` サブパスの型設計に転用可能
+
+---
+
+## 5. ドキュメント構造の抽象化
+
+両アプリの一次資料から、simple/core 二層ドキュメントの必須要素が抽出できる:
+
+1. **Decision tree は「誰がリソースを所有するか」で分岐させる**（現 README の "Which API should I use?" は Cannelloni の doc-feedback §2 の要望通りで正しい。維持）
+2. **役割テーブル + 依存方向図**（renderer → core → native → platform-binary）。Cannelloni doc-feedback §1 が要望。※ `texture-bridge-core` の package.json description が *"High-level GPU texture sharing"* になっているのは実バグ（低レベル package なのに High-level と自称）— 要修正
+3. **拡張の complexity 段階表**: Genovese `effect-system.md` の Pattern A（3 ファイルのレシピ、plugin 不要）/ B / C（plugin 自作）→ Low/Medium/High 比較表という構成は、texture-bridge の「simple で足りるか core に降りるか」ガイドの雛形になる
+4. **プラットフォーム quirk は simple tier の吸収機能として文書化し、core tier では「吸収しない」と明記**（DPR 警告の現構成は正しい）
+
+---
+
+## 6. texture-bridge 再設計 backlog（優先度順）
+
+調査から直接導かれる具体タスク。上 3 つは消費者が現に踏んでいる実バグ/実需要。
+
+> **進捗（2026-08-12 時点）**: #1 = 0.13.1 で修正済みだった（回帰ガードを PR #67 で追加）/ #2 = PR #67（`PaintDefect` + `frameDropped` + `droppedReason`）/ #3 = PR #69（OSR scale policy — 正体は Electron 42 の OSR scale 1.0 化。`reports/2026-08-11-pixelexact-osr-scale-investigation.md`）/ #4 = #2 のガード分岐実装で実質消化 / #5・#6・#7 = PR #70（`createTextureBridgeWith` / 同期 `destroy()` / description + 依存方向図）/ **#8 = 棚卸しの結果クローズ** — 内部 seam は既に union ベース（worker protocol の message union、multi-dispatcher の lifecycle event union）で、唯一のコールバック object `SharedTextureConsumerHandlers` は単一 variant（union 化の閾値未満）。公開面の tuple map は §4.3 の方針どおり維持 / #9 = 設計どおり保留（command family > 5 まで）。残: Windows 実機での display scaling 検証（要 Windows 機）。
+
+| # | 項目 | 出典 | 規模 |
+|---|---|---|---|
+| 1 | ~~ESM `__dirname` バグ修正~~ **→ 0.13.1 で修正済み**（`tsdown.config.mts` の `shims: true`、commit df76799 / 8c06ba6）。Cannelloni の patch は 0.13.0 固定に当てたもの。残作業: (a) shim 消失を防ぐ回帰テスト（本 repo）、(b) Cannelloni の 0.13.1 アップグレード + patch 撤去（消費者側） | Cannelloni `patches/@napolab__texture-bridge-renderer@0.13.0.patch` / renderer CHANGELOG 0.13.1 | 小 |
+| 2 | **silent drop の event 化**: `classifyPaintTexture` + `frameDropped: [PaintDefect]` event（§4.1） | Cannelloni win10 調査レポート / diagnostics worktree | 中 |
+| 3 | **`pixelExact` の再検証**: OSR shared-texture が device scale 1.0 で描画される環境では `computeDipSize` が逆効果（1920→実質 960）。Cannelloni は削除して `force-device-scale-factor=1` へ移行、Genovese は使用継続。どの環境で正しく働くかの契約明確化 + `width/height` が "pixels" と文書化されつつ DIP として渡される契約不一致（Genovese AGENTS.md 指摘）の解消 | Cannelloni `reports/2026-06-17-*.md` / Genovese `AGENTS.md:47` | 中〜大 |
+| 4 | `TextureInfo.handle` の内部分類 union 化（#2 の前提。公開型は Electron 互換のまま） | §4.1 | 小 |
+| 5 | `createTextureBridgeWith(deps)` seam の公開（テスト用 factory 注入） | Cannelloni `createDeckWith` | 小 |
+| 6 | `dispose()` と `before-quit` の競合: `renderWindow.close()`（async）では SIGKILL に間に合わずクラッシュダイアログが出る。`destroy()` を含む同期 teardown の提供 or 文書化 | Genovese `texture-bridge-setup.ts:92-99` / Cannelloni `deck.ts:120-124`（両者が独立に同じ workaround） | 小 |
+| 7 | core package description 修正（"High-level" → 低レベルの正しい説明）+ 依存方向図の README 追加 | Cannelloni doc-feedback §1 | 小 |
+| 8 | 内部 seam のイベントを union + subscribe に寄せる（worker protocol から段階適用） | §4.3 | 中 |
+| 9 | command 家族が 5 を超えた時点で intent-router 型 processor chain 導入（それまでは着手しない） | §3.3 | 保留 |
+
+---
+
+## 付録: 抽象モデルの型スケッチ（seam 契約の全体像）
+
+```ts
+// ── L1: simple usage の Handle 契約 ─────────────────────────
+interface BridgeEvents {
+  fps: [fps: number];
+  ready: [];
+  error: [error: Error];
+  frameDropped: [defect: PaintDefect];   // 追加（§4.1）
+  disposed: [];
+  resize: [width: number, height: number];
+}
+
+interface TextureBridge {
+  on<K extends keyof BridgeEvents>(event: K, listener: (...args: BridgeEvents[K]) => void): this;
+  resize(width: number, height: number): void;
+  readonly renderWindow: BrowserWindow;
+  readonly isDisposed: boolean;
+  dispose(): void;
+  [Symbol.dispose](): void;
+}
+
+// ── L2: assembly の注入 seam ────────────────────────────────
+interface TextureBridgeDeps {
+  createWindow: (options: Electron.BrowserWindowConstructorOptions) => BrowserWindow;
+  createSender: (name: string, width: number, height: number) => TextureSender;
+}
+declare const createTextureBridgeWith: (
+  deps: TextureBridgeDeps,
+) => (options: TextureBridgeOptions) => Promise<TextureBridge>;
+
+// ── L3/L4 境界: boundary 分類（unknown は通過点） ───────────
+type ClassifiedHandle =
+  | { readonly platform: "win32"; readonly ntHandle: Buffer }
+  | { readonly platform: "darwin"; readonly ioSurface: Buffer };
+
+type PaintDefect =
+  | { readonly reason: "no-texture" }
+  | { readonly reason: "no-nt-handle" }
+  | { readonly reason: "no-io-surface" };
+
+declare const classifyPaintTexture: (
+  texture: PaintTexture | undefined,
+  platform: NodeJS.Platform,
+) => Result<ClassifiedHandle, PaintDefect>;
+
+// ── 将来の dispatch seam（family > 5 になったら。§3.3） ────
+interface Processor<In, Out> {
+  readonly id: string;
+  run(input: In): Result<Out, In>;   // ok = 引き取った / err(input) = 次へ
+}
+```


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with agent guidance for this repository
- Add superpowers plan docs: `2026-08-12-di-seam-sync-dispose-docs.md`, `2026-08-12-refactor-stack-revival.md`
- Add investigation report: `reports/2026-08-10-simple-core-api-abstraction.md`

Documentation-only change — no package source touched, so no release-please release is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDqX9uSw79G2irtbs5AJd5