### PR TITLE
feat(renderer): report forwardFrames delivery state via forwardStatus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,42 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only: these jobs build and test, they never write back.
+permissions:
+  contents: read
+
 jobs:
+  # Keeps the workflows themselves under review — unpinned actions, the token
+  # left behind in .git/config, permissions wider than a job needs. The tree is
+  # clean as of this job's introduction, so anything it reports later is
+  # something that pull request introduced, not inherited debt.
+  workflows:
+    runs-on: ubuntu-latest
+    name: Workflow Audit
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      # Pinned: an audit that silently changes its own ruleset turns a green
+      # check into a moving target.
+      - run: uvx zizmor@1.29.0 --persona=regular .github/workflows/
+
   check:
     runs-on: ubuntu-latest
     name: Lint & Typecheck
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -3,25 +3,30 @@ name: Platform Smoke
 on:
   workflow_dispatch:
 
+# Read-only: these jobs build and test, they never write back.
+permissions:
+  contents: read
+
 jobs:
   macos-native-smoke:
     runs-on: macos-14
     name: macOS Native Smoke
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          persist-credentials: false
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build Syphon.framework
         run: |
@@ -64,18 +69,20 @@ jobs:
     runs-on: windows-latest
     name: Windows Native Smoke
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Fetch Spout2 SDK
         shell: pwsh

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,48 @@
+name: Preview Release
+
+# Publishes an installable preview of the renderer package for every pull
+# request, so a consumer app can run against a change before it is merged and
+# released. Nothing reaches the npm registry and no version is bumped —
+# pkg.pr.new serves the tarball from its own host, keyed by commit SHA.
+#
+# Requires the pkg.pr.new GitHub App to be installed on this repository
+# (https://github.com/apps/pkg-pr-new). Without it the publish step fails with
+# an explicit message; it cannot be granted from inside the workflow.
+
+on:
+  pull_request:
+    branches: [main]
+
+# The preview URL and the PR comment come from the GitHub App, not from this
+# workflow's token — it needs nothing.
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: pkg.pr.new
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      # core is built because renderer's build reads its types; only renderer
+      # is published. The native addon is deliberately left out: it needs the
+      # Rust matrix, and a preview of a renderer-only change does not move it.
+      - run: pnpm build:core && pnpm build:renderer
+
+      # --pnpm packs through `pnpm pack`, which rewrites the `workspace:*`
+      # dependency on @napolab/texture-bridge-core to its concrete version, so
+      # the preview installs that dependency from npm like a normal release.
+      # `npm pack` would leave the protocol literal and the tarball would be
+      # uninstallable outside this workspace.
+      - run: pnpm dlx pkg-pr-new@0 publish --pnpm './packages/renderer'

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -22,13 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     name: pkg.pr.new
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -45,4 +47,8 @@ jobs:
       # the preview installs that dependency from npm like a normal release.
       # `npm pack` would leave the protocol literal and the tarball would be
       # uninstallable outside this workspace.
-      - run: pnpm dlx pkg-pr-new@0 publish --pnpm './packages/renderer'
+      #
+      # zizmor reads "publish" and asks for trusted publishing. There is no
+      # registry credential to replace here: pkg.pr.new authorizes the run
+      # through its GitHub App, and nothing is sent to npm.
+      - run: pnpm dlx pkg-pr-new@0 publish --pnpm './packages/renderer' # zizmor: ignore[use-trusted-publishing]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,18 +4,21 @@ on:
   push:
     branches: [main]
 
+# Default for every job; the two that need to write ask for it themselves.
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # Opens/updates the release PR and cuts the GitHub release.
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
           config-file: release-please-config.json
@@ -42,20 +45,21 @@ jobs:
     name: Build (${{ matrix.name }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          persist-credentials: false
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -97,7 +101,7 @@ jobs:
         env:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bindings-${{ matrix.name }}
           path: packages/native/index.*.node
@@ -107,7 +111,7 @@ jobs:
       # These are platform-independent so we only need them once
       - name: Upload JS loader
         if: matrix.name == 'darwin-arm64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: js-loader
           path: |
@@ -119,7 +123,7 @@ jobs:
       # Only from ARM build (framework is universal via ONLY_ACTIVE_ARCH=NO)
       - name: Upload Syphon.framework
         if: matrix.name == 'darwin-arm64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: syphon-framework
           path: vendor/Syphon.framework
@@ -130,15 +134,21 @@ jobs:
     if: always() && !cancelled() && needs.build.result == 'success' && needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
     name: Publish
+    # id-token is the npm OIDC trusted-publishing credential.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           # Node 24 ships with npm 11+, required for OIDC trusted publishing.
           # Avoids upgrading npm at runtime — Node 22.22.2's bundled npm was
@@ -150,7 +160,7 @@ jobs:
 
       - run: pnpm install
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: packages/native/artifacts
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npx skills add naporin0624/electron-texture-bridge@receiving-shared-textures
 npx skills add naporin0624/electron-texture-bridge@managing-frame-forward-lifecycle
 npx skills add naporin0624/electron-texture-bridge@delivering-imported-textures
 npx skills add naporin0624/electron-texture-bridge@handling-texture-bridge-failures
+npx skills add naporin0624/electron-texture-bridge@diagnosing-dead-frame-forwards
 ```
 
 Add `-g` to install globally instead of into the current project.
@@ -74,6 +75,7 @@ Skills activate automatically from conversation context — there are no command
 | `managing-frame-forward-lifecycle` | Registering and tearing down `forwardFrames` targets: monitor windows that close and reopen, repeated connect/disconnect, `MaxListenersExceededWarning`, leaks around forwarding |
 | `delivering-imported-textures` | Delivering a texture to a renderer from main: `importSharedTexture` / `sendSharedTexture` / `release()` by hand, where `release()` belongs, `sendImportedTexture` vs `forwardSharedTexture` |
 | `handling-texture-bridge-failures` | Error handling and telemetry: which calls throw, reject, model a defect, or emit — what to wrap with `Result.fromThrowable`, silently black output, a main-process crash from a bridge call |
+| `diagnosing-dead-frame-forwards` | A forwarded preview/monitor that went black, froze on its last frame, or shows "no signal" — dead previews with nothing in the logs, or only some targets dying while Syphon/Spout keeps working |
 
 ## Quick Start
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,6 +64,7 @@ interface TextureBridge {
   on(event: "ready", listener: () => void): this;
   on(event: "error", listener: (error: Error) => void): this;
   on(event: "frameDropped", listener: (defect: PaintDefect) => void): this;
+  on(event: "forwardStatus", listener: (status: ForwardStatusEvent) => void): this;
   on(event: "resize", listener: (width: number, height: number) => void): this;
   on(event: "disposed", listener: () => void): this;
 
@@ -88,6 +89,27 @@ again only after a successful send or a reason change. If a drop latches
 before your listener is attached (e.g. while the renderer page is still
 loading), read `bridge.droppedReason` — it holds the latest drop reason, or
 `null` after a successful send.
+
+`forwardStatus` reports the delivery state of each `forwardFrames`
+registration — the only channel that does, since forwarding never raises
+`"error"` and never touches `frameDropped` / `droppedReason`. It fires on
+state *changes*, not per frame: the first successful frame, the first
+failure, a change of failure reason, and the recovery back to success.
+
+```typescript
+type ForwardStatus =
+  | { ok: true }
+  | { ok: false; reason: "target-destroyed" | "import-failed" | "send-failed"; cause?: Error };
+
+type ForwardStatusEvent = ForwardStatus & { extraArgs: readonly unknown[] };
+```
+
+Which registration a status belongs to is identified by `extraArgs` — the tag
+passed to `forwardFrames(target, { extraArgs })`. To scope the same
+transitions to one registration instead, pass `onStatus` in the same options
+object. Watch this: a forward can die while paint, sender and preview all stay
+healthy, and without it the only symptom is a monitor window that quietly
+stays black.
 
 `dispose()` destroys the offscreen `renderWindow` synchronously via
 `destroy()` (not `close()`), so teardown cannot lose the race against
@@ -115,14 +137,18 @@ call it **before** `dispose()`, not after.
 ### `TextureBridge.forwardFrames(target, options?)`
 
 ```typescript
-const forward = bridge.forwardFrames(monitorWindow.webContents, { extraArgs: [slot] });
+const forward = bridge.forwardFrames(monitorWindow.webContents, {
+  extraArgs: [slot],
+  onStatus: (s) => log(`slot ${slot} forwarding`, s.ok ? "ok" : s.reason),
+});
+if (!forward.active) log(`slot ${slot} was refused — no frames will arrive`);
 // later
 forward.dispose(); // idempotent
 ```
 
 Registers a `WebContents` (e.g. a monitor/multiviewer window) to receive every subsequent paint frame over the same zero-copy shared-texture path `forwardSharedTexture` uses — no pixel readback, just a GPU handle.
 
-**Best-effort contract**, same as the preview path: forward failures (a `ForwardDefect` from the core `forwardSharedTexture` primitive) are discarded by this driver and never surface as an `"error"` event or affect `frameDropped`/`droppedReason`. **Independent of the native Syphon/Spout send** — forwarding runs before `sendTextureFromPaintEvent` inside the paint handler, so a thrown native send failure can't suppress a registered forward, and a forward failure can never block the native send either; the two paths fire regardless of each other's outcome.
+**Best-effort contract**, same as the preview path: forward failures (a `ForwardDefect` from the core `forwardSharedTexture` primitive) never stop the stream, never surface as an `"error"` event, and never affect `frameDropped`/`droppedReason` — they are reported as state transitions on `forwardStatus` (bridge-wide) and `options.onStatus` (this registration only). `FrameForward.active` covers the other half: it is `false` when the registration was refused outright (bridge disposed, or target already destroyed) and flips to `false` when the target is destroyed or the forward is disposed. **Independent of the native Syphon/Spout send** — forwarding runs before `sendTextureFromPaintEvent` inside the paint handler, so a thrown native send failure can't suppress a registered forward, and a forward failure can never block the native send either; the two paths fire regardless of each other's outcome.
 
 `FrameForward.dispose()` unregisters that one target and is idempotent — calling it twice, or after `bridge.dispose()` already cleared it, is a no-op. `bridge.dispose()` clears every registered forward.
 

--- a/packages/renderer/src/__tests__/bridge.test.ts
+++ b/packages/renderer/src/__tests__/bridge.test.ts
@@ -82,7 +82,7 @@ import { BrowserWindow } from "electron";
 import { TextureSender, sendTextureFromPaintEvent } from "@napolab/texture-bridge-core";
 import type { PaintDefect, PaintTexture } from "@napolab/texture-bridge-core";
 import type { ForwardDefect } from "@napolab/texture-bridge-core/electron";
-import type { TextureBridgeOptions } from "../types";
+import type { ForwardStatus, ForwardStatusEvent, TextureBridgeOptions } from "../types";
 import type { PreviewManager } from "../preview-manager";
 
 // Module-scope so both `TextureBridgeImpl.handlePaint — frameDropped` and
@@ -990,5 +990,233 @@ describe("TextureBridgeImpl.forwardFrames", () => {
     expect(forwardSharedTextureMock).not.toHaveBeenCalled();
 
     expect(() => forward.dispose()).not.toThrow();
+  });
+});
+
+// forwardFrames の配信状態は 0.14 まで完全に不可視だった(defect は catch で捨てられ、
+// 登録失敗は inert handle で黙殺)。本番で「paint は正常なのにプレビューだけ無言で死ぬ」
+// 事故が起きても切り分ける手段が無かったため、状態遷移を 1 本のチャネルで出す。
+describe("TextureBridgeImpl.forwardFrames — status observability", () => {
+  const makeTexture = () => ({
+    textureInfo: {
+      pixelFormat: "bgra" as const,
+      codedSize: { width: 16, height: 9 },
+      visibleRect: { x: 0, y: 0, width: 16, height: 9 },
+      handle: {},
+    },
+    release: vi.fn(),
+  });
+
+  const makeWebContentsStub = (id: string): Electron.WebContents => {
+    const stub: unknown = Object.assign(new EventEmitter(), { id, isDestroyed: () => false });
+    return stub as Electron.WebContents;
+  };
+
+  const makeBridge = (): TextureBridgeImpl =>
+    new TextureBridgeImpl(new BrowserWindow(), new TextureSender("t", 16, 9), null, baseOpts);
+
+  // forwardSharedTexture は async — 解決 → .then → emit まで複数 tick かかるので
+  // マクロタスク境界まで待ってから assert する。
+  const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("emits forwardStatus { ok: true } once when forwarding starts, not per frame", async () => {
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    const statuses: ForwardStatusEvent[] = [];
+    bridge.on("forwardStatus", (s) => {
+      statuses.push(s);
+    });
+    bridge.forwardFrames(makeWebContentsStub("a"), { extraArgs: ["P1"] });
+
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    expect(statuses).toEqual([{ ok: true, extraArgs: ["P1"] }]);
+  });
+
+  it("emits ok:false with the defect reason and dedupes consecutive identical failures", async () => {
+    sendMock.mockReturnValue(undefined);
+    // 永続 mockResolvedValue は afterEach の mockClear では消えず後続テストへ漏れるので
+    // フレーム数ぶんの Once を積む。
+    forwardSharedTextureMock
+      .mockResolvedValueOnce({ reason: "target-destroyed" })
+      .mockResolvedValueOnce({ reason: "target-destroyed" })
+      .mockResolvedValueOnce({ reason: "target-destroyed" });
+    const bridge = makeBridge();
+    const statuses: ForwardStatusEvent[] = [];
+    bridge.on("forwardStatus", (s) => {
+      statuses.push(s);
+    });
+    bridge.forwardFrames(makeWebContentsStub("a"));
+
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    expect(statuses).toEqual([{ ok: false, reason: "target-destroyed", extraArgs: [] }]);
+  });
+
+  it("emits ok:true again when forwarding recovers", async () => {
+    sendMock.mockReturnValue(undefined);
+    forwardSharedTextureMock.mockResolvedValueOnce({ reason: "target-destroyed" });
+    const bridge = makeBridge();
+    const statuses: ForwardStatusEvent[] = [];
+    bridge.on("forwardStatus", (s) => {
+      statuses.push(s);
+    });
+    bridge.forwardFrames(makeWebContentsStub("a"));
+
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    expect(statuses.map((s) => s.ok)).toEqual([false, true]);
+  });
+
+  it("emits again when the failure reason changes", async () => {
+    sendMock.mockReturnValue(undefined);
+    const cause = new Error("boom");
+    forwardSharedTextureMock.mockResolvedValueOnce({ reason: "import-failed", cause });
+    forwardSharedTextureMock.mockResolvedValueOnce({ reason: "send-failed", cause });
+    const bridge = makeBridge();
+    const statuses: ForwardStatusEvent[] = [];
+    bridge.on("forwardStatus", (s) => {
+      statuses.push(s);
+    });
+    bridge.forwardFrames(makeWebContentsStub("a"));
+
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    expect(statuses).toEqual([
+      { ok: false, reason: "import-failed", cause, extraArgs: [] },
+      { ok: false, reason: "send-failed", cause, extraArgs: [] },
+    ]);
+  });
+
+  it("treats a rejected forward as a send-failed status", async () => {
+    sendMock.mockReturnValue(undefined);
+    const cause = new Error("rejected");
+    forwardSharedTextureMock.mockRejectedValueOnce(cause);
+    const bridge = makeBridge();
+    const statuses: ForwardStatusEvent[] = [];
+    bridge.on("forwardStatus", (s) => {
+      statuses.push(s);
+    });
+    bridge.forwardFrames(makeWebContentsStub("a"));
+
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    expect(statuses).toEqual([{ ok: false, reason: "send-failed", cause, extraArgs: [] }]);
+  });
+
+  it("invokes the per-forward onStatus callback with the same transitions", async () => {
+    sendMock.mockReturnValue(undefined);
+    forwardSharedTextureMock.mockResolvedValueOnce({ reason: "target-destroyed" });
+    const bridge = makeBridge();
+    const seen: ForwardStatus[] = [];
+    bridge.forwardFrames(makeWebContentsStub("a"), {
+      extraArgs: ["P1"],
+      onStatus: (s) => {
+        seen.push(s);
+      },
+    });
+
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    expect(seen).toEqual([{ ok: false, reason: "target-destroyed" }, { ok: true }]);
+  });
+
+  it("keeps forwarding when an onStatus callback throws", async () => {
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    bridge.forwardFrames(makeWebContentsStub("a"), {
+      onStatus: () => {
+        throw new Error("listener blew up");
+      },
+    });
+
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+    bridge.handlePaint({ texture: makeTexture() });
+    await flush();
+
+    // 例外は unhandled rejection にならず、後続フレームの転送も止まらない。
+    expect(forwardSharedTextureMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not emit for a forward disposed while a frame was in flight", async () => {
+    sendMock.mockReturnValue(undefined);
+    let settle: (value: undefined) => void = () => {};
+    forwardSharedTextureMock.mockImplementationOnce(
+      async () =>
+        await new Promise<undefined>((resolve) => {
+          settle = resolve;
+        }),
+    );
+    const bridge = makeBridge();
+    const statuses: ForwardStatusEvent[] = [];
+    bridge.on("forwardStatus", (s) => {
+      statuses.push(s);
+    });
+    const forward = bridge.forwardFrames(makeWebContentsStub("a"));
+
+    bridge.handlePaint({ texture: makeTexture() });
+    forward.dispose();
+    settle(undefined);
+    await flush();
+
+    expect(statuses).toEqual([]);
+  });
+
+  it("exposes active: true while registered and false once disposed", () => {
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    const forward = bridge.forwardFrames(makeWebContentsStub("a"));
+
+    expect(forward.active).toBe(true);
+
+    forward.dispose();
+
+    expect(forward.active).toBe(false);
+  });
+
+  it("flips active to false when the target is destroyed or the bridge is disposed", () => {
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    const wc = makeWebContentsStub("a");
+    const byTarget = bridge.forwardFrames(wc);
+    const byBridge = bridge.forwardFrames(makeWebContentsStub("b"));
+
+    wc.emit("destroyed");
+    expect(byTarget.active).toBe(false);
+    expect(byBridge.active).toBe(true);
+
+    bridge.dispose();
+    expect(byBridge.active).toBe(false);
+  });
+
+  it("reports active: false for a registration that was silently refused", () => {
+    sendMock.mockReturnValue(undefined);
+    const bridge = makeBridge();
+    const dead = makeWebContentsStub("a");
+    Object.assign(dead, { isDestroyed: () => true });
+
+    // 破壊済み target と dispose 済み bridge — どちらも 0.14 では inert handle を
+    // 無言で返していた。呼び出し側が登録の失敗を検知できることが肝。
+    expect(bridge.forwardFrames(dead).active).toBe(false);
+
+    bridge.dispose();
+
+    expect(bridge.forwardFrames(makeWebContentsStub("b")).active).toBe(false);
   });
 });

--- a/packages/renderer/src/bridge.ts
+++ b/packages/renderer/src/bridge.ts
@@ -6,12 +6,14 @@ import {
   type PaintTexture,
   type PaintDefect,
 } from "@napolab/texture-bridge-core";
-import { forwardSharedTexture } from "@napolab/texture-bridge-core/electron";
+import { forwardSharedTexture, type ForwardDefect } from "@napolab/texture-bridge-core/electron";
 import { PreviewManager } from "./preview-manager";
 import { FpsCounter } from "./fps-counter";
 import type {
   TextureBridgeOptions,
   TextureBridge,
+  ForwardStatus,
+  ForwardStatusEvent,
   FrameForward,
   FrameForwardOptions,
 } from "./types";
@@ -91,6 +93,49 @@ interface PaintEvent extends Event {
 }
 
 /**
+ * One `forwardFrames` registration. `lastStatus` is the only mutable field —
+ * it is the dedupe cursor that turns a per-frame result stream into the
+ * state-change stream `forwardStatus` / `onStatus` promise to deliver.
+ */
+interface ForwardEntry {
+  readonly target: WebContents;
+  readonly extraArgs: readonly unknown[];
+  readonly onStatus?: (status: ForwardStatus) => void;
+  readonly onDestroyed: () => void;
+  /** Last reported state, or `null` before the first frame settles. */
+  lastStatus: "ok" | ForwardDefect["reason"] | null;
+}
+
+/**
+ * Widen one frame's outcome into the public state shape. Module scope and
+ * pure so the branch that decides whether a `cause` exists is testable and
+ * lives in exactly one place — `target-destroyed` is the only defect without
+ * one, so it cannot be spread in blindly.
+ */
+const toForwardStatus = (defect: ForwardDefect | undefined): ForwardStatus => {
+  if (defect === undefined) return { ok: true };
+  if (defect.reason === "target-destroyed") return { ok: false, reason: defect.reason };
+  return { ok: false, reason: defect.reason, cause: defect.cause };
+};
+
+/**
+ * Hand a status to one best-effort observer, swallowing whatever it throws.
+ * Both sinks (`onStatus` and the `forwardStatus` event) run inside a promise
+ * continuation, where an escaping throw becomes an unhandled rejection in the
+ * main process — and neither sink is allowed to break frame forwarding. The
+ * `"error"` event is deliberately not used to report this: it throws when
+ * nobody is listening, which is exactly the situation a diagnostic channel
+ * has to survive.
+ */
+const notifyForwardObserver = (deliver: () => void, label: string): void => {
+  try {
+    deliver();
+  } catch (err) {
+    console.error(`[texture-bridge] ${label} threw:`, err);
+  }
+};
+
+/**
  * Remove a `forwardFrames` entry's "destroyed" listener from its target.
  * Module scope so the dependency (the entry) is an explicit argument — no
  * inner function declarations. Guarded with `isDestroyed()` because
@@ -134,11 +179,7 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
   private options: TextureBridgeOptions;
   private readonly policy: OsrScalePolicy;
   private readonly createSender: TextureBridgeDeps["createSender"];
-  private readonly forwardEntries = new Set<{
-    readonly target: WebContents;
-    readonly extraArgs: readonly unknown[];
-    readonly onDestroyed: () => void;
-  }>();
+  private readonly forwardEntries = new Set<ForwardEntry>();
 
   constructor(
     renderWindow: BrowserWindow,
@@ -181,6 +222,28 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     this.emit("frameDropped", defect);
   }
 
+  /**
+   * Record one frame's forward outcome for `entry` and announce it only when
+   * it differs from the last announced one — the first success, the first
+   * failure, a change of failure reason, and the recovery back to success.
+   * At 30fps a stuck target would otherwise emit 30 identical events a
+   * second (same dedupe stance as `frameDropped`).
+   */
+  private settleForward(entry: ForwardEntry, defect: ForwardDefect | undefined): void {
+    // A result that lands after the registration was disposed (or pruned by
+    // the target's "destroyed" event) describes a forward nobody owns
+    // anymore — reporting it would resurrect a dead handle in the log.
+    if (!this.forwardEntries.has(entry)) return;
+    const next = defect?.reason ?? "ok";
+    if (next === entry.lastStatus) return;
+    entry.lastStatus = next;
+
+    const status = toForwardStatus(defect);
+    notifyForwardObserver(() => entry.onStatus?.(status), "forwardFrames onStatus");
+    const event: ForwardStatusEvent = { ...status, extraArgs: entry.extraArgs };
+    notifyForwardObserver(() => this.emit("forwardStatus", event), "forwardStatus listener");
+  }
+
   /** Handle a paint event from the offscreen BrowserWindow. */
   handlePaint(event: { texture?: PaintTexture }): void {
     const texture = event.texture;
@@ -201,7 +264,9 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
 
     try {
       // Best-effort monitors: the primitive reports defects, this driver
-      // discards them by contract (same stance as the preview path).
+      // turns them into `forwardStatus` transitions instead of dropping them
+      // — a silently dead forward is indistinguishable from a healthy one at
+      // every other layer (paint, sender and preview all keep working).
       // Independent of the native Syphon/Spout send — this runs before
       // sendTextureFromPaintEvent so a native send throw cannot suppress a
       // monitor forward. Each call must START synchronously — the paint
@@ -210,10 +275,16 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
       for (const entry of this.forwardEntries) {
         // The primitive cannot reject today, but the best-effort contract
         // must not depend on another package's discipline — an unhandled
-        // rejection would surface in the main process.
-        void forwardSharedTexture(texture.textureInfo, entry.target, entry.extraArgs).catch(
-          () => {},
-        );
+        // rejection would surface in the main process. A rejection is
+        // reported as `send-failed`: it can only escape from the send half,
+        // the import half is already wrapped in a Result by the primitive.
+        void forwardSharedTexture(texture.textureInfo, entry.target, entry.extraArgs)
+          .then((defect) => {
+            this.settleForward(entry, defect);
+          })
+          .catch((err: unknown) => {
+            this.settleForward(entry, { reason: "send-failed", cause: toError(err) });
+          });
       }
 
       const defect = sendTextureFromPaintEvent(this.sender, texture.textureInfo);
@@ -260,17 +331,22 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     // from the other direction: `once("destroyed", ...)` below would never
     // fire for a target that's already dead, so the entry would never
     // self-prune either — reject it up front instead.
-    if (this._disposed || target.isDestroyed()) return { dispose: () => {} };
+    // `active: false` is the only trace a refused registration leaves —
+    // without it the caller wires up a forward, gets a handle, and waits
+    // forever for frames that were never going to come.
+    if (this._disposed || target.isDestroyed()) return { dispose: () => {}, active: false };
 
     // `entry` closes over itself via `onDestroyed` — safe despite the
     // apparent forward reference: the closure only runs once `target`
     // fires "destroyed", by which point `entry` has long been assigned.
-    const entry = {
+    const entry: ForwardEntry = {
       target,
       extraArgs: options?.extraArgs ?? [],
+      onStatus: options?.onStatus,
       onDestroyed: (): void => {
         this.forwardEntries.delete(entry);
       },
+      lastStatus: null,
     };
     this.forwardEntries.add(entry);
 
@@ -281,6 +357,13 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
     // forwardSharedTexture against an already-destroyed target.
     target.once("destroyed", entry.onDestroyed);
 
+    // Membership in the set IS the liveness of this registration — reading
+    // it through a getter keeps `active` honest for the two teardowns the
+    // caller never initiates: the target being destroyed, and the bridge
+    // being disposed. Captured as a local because an object-literal getter
+    // does not inherit the enclosing `this`.
+    const entries = this.forwardEntries;
+
     return {
       dispose: () => {
         this.forwardEntries.delete(entry);
@@ -289,6 +372,9 @@ export class TextureBridgeImpl extends EventEmitter implements TextureBridge {
         // connect/disconnect cycles — without unhooking here, each cycle
         // leaves a dangling "destroyed" listener on that target.
         unhookDestroyedListener(entry);
+      },
+      get active(): boolean {
+        return entries.has(entry);
       },
     };
   }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -10,6 +10,8 @@ export type {
   TextureBridge,
   FrameForwardOptions,
   FrameForward,
+  ForwardStatus,
+  ForwardStatusEvent,
 } from "./types";
 export type {
   TextureReceiverBridgeOptions,

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow, WebContents } from "electron";
 import type { PaintDefect } from "@napolab/texture-bridge-core";
+import type { ForwardDefect } from "@napolab/texture-bridge-core/electron";
 
 /** Options for the preview window */
 export interface PreviewOptions {
@@ -96,20 +97,69 @@ export interface BridgeEvents {
    * keeps the last drop reason until a successful send or a reason change.
    */
   frameDropped: [defect: PaintDefect];
+  /**
+   * The delivery state of one `forwardFrames` registration changed. Fires on
+   * the first successful frame, on the first failure, on a change of failure
+   * reason, and once again on recovery — never per frame. Which registration
+   * it refers to is identified by `extraArgs` (the tag passed to
+   * {@link TextureBridge.forwardFrames}).
+   *
+   * Forwarding is best-effort and never surfaces as an `"error"` event: this
+   * is the only channel that reports it. Without it a monitor window can go
+   * black indefinitely while paint, sender and preview all stay healthy.
+   */
+  forwardStatus: [status: ForwardStatusEvent];
   disposed: [];
   resize: [width: number, height: number];
 }
+
+/**
+ * 転送先 1 つ分の配信状態。失敗の立ち上がりと復帰を 1 本のチャネルで表す
+ * 判別可能ユニオン — 「今どちらなのか」を分岐で必ず読ませるための形。
+ */
+export type ForwardStatus =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly reason: ForwardDefect["reason"];
+      /** `target-destroyed` には原因例外が無いので省略される */
+      readonly cause?: Error;
+    };
+
+/**
+ * `forwardStatus` イベントの payload。どの登録の話かは `extraArgs`
+ * (= {@link FrameForwardOptions.extraArgs}) で識別する。
+ */
+export type ForwardStatusEvent = ForwardStatus & { readonly extraArgs: readonly unknown[] };
 
 /** Options for {@link TextureBridge.forwardFrames} */
 export interface FrameForwardOptions {
   /** consumeSharedTexture の handler に varargs で届くタグ(例: slot 番号) */
   readonly extraArgs?: readonly unknown[];
+  /**
+   * この登録の配信状態が変わったときだけ呼ばれる。`forwardStatus` イベントと
+   * 同じ遷移を、対象を絞った形で受け取るための口 — 転送先ごとに別々の宛先へ
+   * ログを出す呼び出し側は、こちらの方が相関付けが要らない。
+   *
+   * best-effort な監視チャネルなので、ここで throw しても転送は止まらない
+   * (例外は握られ、`console.error` に落ちる)。
+   */
+  readonly onStatus?: (status: ForwardStatus) => void;
 }
 
 /** Handle returned by {@link TextureBridge.forwardFrames} */
 export interface FrameForward {
   /** 転送登録を解除する。冪等 */
   dispose(): void;
+  /**
+   * 登録が生きているか。`false` ならこの handle にフレームは流れない —
+   * 登録自体が拒否された(bridge が dispose 済み / target が破壊済み)場合と、
+   * `dispose()` 済み、target が後から破壊された場合を区別せずに表す。
+   *
+   * 登録の拒否は 0.14 まで無言だった。呼び出し側は登録直後にこれを見ることで
+   * 「配線したつもりで 1 枚も流れない」状態を即座に検出できる。
+   */
+  readonly active: boolean;
 }
 
 /** High-level texture bridge handle */
@@ -143,8 +193,10 @@ export interface TextureBridge {
    * Register a `WebContents` (e.g. a monitor/multiviewer window) to receive
    * every subsequent paint frame via zero-copy shared-texture forwarding.
    * Same best-effort contract as the preview path: forward failures
-   * (`ForwardDefect`, from `forwardSharedTexture`) are discarded by this
-   * driver and never surface as an `"error"` event — the receiving end is
+   * (`ForwardDefect`, from `forwardSharedTexture`) never surface as an
+   * `"error"` event and never stop the stream — they are reported as state
+   * transitions through the `forwardStatus` event and
+   * {@link FrameForwardOptions.onStatus} — the receiving end is
    * `installSharedTextureReceiver` / `consumeSharedTexture` on
    * `@napolab/texture-bridge-renderer/client`. Call `dispose()` on the
    * returned {@link FrameForward} to stop forwarding to that target
@@ -156,8 +208,10 @@ export interface TextureBridge {
    * release only after all sends settle" — deferred as YAGNI until a
    * multi-target workload actually needs it.
    *
-   * Calling this after the bridge has been disposed returns an inert
-   * {@link FrameForward} whose `dispose()` is a no-op — it does not register.
+   * Calling this after the bridge has been disposed — or against an
+   * already-destroyed `target` — returns an inert {@link FrameForward} whose
+   * `dispose()` is a no-op and whose `active` is `false`; it does not
+   * register. Check `active` at the call site to catch a refused wiring.
    */
   forwardFrames(target: WebContents, options?: FrameForwardOptions): FrameForward;
 

--- a/plugins/texture-bridge/README.md
+++ b/plugins/texture-bridge/README.md
@@ -25,6 +25,7 @@ npx skills add naporin0624/electron-texture-bridge@receiving-shared-textures
 npx skills add naporin0624/electron-texture-bridge@managing-frame-forward-lifecycle
 npx skills add naporin0624/electron-texture-bridge@delivering-imported-textures
 npx skills add naporin0624/electron-texture-bridge@handling-texture-bridge-failures
+npx skills add naporin0624/electron-texture-bridge@diagnosing-dead-frame-forwards
 ```
 
 Add `-g` to install globally instead of into the current project.
@@ -47,6 +48,7 @@ Skills activate automatically from conversation context — no commands to learn
 | `managing-frame-forward-lifecycle` | Registering and tearing down `forwardFrames` targets: monitor windows that close and reopen, repeated connect/disconnect, `MaxListenersExceededWarning`, leaks around forwarding |
 | `delivering-imported-textures` | Delivering a texture to a renderer from main: `importSharedTexture` / `sendSharedTexture` / `release()` by hand, where `release()` belongs, `sendImportedTexture` vs `forwardSharedTexture` |
 | `handling-texture-bridge-failures` | Error handling and telemetry: which calls throw, reject, model a defect, or emit — what to wrap with `Result.fromThrowable`, silently black output, a main-process crash from a bridge call |
+| `diagnosing-dead-frame-forwards` | A forwarded preview/monitor that went black, froze on its last frame, or shows "no signal" — dead previews with nothing in the logs, or only some targets dying while Syphon/Spout keeps working |
 
 ## Why these skills exist
 

--- a/plugins/texture-bridge/skills/diagnosing-dead-frame-forwards/SKILL.md
+++ b/plugins/texture-bridge/skills/diagnosing-dead-frame-forwards/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: diagnosing-dead-frame-forwards
+description: Use when forwarded frames stop arriving — a preview or monitor window that goes black or shows a "no signal" placeholder, a multiviewer deck frozen on its last frame, previews that die during a long session or for only some targets while Syphon/Spout output keeps working, a forwardFrames registration you suspect never delivered anything, or a dead preview with nothing in the logs.
+---
+
+# Diagnosing dead frame forwards
+
+## Overview
+
+Forwarding is the one path in this library whose failure has **no other symptom**. Paint keeps firing, the native sender keeps sending, the preview window keeps updating, `droppedReason` stays `null`, and no `"error"` or `"frameDropped"` ever fires — while the forwarded target sits black. A silent log is the expected appearance of this bug, not evidence against it.
+
+So do not open with a hypothesis. Two signals the library already publishes answer *which layer* in one repro; everything else is guessing at 30fps.
+
+## The two signals, in this order
+
+| # | Signal | Where | Answers |
+|---|---|---|---|
+| 1 | `FrameForward.active` | return value of `forwardFrames()`, read right after the call | Did the registration ever exist? |
+| 2 | `forwardStatus` event / `options.onStatus` | `bridge.on("forwardStatus", …)`, or per registration | Is it delivering, and since when is it not? |
+
+```typescript
+const forward = bridge.forwardFrames(target, {
+  extraArgs: [slot],                       // tags every status with the slot
+  onStatus: (s) => log(`forward ${slot}`, s.ok ? "ok" : s.reason, s.ok ? "" : s.cause),
+});
+if (!forward.active) log(`forward ${slot} REFUSED — no frames will ever arrive`);
+```
+
+`forwardStatus` is deduped to transitions, so a plain log of every event is already the outage report: `{ ok: false }` with no `{ ok: true }` after it means that target has been dark since that timestamp.
+
+## Reading the result
+
+| `active` | Status history | What it means | Where to look next |
+|---|---|---|---|
+| `false` | none | Registration was refused — the bridge was disposed or the target already destroyed. The caller is holding a dead handle it believes is live | the call site: re-register against the current `WebContents` after a window is recreated |
+| `true` | nothing, ever | Paint never reached this entry | is the source painting at all? (see below) — then the registration's own lifecycle |
+| `true` → `false` | ends abruptly | The entry was pruned: target destroyed, `dispose()`, or the bridge disposed | whoever tore it down — an unpaired `detach()`, a rebuild that never re-added it |
+| `true` | `ok`, then nothing | The library is delivering. Stop looking at the bridge | the renderer: `installSharedTextureReceiver` present? consumer registered? `VideoFrame` drawn? |
+| `true` | `target-destroyed` | Target died under the registration | re-register after the window is recreated |
+| `true` | `import-failed` / `send-failed` | GPU or IPC layer refused the frame; `cause` carries the error | the `cause`, then GPU/handle pressure |
+
+## An idle source emits nothing — by design
+
+OSR paint is damage-driven. A paused video, a static page, a stalled worker: **zero paint, therefore zero forwards, and that is not a fault.** Confirm the source is actually producing frames — the bridge's `"fps"` event, or a paint counter — *before* you conclude the forward path is broken. Skipping this check turns a paused deck into an afternoon of debugging a healthy pipeline.
+
+## Frozen picture ≠ blank picture
+
+The two look equally "dead" to a user and mean opposite things:
+
+| Symptom | Meaning |
+|---|---|
+| Last frame frozen on screen | Frames stopped arriving; the consumer still holds its last `VideoFrame`. The break is upstream — source idle, or forwarding dead |
+| Black / "no signal" / placeholder | The consumer *discarded* what it held and got nothing since. Something on the receiving side cleared its store; a still-live forward would refill it within a frame |
+
+Ask which one the user actually sees. It splits the search space in half before you touch any code.
+
+## Do not instrument first
+
+The failure is timing-sensitive. In a real investigation, adding logging around the paint path moved the reproduction rate from 3-in-5 launches to 0-in-22 — the probe hid the bug it was measuring. The published signals are safe to leave on permanently (deduped to transitions, nothing per frame), so wire *those* and reproduce, instead of adding a temporary probe to the paint loop.
+
+## Common mistakes
+
+| Mistake | Reality |
+|---|---|
+| "Nothing in the log, so forwarding is fine" | Forwarding never raises `"error"` and never touches `"frameDropped"` / `droppedReason`. A clean log is what this failure looks like |
+| "Syphon/Spout output works, so the bridge is fine" | Native send and forwarding are independent paths in `handlePaint`. Either can die alone |
+| "`forwardFrames()` returned a handle, so it is registered" | A refused registration returns a handle too. Only `active` distinguishes them |
+| "Frames stopped, so the library broke" | A paused or static source produces no paint. Check the source first |
+| Ranking hypotheses (backpressure, leaks, GPU pressure) before reading `active` + `forwardStatus` | Both signals already exist and are free. Guessing costs a repro cycle each |
+| Patching `handlePaint` to count in-flight promises | You are rebuilding, less accurately, the reporting the driver already does |
+| Subscribing to nothing and calling forwarding "best-effort" | Best-effort means the *stream* survives failures, not that failures are invisible |
+
+## Related skills
+
+- **`managing-frame-forward-lifecycle`** — registration, teardown, and re-registration after a target window reopens
+- **`handling-texture-bridge-failures`** — which calls throw, reject, model a defect, or emit
+- **`receiving-shared-textures`** — the renderer half, once `forwardStatus` says `ok` and the canvas is still black

--- a/plugins/texture-bridge/skills/diagnosing-dead-frame-forwards/SKILL.md
+++ b/plugins/texture-bridge/skills/diagnosing-dead-frame-forwards/SKILL.md
@@ -28,6 +28,12 @@ if (!forward.active) log(`forward ${slot} REFUSED — no frames will ever arrive
 
 `forwardStatus` is deduped to transitions, so a plain log of every event is already the outage report: `{ ok: false }` with no `{ ok: true }` after it means that target has been dark since that timestamp.
 
+### If the installed version predates these signals
+
+Check the consumer's installed types, not the source you have checked out: if `FrameForwardOptions` has no `onStatus` (or `FrameForward` has no `active`), the app is pinned to a version that reports nothing. **Upgrade — that IS the fix**, not a prerequisite for one: on the old version this failure mode is undiagnosable by construction, and every substitute costs a repro cycle and hides the race (see below).
+
+If the upgrade cannot land immediately, the surviving seams are coarse and none of them observe forwarding itself: `bridge.on("frameDropped")` / `bridge.on("error")` per source, and your own logging around every place *you* call `forwardFrames()` and `dispose()`. Absence of events there tells you almost nothing — which is exactly why the signals were added.
+
 ## Reading the result
 
 | `active` | Status history | What it means | Where to look next |
@@ -69,6 +75,8 @@ The failure is timing-sensitive. In a real investigation, adding logging around 
 | Ranking hypotheses (backpressure, leaks, GPU pressure) before reading `active` + `forwardStatus` | Both signals already exist and are free. Guessing costs a repro cycle each |
 | Patching `handlePaint` to count in-flight promises | You are rebuilding, less accurately, the reporting the driver already does |
 | Subscribing to nothing and calling forwarding "best-effort" | Best-effort means the *stream* survives failures, not that failures are invisible |
+| Building a substitute for `forwardStatus` because the pinned version lacks it | The upgrade is smaller than the substitute, and the substitute cannot see the forward path at all |
+| Reading the checked-out library source instead of the consumer's installed `node_modules` types | The repo you are reading and the version the app runs can differ by exactly the feature you are about to rely on |
 
 ## Related skills
 

--- a/plugins/texture-bridge/skills/handling-texture-bridge-failures/SKILL.md
+++ b/plugins/texture-bridge/skills/handling-texture-bridge-failures/SKILL.md
@@ -16,14 +16,14 @@ Failures in this library take five shapes, and **which shape a given call uses i
 | `await createTextureBridge(options)` | **rejects** — called before `app.whenReady()`, native sender construction, renderer load failure |
 | `bridge.resize(w, h)` | **throws** — rebuilding the native sender can fail. Size is rolled back first, so the bridge stays usable |
 | `bridge.openPreview()` | **throws** — `new BrowserWindow` inside can fail |
-| `bridge.forwardFrames(target, opts?)` | **cannot fail** — returns an inert `FrameForward` when the bridge is disposed or the target is dead |
+| `bridge.forwardFrames(target, opts?)` | **cannot fail** — returns an inert `FrameForward` when the bridge is disposed or the target is dead. Read `.active` to tell the two apart |
 | `forward.dispose()`, `bridge.dispose()`, `bridge.closePreview()`, `sender.stop()`, receiver `start()` / `stop()` / `dispose()` / `setFlipY()` | **cannot fail** — idempotent |
 | `sendTextureFromPaintEvent(sender, textureInfo)` | **returns a `PaintDefect`** for drops **and throws `TextureSendError`** on native send failure — both, on the same call |
 | `forwardSharedTexture(textureInfo, target, extraArgs?)` | **returns a `ForwardDefect`** — never throws, never rejects |
 | `sendImportedTexture(frame, imported, extraArgs?)` | **rejects** — async fn, so never a sync throw |
 | `new TextureSender(...)`, `sender.send/sendSurface/sendRgbaBuffer`, `closeNativeHandle(buf)`, `listSenders()` | **throw** (native) |
 | `createTextureReceiver(opts)`, `createSharedTextureReceiver(opts)` | **throw** — construction only (no such sender). `createSharedTextureReceiver` also throws `TypeError` for a non-positive `pollIntervalMs`; `createTextureReceiver` does not validate it |
-| `bridge` paint pipeline, receiver poll loops, `SenderDiscovery` | **emit** — `"error"`, plus `"frameDropped"` (`PaintDefect`) on a bridge. Forward failures are discarded and reach neither |
+| `bridge` paint pipeline, receiver poll loops, `SenderDiscovery` | **emit** — `"error"`, plus `"frameDropped"` (`PaintDefect`) on a bridge. Forward failures reach neither: they surface on `"forwardStatus"` (and `options.onStatus`) as state changes |
 | `getPlatform()`, `sender.platform()`, `receiver.isConnected/getWidth/getHeight`, `bridge.isDisposed` | **cannot fail** — safe defaults |
 
 ## What to wrap
@@ -54,6 +54,8 @@ receiver.on("error", (error) => telemetry.report("receiver.error", error)); // t
 ## Two facts that decide most of the code
 
 **A defect is not an error.** `PaintDefect` and `ForwardDefect` are normal dropped frames — a paint arrived without a shareable handle, a monitor window closed. Count them, show them in a HUD, alert on a sustained rate. Reporting each one as an error buries the real failures.
+
+**But a defect that never stops is an incident.** `"forwardStatus"` already does the counting for you: it is deduped down to transitions, so every event it delivers is a genuine change of state. One `{ ok: false }` with no `{ ok: true }` behind it means that target has been dark ever since — log both edges and the outage interval reads straight out of the log.
 
 **`sendTextureFromPaintEvent` is the one call that does both.** Handling only its return value silently drops `TextureSendError`, which means a dead sender — black Syphon output — with nothing in telemetry. In a bridge, that throw already reaches `bridge.on("error")`. In your own paint loop, it is yours:
 
@@ -86,4 +88,6 @@ win.webContents.on("paint", (e) => {          // stays sync
 | `.catch()` on `forwardSharedTexture(...)` | It resolves its defect, never rejects. The handler is dead code. |
 | Reporting a `PaintDefect` / `ForwardDefect` through the error channel | A dropped frame is not an incident. Count it. |
 | `bridge.resize(w, h)` unguarded in a settings-dialog handler | An uncaught throw in the main process takes the app down. This is one of the two throwing bridge methods. |
-| Assuming the bridge's `"frameDropped"` / `"error"` covers forwarding | Forward failures are discarded by contract and reach neither event. |
+| Assuming the bridge's `"frameDropped"` / `"error"` covers forwarding | Forwarding has its own channel: `"forwardStatus"` / `options.onStatus`. Neither of the other two ever fires for it. |
+| Subscribing to nothing and calling forwarding "best-effort" | Best-effort means *the stream survives failures*, not *failures are invisible*. An unwatched forward that dies looks identical to a healthy one at every other layer — paint, sender, preview and `droppedReason` all stay green while the monitor sits black. |
+| Treating `forwardFrames()` as proof the wiring is live | A refused registration returns a handle too. `if (!forward.active)` right after the call is the one-line check that catches it. |

--- a/plugins/texture-bridge/skills/handling-texture-bridge-failures/SKILL.md
+++ b/plugins/texture-bridge/skills/handling-texture-bridge-failures/SKILL.md
@@ -91,3 +91,5 @@ win.webContents.on("paint", (e) => {          // stays sync
 | Assuming the bridge's `"frameDropped"` / `"error"` covers forwarding | Forwarding has its own channel: `"forwardStatus"` / `options.onStatus`. Neither of the other two ever fires for it. |
 | Subscribing to nothing and calling forwarding "best-effort" | Best-effort means *the stream survives failures*, not *failures are invisible*. An unwatched forward that dies looks identical to a healthy one at every other layer — paint, sender, preview and `droppedReason` all stay green while the monitor sits black. |
 | Treating `forwardFrames()` as proof the wiring is live | A refused registration returns a handle too. `if (!forward.active)` right after the call is the one-line check that catches it. |
+
+**Already black?** Diagnosing a forward that has *already* gone dead is a different job from wiring the handling: use `diagnosing-dead-frame-forwards`.

--- a/plugins/texture-bridge/skills/managing-frame-forward-lifecycle/SKILL.md
+++ b/plugins/texture-bridge/skills/managing-frame-forward-lifecycle/SKILL.md
@@ -16,8 +16,9 @@ description: Use when registering or tearing down `TextureBridge.forwardFrames` 
 | Target `WebContents` destroyed later (its window closed) | Entry is auto-pruned via an internal `once("destroyed")` — no forwarding to a dead target | nothing |
 | `forward.dispose()` | Deletes the entry **and removes that internal `"destroyed"` listener** from your target. Idempotent, never throws, safe after the target died | call it (see below) |
 | `bridge.dispose()` | Unhooks every entry's listener, then clears all entries | nothing |
-| `forwardFrames()` after `bridge.dispose()` | Does **not** register; returns an inert `FrameForward` whose `dispose()` is a no-op | see "own the truth" below |
-| `forwardFrames()` with an already-destroyed target | Same — inert handle, no registration, no leak | same |
+| `forwardFrames()` after `bridge.dispose()` | Does **not** register; returns an inert `FrameForward` whose `dispose()` is a no-op and whose `active` is `false` | see "own the truth" below |
+| `forwardFrames()` with an already-destroyed target | Same — inert handle, `active: false`, no registration, no leak | same |
+| A live registration stops delivering (target dies mid-session, import or send fails) | Reports the change on `"forwardStatus"` / `options.onStatus`, and keeps trying every frame | log both edges (see 4) |
 
 Repeated connect/disconnect on one long-lived multiviewer window accumulates nothing: each `dispose()` takes its listener with it.
 
@@ -25,7 +26,9 @@ Repeated connect/disconnect on one long-lived multiviewer window accumulates not
 
 1. **Dispose before you drop the handle.** Overwriting a `Map` entry that holds a live `FrameForward` leaks the registration — the library cannot see your map.
 2. **Re-register after the target window is recreated.** A reopened window is a new `WebContents`; the old entry already pruned itself, so connect again against the new one.
-3. **Own the truth of your own connected state — and throw when it is false.** Registration is silent: an inert handle looks exactly like a live one, and no event ever fires. Check `bridge.isDisposed` / `target.isDestroyed()` *yourself, before registering*, and **throw a named error** when the check fails. Do not return a boolean or an `undefined` handle: a status a caller can ignore is a UI that says "connected" over a dead deck.
+3. **Own the truth of your own connected state — and throw when it is false.** A refused registration still hands you a handle; what it does not hand you is frames. `FrameForward.active` is `false` in that case, so the failure is detectable — but detectable is not the same as handled. Check `bridge.isDisposed` / `target.isDestroyed()` *yourself, before registering*, and **throw a named error** when the check fails; assert `forward.active` after the call as the backstop for whatever your pre-check missed. Do not return a boolean or an `undefined` handle: a status a caller can ignore is a UI that says "connected" over a dead deck.
+
+4. **Subscribe to `forwardStatus` (or pass `onStatus`) for the deaths that happen later.** Registration succeeding says nothing about the next hour: the target can die, an import can start failing, and forwarding is best-effort — the stream survives, silently. The event is deduped to transitions, so a plain log of every status is already an outage report: `{ ok: false }` with no `{ ok: true }` after it means that target has been dark since that timestamp. Tag each registration with `extraArgs` so the log says *which* one.
 
 ```typescript
 export class ForwardTargetUnavailableError extends Error {
@@ -79,4 +82,5 @@ Which bridge calls throw, reject, or model their failures instead: see the handl
 | `throw` from inside a paint-rate path, or a `"destroyed"` handler | Throw at *registration*, where a human action is waiting for an answer. Per-frame failures stay best-effort. |
 | `forwards.set(slot, bridge.forwardFrames(...))` over an existing entry | The overwritten handle is unreachable and still registered — the one real leak in this API. |
 | Keeping decks "connected" across a window close and expecting frames after reopen | The old entry self-pruned. New window = new `WebContents` = new `forwardFrames` call. |
-| Expecting forward failures on `bridge.on("error")` / `frameDropped` | Best-effort by contract: defects are discarded by the driver. |
+| Expecting forward failures on `bridge.on("error")` / `frameDropped` | Wrong channel — forwarding reports on `"forwardStatus"` / `options.onStatus`. |
+| Registering forwards and subscribing to nothing | The one failure mode with no other symptom: paint, sender and preview stay healthy while the monitor goes black. One `forwardStatus` listener is the whole fix. |

--- a/plugins/texture-bridge/skills/managing-frame-forward-lifecycle/SKILL.md
+++ b/plugins/texture-bridge/skills/managing-frame-forward-lifecycle/SKILL.md
@@ -84,3 +84,5 @@ Which bridge calls throw, reject, or model their failures instead: see the handl
 | Keeping decks "connected" across a window close and expecting frames after reopen | The old entry self-pruned. New window = new `WebContents` = new `forwardFrames` call. |
 | Expecting forward failures on `bridge.on("error")` / `frameDropped` | Wrong channel — forwarding reports on `"forwardStatus"` / `options.onStatus`. |
 | Registering forwards and subscribing to nothing | The one failure mode with no other symptom: paint, sender and preview stay healthy while the monitor goes black. One `forwardStatus` listener is the whole fix. |
+
+**Already black?** Diagnosing a forward that has *already* gone dead is a different job from wiring the handling: use `diagnosing-dead-frame-forwards`.

--- a/plugins/texture-bridge/skills/migrating-to-forward-frames/SKILL.md
+++ b/plugins/texture-bridge/skills/migrating-to-forward-frames/SKILL.md
@@ -78,7 +78,7 @@ Three properties of that handler are load-bearing, and adding forwarding is exac
 |---------|---------|
 | `bridge.forwardFrames(wc, { sourceId })` / `{ channel }` / `{ maxFps }` | Only `{ extraArgs: [...] }` exists. Rate control belongs to the receiver's rAF coalescing. |
 | `forward.stop()` / `subscription.unsubscribe()` | `forward.dispose()`. |
-| Expecting forward failures on `bridge.on("error")` | Best-effort: defects are discarded by the driver. Use `forwardSharedTexture`'s returned defect if you need visibility. |
+| Expecting forward failures on `bridge.on("error")` | Wrong channel. `bridge.on("forwardStatus")` (or `forwardFrames`'s `onStatus`) reports them as deduped state changes; with the primitive, read the resolved `ForwardDefect` yourself. |
 | Preview window with default `webPreferences` | Shared-texture consumption needs the receiver preload setup — see receiving-shared-textures skill. |
 | Calling `frame.videoFrame.close()` on the frame passed to `onFrame` | The consumer pool closes the original after your handler settles. `clone()` if you hold it; close only clones. |
 | Keeping a `capturePage` fallback "just in case" | Delete it once verified — a hidden 30fps readback timer defeats the migration. |


### PR DESCRIPTION
## なぜ

Cannelloni で「**プレビューだけが無言で死ぬ**」事故を実機計測で確認した。3 時間のセッションでも、5 回の起動中 3 回でも再現した状態は次のとおり:

| 計測点 | 故障時 | 正常時 |
|---|---|---|
| OSR `paint` | 正常 25fps (600枚) | 正常 |
| `frameDropped` / `error` | 0 件 | 0 件 |
| `sharedTexture.sendSharedTexture` | **一度も呼ばれない** | 300 回/10 秒 |
| renderer に届いたフレーム | **0** | 25fps |
| main プロセスのログ | 例外なし | 例外なし |

paint も native sender も preview も `droppedReason` も全部健全なまま、監視ウィンドウだけが黙って黒くなる。切り分けようにも materials が無い:

- 毎フレームの `ForwardDefect` は `handlePaint` の `.catch(() => {})` で捨てられている
- 登録の拒否 (bridge が dispose 済み / target が破壊済み) は inert handle として黙殺され、生きている handle と見分けがつかない

調査には計測コードの注入が必要で、しかも計装するとレースが消えた (計装前 3/5 失敗 → 計装後 22/22 成功)。**ライブラリが状態を報告しない限り、この故障は現場で追えない。**

## なにを

### `forwardStatus` イベント + `FrameForwardOptions.onStatus`

どちらも **状態遷移だけ** を通知する — 初回成功 / 初回失敗 / 失敗理由の変化 / 復帰。30fps で同じ状態を垂れ流さない (`frameDropped` と同じ dedupe 方針)。

```typescript
type ForwardStatus =
  | { ok: true }
  | { ok: false; reason: "target-destroyed" | "import-failed" | "send-failed"; cause?: Error };

// bridge 全体で受ける (どの登録かは extraArgs で識別)
bridge.on("forwardStatus", (s) => log(`slot ${s.extraArgs[0]}`, s.ok ? "ok" : s.reason));

// 登録単位で受ける
bridge.forwardFrames(target, { extraArgs: [slot], onStatus: (s) => log(slot, s) });
```

遷移だけを出すので、**ログを素直に読むだけで停止区間になる**: `{ ok: false }` の後に `{ ok: true }` が無ければ、そのターゲットはその時刻から今も暗い。

### `FrameForward.active`

登録が成立したかどうか。set のメンバーシップを見る getter なので、登録拒否・`dispose()`・target の後からの破壊をすべて反映する。

```typescript
const fwd = bridge.forwardFrames(target, { extraArgs: [slot] });
if (!fwd.active) log(`slot ${slot} was refused — no frames will ever arrive`);
```

## 設計上の判断

- **`"error"` イベントは使わない。** 購読者ゼロだと throw するため、まさに「誰も見ていない」状況を生き延びる必要がある診断チャネルには不適。
- **購読側の throw を握る。** 両 sink は promise continuation の中で走るので、逃げた例外は main プロセスの unhandled rejection になる。どちらの sink も転送を止めてはいけない (`console.error` に落とす)。
- **reject は `send-failed` として報告。** import 側は primitive が Result で包んでいるので、reject し得るのは send 側だけ。
- **dispose 後に着弾した結果は捨てる。** 誰も所有していない登録の状態をログに復活させない。

## テスト

新規 9 件 (renderer 201 件 / core 33 件すべてパス)。dedupe・復帰・理由変化・reject 経路・in-flight dispose・`active` の 4 状態を個別に固定した。

`typecheck` クリーン、`lint` 0 errors、`oxfmt` 済み。

## ドキュメント

`docs/API.md` と 3 つの skill に「defect は driver が捨てる」「登録は無言」と書いてあり、**この PR で嘘になる**ため全部更新した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TErgwokxkbfxexfUNeuMoW

---

## 追記: `diagnosing-dead-frame-forwards` skill

同じ事故に次に当たった人が 2 手で層を特定できるよう、診断 skill を TDD で追加した。

**RED (skill 無しのベースライン, 2 エージェント):** どちらも根拠の薄い仮説から始めた。片方は in-flight promise の積み上がりを疑い、**ライブラリが既に公開している信号を読む前に `handlePaint` へ pending カウンタを足す**と提案した。両者とも `FrameForward.active` に触れず、「アイドルなソースはそもそも paint を出さない」を考慮せず、「フリーズ画像 / 空白プレースホルダ」の弁別も使わなかった。

**GREEN (skill 有り):** Syphon が生きている事実から「死んだのは転送だけ」と推論し、`active` を確認し、4 つの結果すべてに分岐を用意し、**paint ループへの一時プローブ追加を明示的に見送った**。

skill には計測済みの警告も入れた — 計装するとこのバグは隠れる (実測: 再現率 3/5 → 0/22)。
